### PR TITLE
chore(template): wire plugins — defaults for coding/guardrails + browser-automation for research & UIUX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Shared plugins in `plugins/` are auto-loaded by every workspace:
 - **`molecule-dev`**: Codebase conventions (rules injected into CLAUDE.md) + `review-loop` skill for multi-round QA cycles
 - **`superpowers`**: `verification-before-completion`, `test-driven-development`, `systematic-debugging`, `writing-plans`
 - **`ecc`**: General Claude Code guardrails
+- **`browser-automation`**: Puppeteer/CDP-based web scraping and live canvas screenshots (opt-in per workspace — wired into Research + UIUX roles in `org-templates/molecule-dev/org.yaml`)
 
 ### Scripts
 ```bash

--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -7,6 +7,19 @@ defaults:
   tier: 2
   required_env:
     - CLAUDE_CODE_OAUTH_TOKEN
+  # Default plugin set applied to every workspace unless the workspace
+  # specifies its own `plugins:` list (which REPLACES defaults — not a union;
+  # see platform/internal/handlers/org.go ~L345). So any workspace that
+  # needs extras must re-list the defaults plus its additions.
+  #
+  # - ecc:           "Everything Claude Code" guardrails + coding skills
+  #                  (api-design, coding-standards, deep-research, security-review, tdd-workflow)
+  # - molecule-dev:  Molecule AI codebase conventions, past bugs, review-loop
+  # - superpowers:   systematic-debugging, TDD, planning, verification-before-completion
+  plugins:
+    - ecc
+    - molecule-dev
+    - superpowers
   # workspace_dir: not set by default — each agent gets an isolated Docker volume
   # Set per-workspace to bind-mount a host directory as /workspace
 
@@ -59,6 +72,10 @@ workspaces:
         role: Market analysis and technical research
         files_dir: research-lead
         canvas: { x: 200, y: 250 }
+        # Research roles extend defaults with browser-automation so they can
+        # scrape the live web (product pages, GitHub trending, docs).
+        # Per-workspace plugins REPLACE defaults, so re-list the full set.
+        plugins: [ecc, molecule-dev, superpowers, browser-automation]
         initial_prompt: |
           You just started as Research Lead. Set up silently — do NOT contact other agents.
           1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -71,12 +88,15 @@ workspaces:
           - name: Market Analyst
             role: Market sizing, trends, user research
             files_dir: market-analyst
+            plugins: [ecc, molecule-dev, superpowers, browser-automation]
           - name: Technical Researcher
             role: AI frameworks and protocol evaluation
             files_dir: technical-researcher
+            plugins: [ecc, molecule-dev, superpowers, browser-automation]
           - name: Competitive Intelligence
             role: Competitor tracking and feature comparison
             files_dir: competitive-intelligence
+            plugins: [ecc, molecule-dev, superpowers, browser-automation]
 
       - name: Dev Lead
         role: Engineering planning and team coordination
@@ -269,6 +289,10 @@ workspaces:
             tier: 3
             model: opus
             files_dir: uiux-designer
+            # Add browser-automation for live canvas screenshots via Puppeteer
+            # (Chrome CDP path, works around the Playwright / libglib gap tracked in #23).
+            # Per-workspace plugins REPLACE defaults — re-list the full set.
+            plugins: [ecc, molecule-dev, superpowers, browser-automation]
             initial_prompt: |
               You just started as UIUX Designer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
## Summary
Declare plugins in the molecule-dev org template. No workspace was installing plugins before; agents ran without coding guardrails, codebase conventions, or debugging discipline.

## Changes

**1. `defaults.plugins: [ecc, molecule-dev, superpowers]`** — applied to every workspace unless overridden:
- **ecc** (Everything Claude Code): api-design, coding-standards, deep-research, security-review, tdd-workflow, node guardrails
- **molecule-dev**: project-specific conventions, past bugs, review-loop skill
- **superpowers**: systematic-debugging, test-driven-development, executing-plans, writing-plans, verification-before-completion

**2. Per-workspace override on research + UIUX roles:** `[ecc, molecule-dev, superpowers, browser-automation]`
- Research Lead, Market Analyst, Technical Researcher, Competitive Intelligence → web scraping is core to research output
- UIUX Designer → Puppeteer-via-CDP for live canvas screenshots (may work around #23's libglib/X11 gap since browser-automation uses `puppeteer-core` + Chrome CDP proxy, not Playwright's bundled Chromium install)

## Design note — per-workspace replaces, not unions
`platform/internal/handlers/org.go:345` treats `ws.Plugins` as a REPLACEMENT of `defaults.Plugins` when set. Any workspace that wants extras must re-list the defaults. Documented inline in the template so future editors don't accidentally drop the default three.

## Why these choices
- No workspace currently installs any plugin → coding agents lack the TDD + security-review + codebase-conventions skills that are literally sitting in `plugins/` ready to use.
- Research workspaces have no web access today beyond what the SDK tool belt gives them; `browser-automation` closes that.
- UIUX Designer has been noting "screenshots unavailable" for four consecutive hourly audit cycles (#23) — this PR gives a second path (puppeteer-core CDP) that's more likely to work inside the current container sandbox.
- Other dev roles (Dev Lead, BE, FE, DevOps, Security, QA, PM) get the default three; if they need web access they can install per-workspace via the runtime plugin API without a template change.

## Related
- **#23** — UIUX Designer missing Playwright system libs. This PR provides a parallel path (Puppeteer via CDP) but doesn't fix the underlying image gap.
- **#22** — per-workspace secret ACL (for when plugins need role-scoped secrets).

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('org-templates/molecule-dev/org.yaml'))"` — YAML valid.
- [x] `defaults.plugins` parses as `['ecc', 'molecule-dev', 'superpowers']`.
- [ ] After re-import: every workspace's `/configs/plugins/ecc/`, `/configs/plugins/molecule-dev/`, `/configs/plugins/superpowers/` populated at provision time (per `platform/internal/handlers/org.go:343-370` plugin-copy logic).
- [ ] Research + UIUX workspaces additionally have `/configs/plugins/browser-automation/`.
- [ ] Plugin skills appear in agents' tool catalogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)