### PR TITLE
chore(template): Security Auditor DAST must clean up its own test artifacts

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -250,6 +250,34 @@ workspaces:
                      - CORS: verify Access-Control-Allow-Origin on a cross-origin request
                      - Rate limit headers on /health
 
+                  4a. DAST TEARDOWN (MANDATORY — prevents test-artifact leak into prod DB):
+                      Any workspace, secret, or plugin you CREATE during this audit must be
+                      DELETED before this step exits. Maintain three lists as you go:
+
+                        TESTS_WORKSPACES=""   # workspace IDs you POSTed
+                        TESTS_SECRETS=""      # secret keys you set
+                        TESTS_PLUGINS=""      # "<ws_id>:<plugin_name>" pairs
+
+                      At the end of step 4, iterate each list and DELETE — even if the audit
+                      aborts, the teardown block must run:
+
+                        for ws_id in $TESTS_WORKSPACES; do
+                          curl -s -X DELETE "http://host.docker.internal:8080/workspaces/$ws_id" \
+                            -H "Authorization: Bearer $WORKSPACE_AUTH_TOKEN" > /dev/null || true
+                        done
+                        for key in $TESTS_SECRETS; do
+                          curl -s -X DELETE "http://host.docker.internal:8080/admin/secrets/$key" > /dev/null || true
+                        done
+                        for pair in $TESTS_PLUGINS; do
+                          ws="${pair%:*}"; pl="${pair#*:}"
+                          curl -s -X DELETE "http://host.docker.internal:8080/workspaces/$ws/plugins/$pl" > /dev/null || true
+                        done
+
+                      Prior incident (#17): repeated DAST runs leaked 4 workspaces
+                      (aaaaaaaa-/bbbbbbbb-/cccccccc-/dddddddd-) into the live DB, each trapped
+                      in a restart loop on missing config.yaml. This teardown step prevents
+                      that class of leak regardless of which specific probes you run.
+
                   5. SECRETS SCAN: last 20 commits grepped for token patterns
                      (sk-ant, sk-or, api_key= etc.) excluding test files.
 


### PR DESCRIPTION
## Summary
The Security Auditor's hourly DAST cron was creating test workspaces during security probes and never tearing them down, leaking rows into the live `workspaces` table. Adds an explicit `4a. DAST TEARDOWN` step to the cron prompt with a track-and-cleanup pattern for workspaces, secrets, and plugins.

## Root cause
Investigated under #17 (see comment 2026-04-14 02:14 UTC). The cron prompt already cleaned up secrets and plugins it created, but workspace-create probes had no teardown. Over four hourly runs we got four leaked rows with sequential IDs (`aaaaaaaa-…`/`bbbbbbbb-…`/`cccccccc-…`/`dddddddd-…`), each trapped in a restart loop against the missing config.yaml.

Platform log evidence at 2026-04-14 04:27:17 UTC (one sample, representative of every cycle):
```
POST  /admin/secrets                                           — create test secret
DELETE /admin/secrets/SEC-TEST-C5                              — cleanup (good)
POST  /workspaces/<PM>/plugins (404 for non-existent plugin)
DELETE /workspaces/<PM>/plugins/nonexistent-sec-test           — cleanup (good)
ProxyA2A: access denied <PM> → <BE>                            — CanCommunicate bypass probe
[workspace row `dddddddd-1234-5678-abcd-000000000004` appears in DB]
[no corresponding DELETE]
```

## Changes
Single edit to `org-templates/molecule-dev/org.yaml` — adds step 4a to the `Hourly security audit` cron prompt:

- Declare three tracking lists at the start of step 4: `TESTS_WORKSPACES`, `TESTS_SECRETS`, `TESTS_PLUGINS`.
- Every probe that creates an artifact appends its ID to the right list.
- At the end of step 4 (unconditional, runs even on partial audit failure), iterate each list and issue `DELETE`. Uses `|| true` so a failed cleanup doesn't abort the audit.
- Includes the prior-incident narrative inline so future editors understand *why* the step exists.

## Why inline vs. platform-layer
A platform-level circuit-breaker (reject workspace creates from DAST, or TTL test workspaces) is still valid (proposed in #17 options B/C/D). But this template-layer fix is orthogonal and the cheapest immediate stop — it doesn't depend on any code change, and it closes the specific incident class we've already seen four times today.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('org-templates/molecule-dev/org.yaml'))"` — YAML valid.
- [ ] Next hourly cron run (after merge + template re-import): no new `eeeeeeee-…` row appears in `workspaces`.
- [ ] `docker ps | grep -c 'ws-[a-z]\{8\}-123'` stays at 0 across successive runs.
- [ ] Secret/plugin cleanup still works as before (no regression on existing teardown).

## Related
- **#17** — root cause captured; this PR closes the template-layer side. Platform-level circuit-breaker remains in scope for that issue.
- **#26** — audit cron routing (merged). This change sits alongside that structure without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)