### PR TITLE
fix(infra): attach docker-compose.infra.yml services to molecule-monorepo-net + add Temporal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,15 @@ Four main components:
 
 ### Infrastructure
 ```bash
-./infra/scripts/setup.sh    # Start Postgres, Redis, Langfuse; run migrations
+./infra/scripts/setup.sh    # Start Postgres, Redis, Langfuse, Temporal; run migrations
 ./infra/scripts/nuke.sh     # Tear down everything, remove volumes
 ```
+
+Infra services (via `docker-compose.infra.yml`, all attached to the shared `molecule-monorepo-net` network — `setup.sh` creates it idempotently):
+- **Postgres** `:5432` — primary datastore (also backs Langfuse + Temporal via separate DBs)
+- **Redis** `:6379` — pub/sub, heartbeat TTLs
+- **Langfuse** `:3001` — LLM trace viewer (backed by Clickhouse)
+- **Temporal** `:7233` (gRPC) + `:8233` (Web UI) — durable workflow engine for `workspace-template/builtin_tools/temporal_workflow.py`. **Dev-only posture:** the auto-setup image runs with no auth on `0.0.0.0:7233`; production deployments must gate access via mTLS or an API key / reverse proxy.
 
 ### Platform (Go)
 ```bash

--- a/PLAN.md
+++ b/PLAN.md
@@ -317,3 +317,13 @@ Deferred, not blocking:
   leaves copied skill dirs behind. Low user impact.
 - **Shared org-template `system-prompt.md` via `_shared/`** — DRY molecule-dev
   and molecule-worker-gemini. Drift risk; revisit at 3+ orgs.
+
+## Infra footnote — Temporal
+
+`docker-compose.infra.yml` now includes Temporal (`:7233` gRPC, `:8233` Web
+UI) backing `workspace-template/builtin_tools/temporal_workflow.py` for
+durable long-running agent workflows. All infra services share the
+`molecule-monorepo-net` Docker network, which `infra/scripts/setup.sh`
+creates idempotently. Temporal currently runs with **no auth** on
+`0.0.0.0:7233` — dev-only; any production deployment must front it with
+mTLS, API keys, or a reverse proxy before exposing the cluster.

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ git clone https://github.com/Molecule-AI/molecule-monorepo.git
 cd molecule-monorepo
 
 ./infra/scripts/setup.sh
+# Boots Postgres (:5432), Redis (:6379), Langfuse (:3001),
+# and Temporal (:7233 gRPC, :8233 UI) on the shared
+# `molecule-monorepo-net` Docker network. Temporal runs with
+# no auth on localhost — dev-only; production must gate it.
 
 cd platform
 go run ./cmd/server

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,10 @@ git clone https://github.com/Molecule-AI/molecule-monorepo.git
 cd molecule-monorepo
 
 ./infra/scripts/setup.sh
+# 启动 Postgres (:5432)、Redis (:6379)、Langfuse (:3001)
+# 以及 Temporal (:7233 gRPC, :8233 UI)，全部挂在共享的
+# `molecule-monorepo-net` Docker 网络上。Temporal 默认无鉴权，
+# 仅用于本地开发；生产环境必须加 mTLS / API Key。
 
 cd platform
 go run ./cmd/server

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -65,6 +65,7 @@ services:
       timeout: 5s
       retries: 10
 
+  # dev-only: no-auth on 0.0.0.0:7233; production must gate via mTLS or API key
   temporal:
     image: temporalio/auto-setup:1.25
     depends_on:

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -65,6 +65,37 @@ services:
       timeout: 5s
       retries: 10
 
+  temporal:
+    image: temporalio/auto-setup:1.25
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB: postgres12
+      DB_PORT: 5432
+      POSTGRES_USER: ${POSTGRES_USER:-dev}
+      POSTGRES_PWD: ${POSTGRES_PASSWORD:-dev}
+      POSTGRES_SEEDS: postgres
+      DBNAME: temporal
+      VISIBILITY_DBNAME: temporal_visibility
+    ports:
+      - "7233:7233"
+    healthcheck:
+      test: ["CMD", "tctl", "--address", "temporal:7233", "cluster", "health"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  temporal-ui:
+    image: temporalio/ui:2.31.2
+    depends_on:
+      - temporal
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_CORS_ORIGINS: http://localhost:8233
+    ports:
+      - "8233:8080"
+
   langfuse-web:
     image: langfuse/langfuse:2
     depends_on:
@@ -83,6 +114,11 @@ services:
       SALT: langfuse-dev-salt
     ports:
       - "3001:3000"
+
+networks:
+  default:
+    name: molecule-monorepo-net
+    external: true
 
 volumes:
   pgdata:

--- a/infra/scripts/setup.sh
+++ b/infra/scripts/setup.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
+echo "==> Ensuring shared docker network exists..."
+docker network create molecule-monorepo-net 2>/dev/null || true
+
 echo "==> Starting infrastructure..."
 docker compose -f "$ROOT_DIR/docker-compose.infra.yml" up -d
 


### PR DESCRIPTION
## Summary
- Declare `molecule-monorepo-net` as the external default network for `docker-compose.infra.yml` so services (postgres, redis, clickhouse, langfuse, temporal) join the platform's existing network instead of a fresh `_default` bridge.
- Add Temporal + Temporal UI services (was planned but never landed; every agent logs `cannot connect to localhost:7233` at startup).
- Expose Temporal UI on :8233.

## Incident that motivated this
2026-04-13: ran `docker compose -f docker-compose.infra.yml up -d temporal` to bring up Temporal. Compose recreated postgres onto a fresh `molecule-monorepo_default` network. Platform lost DNS on `postgres:5432`, crashed, and took all 12 workspace agents offline. Manual remediation: `docker network connect --alias postgres molecule-monorepo-net molecule-monorepo-postgres-1` for each affected service, then platform restart.

With this patch, any future `compose up` on the infra file keeps everything on the same network as the platform.

## Test plan
- [x] `docker compose -f docker-compose.infra.yml up -d` — all services attach to `molecule-monorepo-net`; no `_default` network created.
- [x] Platform reaches postgres: `docker exec molecule-monorepo-platform-1 getent hosts postgres` returns the container IP.
- [x] Workspace agents reach temporal: `docker exec ws-<id> getent hosts temporal` resolves.
- [x] Temporal UI loads at http://localhost:8233 (HTTP 200).
- [x] `CLAUDE_CODE_OAUTH_TOKEN` / `TEMPORAL_HOST=temporal:7233` saved as global secrets via `POST /admin/secrets`.

Related: #15 (same incident class — secret/infra rotation making all 12 agents scrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)