### PR TITLE
chore(template): authenticated git clone in initial_prompt when GITHUB_TOKEN is set

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,10 @@ PLUGINS_DIR=                   # Path to plugins/ directory (default: /plugins i
 # Observability (Awareness)
 # AWARENESS_URL=                         # If set, injected into workspace containers along with a deterministic AWARENESS_NAMESPACE derived from workspace ID. Enables the cross-session memory MCP server.
 
+# GitHub
+# GITHUB_REPO=owner/repo                 # Target repo for agent initial_prompt clone (e.g. Molecule-AI/molecule-monorepo). Read inside workspace containers.
+# GITHUB_TOKEN=                          # Personal access token / installation token used by agents that clone private repos. Register as a global secret via POST /admin/secrets for propagation to workspace env. Token is used in-URL during clone and then scrubbed from .git/config via `git remote set-url`.
+
 # Webhooks
 # GITHUB_WEBHOOK_SECRET=                 # HMAC secret used to verify incoming GitHub webhook payloads at /webhooks/github.
 

--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -16,9 +16,13 @@ defaults:
   # be ready yet. Keep it local: clone, read, memorize. Wait for tasks.
   initial_prompt: |
     You just started. Set up your environment silently — do NOT contact other agents yet.
-    1. Clone the repo (authenticated when GITHUB_TOKEN is available, anonymous otherwise):
+    1. Clone the repo (authenticated when GITHUB_TOKEN is available, anonymous otherwise).
+       When a token is present, use it in-URL ONLY for the clone, then immediately scrub
+       the remote URL so the token is never persisted to /workspace/repo/.git/config:
        if [ -n "$GITHUB_TOKEN" ]; then
-         git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git" /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
+         git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git" /workspace/repo 2>/dev/null \
+           && (cd /workspace/repo && git remote set-url origin "https://github.com/${GITHUB_REPO}.git") \
+           || (cd /workspace/repo && git pull)
        else
          git clone "https://github.com/${GITHUB_REPO}.git" /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
        fi

--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -16,7 +16,12 @@ defaults:
   # be ready yet. Keep it local: clone, read, memorize. Wait for tasks.
   initial_prompt: |
     You just started. Set up your environment silently — do NOT contact other agents yet.
-    1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
+    1. Clone the repo (authenticated when GITHUB_TOKEN is available, anonymous otherwise):
+       if [ -n "$GITHUB_TOKEN" ]; then
+         git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git" /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
+       else
+         git clone "https://github.com/${GITHUB_REPO}.git" /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
+       fi
     2. Set up git hooks: cd /workspace/repo && git config core.hooksPath .githooks
     3. Read /workspace/repo/CLAUDE.md to understand the project
     4. Read your system prompt at /configs/system-prompt.md to understand your role


### PR DESCRIPTION
## Summary
- `initial_prompt` in `org-templates/molecule-dev/org.yaml` now uses `https://x-access-token:${GITHUB_TOKEN}@github.com/...` when `GITHUB_TOKEN` is present, falling back to anonymous clone when it isn't.
- Partial fix for #13 — the template-layer half. Platform-level provisioner rewrite (the other half of #13) still pending.

## Why
Observed 2026-04-13: after the main repo went private, Dev Lead's `initial_prompt` failed to clone with:
```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```
…in non-TTY `docker exec`. Workspace came up with an empty `/workspace/repo` and couldn't do any repo-related work until I manually cloned with a token.

`GITHUB_TOKEN` is now a global secret (set via `POST /admin/secrets` on 2026-04-13), so it's available in container env. This PR has the template use it.

## Test plan
- [x] A fresh workspace provisioned from this template successfully clones `Molecule-AI/molecule-monorepo` on first boot.
- [x] If `GITHUB_TOKEN` is unset (e.g. older env), the fallback anonymous clone still runs and succeeds for public repos.
- [x] `git pull` path on re-boot is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)