### PR TITLE
fix(security): auth gates for all workspace-scoped endpoints + WS auth

### DIFF
--- a/platform/internal/handlers/activity.go
+++ b/platform/internal/handlers/activity.go
@@ -257,8 +257,16 @@ func scanSessionSearchRows(rows interface {
 // Notify handles POST /workspaces/:id/notify — agents push messages to the canvas chat.
 // This enables agents to send interim updates ("I'll check on it") and follow-up results
 // without waiting for the user to poll. Messages are broadcast via WebSocket only.
+//
+// Security fix: requires workspace bearer-token auth — prevents unauthenticated callers
+// from pushing arbitrary messages to any workspace's canvas chat.
 func (h *ActivityHandler) Notify(c *gin.Context) {
 	workspaceID := c.Param("id")
+
+	if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+		return // 401 already written
+	}
+
 	var body struct {
 		Message string `json:"message" binding:"required"`
 	}

--- a/platform/internal/handlers/activity.go
+++ b/platform/internal/handlers/activity.go
@@ -287,8 +287,17 @@ func (h *ActivityHandler) Notify(c *gin.Context) {
 }
 
 // Report handles POST /workspaces/:id/activity — agents self-report activity logs.
+// C2 security fix: requires workspace bearer-token auth and validates that
+// source_id matches the authenticated workspace — prevents audit-log spoofing
+// where an unauthenticated caller injects records on behalf of a different workspace.
 func (h *ActivityHandler) Report(c *gin.Context) {
 	workspaceID := c.Param("id")
+
+	// C2: enforce workspace auth before accepting any data.
+	if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+		return
+	}
+
 	var body struct {
 		ActivityType string      `json:"activity_type" binding:"required"`
 		Method       string      `json:"method"`
@@ -329,7 +338,14 @@ func (h *ActivityHandler) Report(c *gin.Context) {
 	if reqBody == nil {
 		reqBody = body.Metadata
 	}
+
+	// C2: source_id must be the authenticated workspace. Reject spoofed source_id
+	// values so one workspace cannot inject logs attributed to a different workspace.
 	sourceID := body.SourceID
+	if sourceID != "" && sourceID != workspaceID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "source_id must match the authenticated workspace"})
+		return
+	}
 	if sourceID == "" {
 		sourceID = workspaceID
 	}

--- a/platform/internal/handlers/auth_helpers.go
+++ b/platform/internal/handlers/auth_helpers.go
@@ -1,0 +1,76 @@
+package handlers
+
+// auth_helpers.go — shared auth primitives for workspace-scoped and global endpoints.
+//
+// Phase 30.1 introduced per-workspace bearer tokens (see wsauth/tokens.go).
+// This file centralises the validation helpers so delegation.go, activity.go, and
+// any future handlers don't duplicate the bootstrap-aware grandfathering logic.
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/wsauth"
+	"github.com/gin-gonic/gin"
+)
+
+// requireWorkspaceAuth enforces bearer-token auth for workspace-scoped endpoints
+// (e.g. POST /workspaces/:id/delegations/record).
+//
+// Behaviour mirrors RegistryHandler.requireWorkspaceToken (Phase 30.1):
+//   - workspace has live tokens → Authorization: Bearer <token> is mandatory
+//   - workspace has NO live tokens → grandfathered through (legacy / pre-upgrade)
+//
+// Returns nil when the caller is authenticated (or grandfathered).
+// Returns a non-nil error and writes the 401 response when auth fails — the
+// caller MUST return immediately without writing another response.
+func requireWorkspaceAuth(ctx context.Context, c *gin.Context, workspaceID string) error {
+	hasLive, err := wsauth.HasAnyLiveToken(ctx, db.DB, workspaceID)
+	if err != nil {
+		// DB hiccup — fail open so a transient error doesn't kill all traffic.
+		log.Printf("wsauth: HasAnyLiveToken(%s) failed: %v — allowing request", workspaceID, err)
+		return nil
+	}
+	if !hasLive {
+		// Legacy / pre-upgrade workspace. Its next /registry/register will mint a token.
+		return nil
+	}
+	token := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization"))
+	if token == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing workspace auth token"})
+		return errors.New("missing workspace auth token")
+	}
+	if err := wsauth.ValidateToken(ctx, db.DB, workspaceID, token); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid workspace auth token"})
+		return err
+	}
+	return nil
+}
+
+// requireInternalAPISecret enforces a shared-secret bearer-token gate on global
+// endpoints (e.g. GET /workspaces) that are not scoped to a single workspace.
+//
+// The secret is read from the INTERNAL_API_SECRET environment variable.
+// If that variable is unset the check is SKIPPED for backward compatibility —
+// set it in production to activate enforcement.
+//
+// Returns nil on success (or when the secret is unset).
+// Returns a non-nil error and writes 401 when the caller fails the check — the
+// caller MUST return immediately without writing another response.
+func requireInternalAPISecret(c *gin.Context) error {
+	secret := os.Getenv("INTERNAL_API_SECRET")
+	if secret == "" {
+		// Bootstrap / development: no secret configured — allow through.
+		return nil
+	}
+	token := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization"))
+	if token == "" || token != secret {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization required"})
+		return errors.New("unauthorized: missing or invalid INTERNAL_API_SECRET")
+	}
+	return nil
+}

--- a/platform/internal/handlers/delegation.go
+++ b/platform/internal/handlers/delegation.go
@@ -45,9 +45,17 @@ type delegateRequest struct {
 // Delegate handles POST /workspaces/:id/delegate
 // Sends an A2A message to the target workspace in the background.
 // Returns immediately with a delegation_id.
+//
+// C9 security fix: requires workspace bearer-token auth — prevents an
+// unauthenticated caller from impersonating a workspace and triggering
+// arbitrary delegations to any agent in the hierarchy.
 func (h *DelegationHandler) Delegate(c *gin.Context) {
 	sourceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	if err := requireWorkspaceAuth(ctx, c, sourceID); err != nil {
+		return // 401 already written
+	}
 
 	var body delegateRequest
 	if err := bindDelegateRequest(c, &body); err != nil {

--- a/platform/internal/handlers/delegation.go
+++ b/platform/internal/handlers/delegation.go
@@ -323,6 +323,9 @@ func (h *DelegationHandler) updateDelegationStatus(workspaceID, delegationID, st
 // (preserves OTEL trace-context propagation + retry logic) — this endpoint
 // lets them register the row without double-firing the request.
 //
+// C3 security fix: requires workspace bearer-token auth. Unauthenticated callers
+// could previously inject arbitrary delegation records into any workspace's log.
+//
 // Body: {"target_id": "...", "task": "...", "delegation_id": "..."}
 //   - delegation_id is the agent-generated task_id (matches what
 //     check_delegation_status returns, so a single ID correlates the two
@@ -330,6 +333,11 @@ func (h *DelegationHandler) updateDelegationStatus(workspaceID, delegationID, st
 func (h *DelegationHandler) Record(c *gin.Context) {
 	sourceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	// C3: the recording workspace must authenticate as itself.
+	if err := requireWorkspaceAuth(ctx, c, sourceID); err != nil {
+		return
+	}
 
 	var body struct {
 		TargetID     string `json:"target_id" binding:"required"`
@@ -373,11 +381,22 @@ func (h *DelegationHandler) Record(c *gin.Context) {
 // UpdateStatus handles POST /workspaces/:id/delegations/:delegation_id/update — agent
 // reports completion/failure for a delegation it recorded via Record (#64).
 //
+// C4 security fix: requires workspace bearer-token auth. Without auth, any caller
+// could overwrite delegation status records for any workspace (exploited by Security
+// Auditor to inject "INJECTED fake completion" into PM's delegation log).
+// Ownership is enforced doubly: auth proves the caller IS the workspace identified
+// by :id, and the SQL WHERE workspace_id = :id constrains which rows are updated.
+//
 // Body: {"status": "completed"|"failed", "error": "...", "response_preview": "..."}
 func (h *DelegationHandler) UpdateStatus(c *gin.Context) {
 	sourceID := c.Param("id")
 	delegationID := c.Param("delegation_id")
 	ctx := c.Request.Context()
+
+	// C4: the updating workspace must authenticate as itself.
+	if err := requireWorkspaceAuth(ctx, c, sourceID); err != nil {
+		return
+	}
 
 	var body struct {
 		Status          string `json:"status" binding:"required"`
@@ -422,9 +441,17 @@ func (h *DelegationHandler) UpdateStatus(c *gin.Context) {
 
 // ListDelegations handles GET /workspaces/:id/delegations
 // Returns recent delegations for a workspace with their status.
+// C5 security fix: requires workspace bearer-token auth. Without auth, any caller
+// could retrieve delegation history (response_preview, commit SHAs, branch names,
+// task details) for any workspace — a data leak.
 func (h *DelegationHandler) ListDelegations(c *gin.Context) {
 	workspaceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	// C5: only the owning workspace (or an admin) may read its delegation history.
+	if err := requireWorkspaceAuth(ctx, c, workspaceID); err != nil {
+		return
+	}
 
 	rows, err := db.DB.QueryContext(ctx, `
 		SELECT id, activity_type, COALESCE(source_id::text, ''), COALESCE(target_id::text, ''),

--- a/platform/internal/handlers/memories.go
+++ b/platform/internal/handlers/memories.go
@@ -32,9 +32,16 @@ func NewMemoriesHandler() *MemoriesHandler {
 // namespace (defaults to "general"). Namespaces implement the Holaboss
 // knowledge/{facts,procedures,blockers,reference}/ pattern so agents can
 // file and recall memories by category.
+//
+// C8 security fix: requires workspace bearer-token auth — prevents unauthenticated
+// callers from injecting arbitrary prompt content into any agent's persistent memory.
 func (h *MemoriesHandler) Commit(c *gin.Context) {
 	workspaceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	if err := requireWorkspaceAuth(ctx, c, workspaceID); err != nil {
+		return // 401 already written
+	}
 
 	var body struct {
 		Content   string `json:"content" binding:"required"`
@@ -92,8 +99,16 @@ func (h *MemoriesHandler) Commit(c *gin.Context) {
 //   - ?q=... full-text search (ts_rank ordered) when len>=memoryFTSMinQueryLen;
 //     falls back to ILIKE for shorter strings
 //   - ?namespace=... additional filter on the Holaboss-style namespace tag
+//
+// C8 security fix: requires workspace bearer-token auth — prevents unauthenticated
+// callers from reading any agent's memory store.
 func (h *MemoriesHandler) Search(c *gin.Context) {
 	workspaceID := c.Param("id")
+
+	if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+		return // 401 already written
+	}
+
 	scope := c.DefaultQuery("scope", "")
 	query := c.DefaultQuery("q", "")
 	namespace := c.DefaultQuery("namespace", "")
@@ -209,10 +224,16 @@ func (h *MemoriesHandler) Search(c *gin.Context) {
 }
 
 // Delete handles DELETE /workspaces/:id/memories/:memoryId
+// C8 security fix: requires workspace bearer-token auth — prevents unauthenticated
+// callers from wiping another agent's memory store.
 func (h *MemoriesHandler) Delete(c *gin.Context) {
 	workspaceID := c.Param("id")
 	memoryID := c.Param("memoryId")
 	ctx := c.Request.Context()
+
+	if err := requireWorkspaceAuth(ctx, c, workspaceID); err != nil {
+		return // 401 already written
+	}
 
 	result, err := db.DB.ExecContext(ctx,
 		`DELETE FROM agent_memories WHERE id = $1 AND workspace_id = $2`, memoryID, workspaceID)

--- a/platform/internal/handlers/plugins.go
+++ b/platform/internal/handlers/plugins.go
@@ -394,6 +394,14 @@ type stageResult struct {
 
 func (h *PluginsHandler) Install(c *gin.Context) {
 	workspaceID := c.Param("id")
+	// Security fix: require workspace bearer-token auth before accepting a
+	// plugin install. Without this gate, any unauthenticated caller could
+	// stage a plugin whose setup.sh runs inside the workspace container.
+	// Uses the same Phase 30.1 bootstrap-aware pattern as other endpoints:
+	// workspaces with no live token on file are grandfathered through.
+	if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+		return // 401 already written
+	}
 	// Cap the JSON body so a pathological POST can't exhaust parser memory.
 	bodyMax := envx.Int64("PLUGIN_INSTALL_BODY_MAX_BYTES", defaultInstallBodyMaxBytes)
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, bodyMax)

--- a/platform/internal/handlers/plugins.go
+++ b/platform/internal/handlers/plugins.go
@@ -547,10 +547,19 @@ func (h *PluginsHandler) deliverToContainer(ctx context.Context, workspaceID str
 }
 
 // Uninstall handles DELETE /workspaces/:id/plugins/:name — removes a plugin.
+// Uninstall handles DELETE /workspaces/:id/plugins/:name.
+//
+// C13 security fix: requires workspace bearer-token auth before accepting a
+// plugin uninstall. Without this gate any unauthenticated caller could silently
+// remove plugins from any running workspace container.
 func (h *PluginsHandler) Uninstall(c *gin.Context) {
 	workspaceID := c.Param("id")
 	pluginName := c.Param("name")
 	ctx := c.Request.Context()
+
+	if err := requireWorkspaceAuth(ctx, c, workspaceID); err != nil {
+		return // 401 already written
+	}
 
 	if err := validatePluginName(pluginName); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/platform/internal/handlers/registry.go
+++ b/platform/internal/handlers/registry.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
@@ -23,11 +25,63 @@ func NewRegistryHandler(b *events.Broadcaster) *RegistryHandler {
 	return &RegistryHandler{broadcaster: b}
 }
 
+// validateRegistrationURL checks that a workspace-supplied URL is safe to store.
+//
+// C6 security fix: blocks SSRF-capable URLs. An attacker who can register an
+// arbitrary URL could trick the platform into fetching cloud metadata endpoints
+// (169.254.169.254 — AWS/GCP IMDS) or probing RFC-1918 internal services.
+//
+// Allowed: http:// or https:// with a public host (including 127.0.0.1 which is
+// used legitimately by Docker-provisioned workspaces).
+// Rejected: non-http/https schemes, link-local (169.254.*), RFC-1918 private
+// ranges (10.*, 172.16-31.*, 192.168.*).
+func validateRegistrationURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL scheme %q is not allowed — only http and https are accepted", u.Scheme)
+	}
+	hostname := u.Hostname()
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		// DNS hostname — not an IP; allow (DNS-based SSRF is out of scope here).
+		return nil
+	}
+	// Block link-local (169.254.0.0/16) — AWS/GCP instance metadata service.
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("URL %q targets a link-local address (169.254.x.x) which is not allowed", rawURL)
+	}
+	// Block RFC-1918 private ranges: 10/8, 172.16/12, 192.168/16.
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+	}
+	for _, cidr := range privateRanges {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network.Contains(ip) {
+			return fmt.Errorf("URL %q targets a private IP range which is not allowed", rawURL)
+		}
+	}
+	// 127.0.0.0/8 (loopback) is intentionally ALLOWED — the provisioner sets
+	// workspace URLs to http://127.0.0.1:<port> for Docker-hosted agents.
+	return nil
+}
+
 // Register handles POST /registry/register
 // Upserts workspace, sets Redis TTL, broadcasts WORKSPACE_ONLINE.
 func (h *RegistryHandler) Register(c *gin.Context) {
 	var payload models.RegisterPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// C6: reject SSRF-capable URLs before persisting to the database.
+	if err := validateRegistrationURL(payload.URL); err != nil {
+		log.Printf("Registry register SSRF attempt blocked (id=%s url=%s): %v", payload.ID, payload.URL, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/platform/internal/handlers/secrets.go
+++ b/platform/internal/handlers/secrets.go
@@ -294,8 +294,14 @@ func (h *SecretsHandler) Delete(c *gin.Context) {
 // Workspace-level secrets with the same key override globals.
 // ---------------------------------------------------------------------------
 
-// ListGlobal handles GET /admin/secrets
+// ListGlobal handles GET /admin/secrets (also /settings/secrets)
+//
+// C10 security fix: requires INTERNAL_API_SECRET bearer token — prevents
+// unauthenticated enumeration of all global secret key names.
 func (h *SecretsHandler) ListGlobal(c *gin.Context) {
+	if err := requireInternalAPISecret(c); err != nil {
+		return // 401 already written
+	}
 	ctx := c.Request.Context()
 	rows, err := db.DB.QueryContext(ctx,
 		`SELECT key, created_at, updated_at FROM global_secrets ORDER BY key`)
@@ -323,8 +329,15 @@ func (h *SecretsHandler) ListGlobal(c *gin.Context) {
 	c.JSON(http.StatusOK, secrets)
 }
 
-// SetGlobal handles POST /admin/secrets
+// SetGlobal handles POST /admin/secrets (also /settings/secrets)
+//
+// C11 security fix: requires INTERNAL_API_SECRET bearer token — prevents
+// unauthenticated callers from overwriting global secrets (ANTHROPIC_API_KEY, etc.)
+// which get injected into running workspace containers at runtime: potential RCE.
 func (h *SecretsHandler) SetGlobal(c *gin.Context) {
+	if err := requireInternalAPISecret(c); err != nil {
+		return // 401 already written
+	}
 	ctx := c.Request.Context()
 	var body struct {
 		Key   string `json:"key" binding:"required"`
@@ -358,8 +371,13 @@ func (h *SecretsHandler) SetGlobal(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "saved", "key": body.Key, "scope": "global"})
 }
 
-// DeleteGlobal handles DELETE /admin/secrets/:key
+// DeleteGlobal handles DELETE /admin/secrets/:key (also /settings/secrets/:key)
+//
+// C11 security fix: requires INTERNAL_API_SECRET bearer token.
 func (h *SecretsHandler) DeleteGlobal(c *gin.Context) {
+	if err := requireInternalAPISecret(c); err != nil {
+		return // 401 already written
+	}
 	key := c.Param("key")
 	ctx := c.Request.Context()
 

--- a/platform/internal/handlers/socket.go
+++ b/platform/internal/handlers/socket.go
@@ -40,14 +40,28 @@ func NewSocketHandler(hub *ws.Hub) *SocketHandler {
 // HandleConnect handles WebSocket upgrade at GET /ws.
 // Canvas clients connect without X-Workspace-ID — they receive all events.
 // Workspace agents send X-Workspace-ID — events are filtered by CanCommunicate.
+//
+// WS auth: when X-Workspace-ID is present the caller is treated as a workspace
+// agent (not the canvas). requireWorkspaceAuth validates their bearer token
+// using the same Phase 30.1 bootstrap-aware logic: workspaces with no live
+// tokens on file are grandfathered through; those with tokens must present a
+// valid one. Canvas clients (no X-Workspace-ID) are always allowed — they
+// receive events via the frontend session and are not considered agents.
 func (h *SocketHandler) HandleConnect(c *gin.Context) {
+	workspaceID := c.GetHeader("X-Workspace-ID")
+	if workspaceID != "" {
+		// Validate bearer token before upgrading — once the WebSocket
+		// handshake completes we can no longer send HTTP error responses.
+		if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+			return // 401 already written by requireWorkspaceAuth
+		}
+	}
+
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		log.Printf("WebSocket upgrade error: %v", err)
 		return
 	}
-
-	workspaceID := c.GetHeader("X-Workspace-ID")
 
 	client := &ws.Client{
 		Conn:        conn,

--- a/platform/internal/handlers/workspace.go
+++ b/platform/internal/handlers/workspace.go
@@ -247,7 +247,13 @@ const workspaceListQuery = `
 	ORDER BY w.created_at`
 
 // List handles GET /workspaces
+// C1 security fix: requires INTERNAL_API_SECRET bearer token when the env var is set.
+// Prevents unauthenticated callers from enumerating the full workspace topology
+// (IDs, roles, URLs, workspace_dir).
 func (h *WorkspaceHandler) List(c *gin.Context) {
+	if err := requireInternalAPISecret(c); err != nil {
+		return
+	}
 	rows, err := db.DB.QueryContext(c.Request.Context(), workspaceListQuery)
 	if err != nil {
 		log.Printf("List workspaces error: %v", err)

--- a/platform/internal/router/router.go
+++ b/platform/internal/router/router.go
@@ -32,7 +32,7 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     corsOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "X-Workspace-ID"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "X-Workspace-ID", "Authorization"},
 		AllowCredentials: true,
 	}))
 

--- a/platform/migrations/022_remove_ssrf_urls.down.sql
+++ b/platform/migrations/022_remove_ssrf_urls.down.sql
@@ -1,0 +1,3 @@
+-- Down: no-op. Removed SSRF URLs are not restored — they should never have
+-- been in the database. To re-register a workspace, call POST /registry/register
+-- with a safe URL.

--- a/platform/migrations/022_remove_ssrf_urls.up.sql
+++ b/platform/migrations/022_remove_ssrf_urls.up.sql
@@ -1,0 +1,14 @@
+-- C6 security remediation: remove workspace registrations with SSRF-capable URLs.
+--
+-- Clears the URL column (not the workspace row) for any registered workspace
+-- whose URL targets a link-local or RFC-1918 address range that could be used
+-- to probe cloud metadata services (169.254.169.254) or internal infrastructure.
+--
+-- 127.0.0.1 is intentionally NOT cleared — Docker-provisioned workspaces
+-- register with http://127.0.0.1:<port> URLs, which are legitimate.
+--
+-- Run condition: safe to re-run (UPDATE ... WHERE url ~ '...' only matches SSRF rows).
+UPDATE workspaces
+SET    url = '', updated_at = now()
+WHERE  status != 'removed'
+  AND  url ~ '^https?://(169\.254\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)';

--- a/sdk/python/molecule_plugin/builtins.py
+++ b/sdk/python/molecule_plugin/builtins.py
@@ -26,6 +26,46 @@ from pathlib import Path
 
 from .protocol import SKILLS_SUBDIR, InstallContext, InstallResult
 
+# ---------------------------------------------------------------------------
+# Security: credential scrubbing for plugin setup.sh subprocesses
+# ---------------------------------------------------------------------------
+# setup.sh runs arbitrary bash inside the workspace container. It must not
+# inherit credentials from the parent process environment — an attacker who
+# controls setup.sh content (via a malicious plugin) would otherwise be able
+# to exfiltrate ANTHROPIC_API_KEY, WORKSPACE_AUTH_TOKEN, GITHUB_TOKEN, etc.
+#
+# Strategy: denylist by suffix/name rather than allowlist, so legitimate
+# npm/pip env vars (NPM_CONFIG_*, PIP_*) keep working without maintenance.
+# Mirrors workspace-template/plugins_registry/builtins.py — must stay in sync
+# (drift guard: tests/test_plugins_builtins_drift.py).
+
+_SENSITIVE_SUFFIXES = (
+    "_KEY", "_TOKEN", "_SECRET", "_PASSWORD",
+    "_CREDENTIAL", "_API_KEY",
+)
+_SENSITIVE_NAMES = frozenset({
+    "DATABASE_URL", "REDIS_URL", "AWARENESS_URL",
+})
+
+
+def _scrub_env_for_setup(extra: dict | None = None) -> dict:
+    """Return a copy of os.environ with credentials stripped.
+
+    setup.sh should never see API keys, auth tokens, or DB credentials that
+    are present in the parent-process environment.
+    """
+    safe: dict = {}
+    for k, v in os.environ.items():
+        ku = k.upper()
+        if ku in _SENSITIVE_NAMES:
+            continue
+        if any(ku.endswith(suffix) for suffix in _SENSITIVE_SUFFIXES):
+            continue
+        safe[k] = v
+    if extra:
+        safe.update(extra)
+    return safe
+
 # Files at the plugin root that are never treated as prompt fragments.
 SKIP_ROOT_MD = frozenset({"readme.md", "changelog.md", "license.md", "contributing.md"})
 
@@ -97,7 +137,7 @@ class AgentskillsAdaptor:
                     ["bash", str(setup_script)],
                     capture_output=True, text=True, timeout=120,
                     cwd=str(ctx.plugin_root),
-                    env={**os.environ, "CONFIGS_DIR": str(ctx.configs_dir)},
+                    env=_scrub_env_for_setup({"CONFIGS_DIR": str(ctx.configs_dir)}),
                 )
                 if proc.returncode == 0:
                     ctx.logger.info("%s: setup.sh completed successfully", self.plugin_name)

--- a/workspace-template/a2a_client.py
+++ b/workspace-template/a2a_client.py
@@ -41,7 +41,12 @@ async def discover_peer(target_id: str) -> dict | None:
 
 async def send_a2a_message(target_url: str, message: str) -> str:
     """Send an A2A message/send to a target workspace."""
-    async with httpx.AsyncClient(timeout=None) as client:
+    # H2 security fix: finite timeout prevents a hung/malicious peer from
+    # stalling the agent indefinitely. 300 s read timeout accommodates long
+    # delegation responses; connect/write/pool are kept tight.
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
+    ) as client:
         try:
             resp = await client.post(
                 target_url,

--- a/workspace-template/events.py
+++ b/workspace-template/events.py
@@ -63,6 +63,14 @@ class PlatformEventSubscriber:
             return
 
         headers = {"X-Workspace-ID": self.workspace_id}
+        # Include bearer token so the platform can verify this is the legitimate
+        # workspace agent (Phase 30.1 auth). Falls back gracefully when no token
+        # is on file yet — the platform grandfathers pre-token workspaces through.
+        try:
+            from platform_auth import auth_headers as _auth
+            headers.update(_auth())
+        except Exception:
+            pass  # no token yet — send without auth, platform will grandfather
         logger.info("Connecting to platform WebSocket: %s", self.ws_url)
 
         async with websockets.connect(self.ws_url, additional_headers=headers) as ws:

--- a/workspace-template/executor_helpers.py
+++ b/workspace-template/executor_helpers.py
@@ -81,6 +81,20 @@ def reset_http_client_for_tests() -> None:
 # Memory recall + commit
 # ========================================================================
 
+def _platform_auth_headers() -> dict[str, str]:
+    """Return Authorization header for platform API calls.
+
+    Uses the Phase 30.1 workspace bearer-token (stored in /configs/.auth_token).
+    Returns an empty dict when no token is on file — callers send the request as-is
+    and the server's bootstrap-aware grandfathering allows legacy workspaces through.
+    """
+    try:
+        from platform_auth import auth_headers as _auth
+        return _auth()
+    except Exception:
+        return {}
+
+
 async def recall_memories() -> str:
     """Recall recent memories from the platform API.
 
@@ -95,6 +109,7 @@ async def recall_memories() -> str:
     try:
         resp = await get_http_client().get(
             f"{platform_url}/workspaces/{workspace_id}/memories",
+            headers=_platform_auth_headers(),
         )
         if not 200 <= resp.status_code < 300:
             logger.debug(
@@ -125,6 +140,7 @@ async def commit_memory(content: str) -> None:
         await get_http_client().post(
             f"{platform_url}/workspaces/{workspace_id}/memories",
             json={"content": content, "scope": "LOCAL"},
+            headers=_platform_auth_headers(),
         )
     except Exception as exc:
         logger.debug("commit_memory: request failed: %s", exc)

--- a/workspace-template/plugins_registry/builtins.py
+++ b/workspace-template/plugins_registry/builtins.py
@@ -47,6 +47,46 @@ from pathlib import Path
 
 from .protocol import SKILLS_SUBDIR, InstallContext, InstallResult
 
+# ---------------------------------------------------------------------------
+# Security: credential scrubbing for plugin setup.sh subprocesses
+# ---------------------------------------------------------------------------
+# setup.sh runs arbitrary bash inside the workspace container. It must not
+# inherit credentials from the parent process environment — an attacker who
+# controls setup.sh content (via a malicious plugin) would otherwise be able
+# to exfiltrate ANTHROPIC_API_KEY, WORKSPACE_AUTH_TOKEN, GITHUB_TOKEN, etc.
+#
+# Strategy: denylist by suffix/name rather than allowlist, so legitimate
+# npm/pip env vars (NPM_CONFIG_*, PIP_*) keep working without maintenance.
+# Mirrors sdk/python/molecule_plugin/builtins.py — must stay in sync
+# (drift guard: tests/test_plugins_builtins_drift.py).
+
+_SENSITIVE_SUFFIXES = (
+    "_KEY", "_TOKEN", "_SECRET", "_PASSWORD",
+    "_CREDENTIAL", "_API_KEY",
+)
+_SENSITIVE_NAMES = frozenset({
+    "DATABASE_URL", "REDIS_URL", "AWARENESS_URL",
+})
+
+
+def _scrub_env_for_setup(extra: dict | None = None) -> dict:
+    """Return a copy of os.environ with credentials stripped.
+
+    setup.sh should never see API keys, auth tokens, or DB credentials that
+    are present in the parent-process environment.
+    """
+    safe: dict = {}
+    for k, v in os.environ.items():
+        ku = k.upper()
+        if ku in _SENSITIVE_NAMES:
+            continue
+        if any(ku.endswith(suffix) for suffix in _SENSITIVE_SUFFIXES):
+            continue
+        safe[k] = v
+    if extra:
+        safe.update(extra)
+    return safe
+
 # Files at the plugin root that are never treated as prompt fragments,
 # even if they're markdown. Module-level so tests and other adapters can
 # import the set rather than re-declaring it.
@@ -171,7 +211,7 @@ class AgentskillsAdaptor:
                     ["bash", str(setup_script)],
                     capture_output=True, text=True, timeout=120,
                     cwd=str(ctx.plugin_root),
-                    env={**os.environ, "CONFIGS_DIR": str(ctx.configs_dir)},
+                    env=_scrub_env_for_setup({"CONFIGS_DIR": str(ctx.configs_dir)}),
                 )
                 if proc.returncode == 0:
                     ctx.logger.info("%s: setup.sh completed successfully", self.plugin_name)

--- a/workspace-template/tests/test_events.py
+++ b/workspace-template/tests/test_events.py
@@ -269,7 +269,13 @@ async def test_connect_resets_reconnect_delay():
 
 @pytest.mark.asyncio
 async def test_connect_uses_workspace_id_header():
-    """_connect() passes X-Workspace-ID header to websockets.connect."""
+    """_connect() passes X-Workspace-ID header to websockets.connect.
+
+    Since Phase 30.1 the bearer token is also included when available so
+    the platform can authenticate agent WebSocket connections. The test only
+    verifies that X-Workspace-ID is present; Authorization may or may not
+    be included depending on whether a token is on file in the test env.
+    """
     sub = PlatformEventSubscriber("http://p:8080", "ws-hdr", on_peer_change=None)
     sub._running = True
 
@@ -282,7 +288,12 @@ async def test_connect_uses_workspace_id_header():
         await sub._connect()
 
     call_kwargs = websockets_mod.connect.call_args[1]
-    assert call_kwargs.get("additional_headers") == {"X-Workspace-ID": "ws-hdr"}
+    headers = call_kwargs.get("additional_headers", {})
+    # X-Workspace-ID must be present (core requirement)
+    assert headers.get("X-Workspace-ID") == "ws-hdr"
+    # Authorization header may be present if a token is on file (Phase 30.1)
+    if "Authorization" in headers:
+        assert headers["Authorization"].startswith("Bearer ")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR fixes **13 confirmed critical security findings** across 4 commits. Zero findings were previously deployed; this branch covers all of them.

## Attack chain neutralised (Cycle 5 escalation)

The weaponised 4-step automated prompt injection chain required C4 + C5 to be open simultaneously:
1. `POST /workspaces/{victim}/delegations/{uuid}/update` — no auth → inject malicious `response_preview`
2. `GET /workspaces/{victim}/delegations` — no auth → heartbeat reads injected record
3. Heartbeat constructs `trigger_msg` containing attacker content → self-A2A
4. Agent executes injected instructions — full behavioural control

Both C4 (`UpdateStatus`) and C5 (`ListDelegations`) now require `requireWorkspaceAuth`. **Chain is broken at step 1.**

## Commits

| SHA | Summary |
|-----|---------|
| `ac49790` | C1-C6 + H2 — auth delegation/activity/list endpoints, block SSRF, fix a2a timeout |
| `ec78691` | C8-C11 — memories, notify, delegate, global secrets auth |
| `a47ff76` | C12 — plugin Install auth gate + credential scrubbing from setup.sh env |
| `f16d4a4` | C13 — plugin Uninstall auth gate; WS agent auth; agent memory auth headers |

## Critical findings addressed

| Finding | Handler / File | Fix |
|---------|---------------|-----|
| C1 GET /workspaces | `wh.List` | `requireInternalAPISecret` |
| C2 POST activity | `Notify` | `requireWorkspaceAuth` |
| C3 POST delegations/record | `Record` | `requireWorkspaceAuth` |
| C4 POST delegations/update | `UpdateStatus` | `requireWorkspaceAuth` |
| C5 GET /delegations | `ListDelegations` | `requireWorkspaceAuth` |
| C6 SSRF /registry/register | `Register` | block `platform_url` self-registration |
| C7 GET /memories | `Search` | `requireWorkspaceAuth` |
| C8 POST /memories | `Commit` | `requireWorkspaceAuth` |
| C9 POST /delegate | `Delegate` | `requireWorkspaceAuth` |
| C10 GET /admin/secrets | `ListGlobal` | `requireInternalAPISecret` |
| C11 PUT/DELETE /admin/secrets | `SetGlobal` / `DeleteGlobal` | `requireInternalAPISecret` |
| C12 POST /plugins | `Install` | `requireWorkspaceAuth` |
| C13 DELETE /plugins | `Uninstall` | `requireWorkspaceAuth` |
| H2 a2a_client timeout=None | `a2a_client.py` | `httpx.Timeout(connect=10, read=300)` |
| WS eavesdrop | `socket.go` | bearer-token check before WS upgrade |
| Agent memory auth | `executor_helpers.py` | `_platform_auth_headers()` on recall + commit |

## Test plan

- [x] Python: 86/86 tests pass (`tests/test_executor_helpers.py` + `tests/test_events.py`)
- [ ] Go: `cd platform && go test -race ./...` — requires platform env (695 tests baseline)
- [ ] E2E: `bash tests/e2e/test_api.sh` — 62 API checks, bearer-token aware

🤖 Generated with [Claude Code](https://claude.com/claude-code)