### PR TITLE
ci: post canvas deploy reminder after every main merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,44 @@ jobs:
         with:
           scandir: tests/e2e
 
+  canvas-deploy-reminder:
+    name: Canvas Deploy Reminder
+    runs-on: ubuntu-latest
+    needs: canvas-build
+    # Only fires on direct pushes to main (i.e. after a PR merges).
+    # PRs get canvas-build CI but no reminder — no deployment happens on PRs.
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      # Required to post commit comments via the GitHub API.
+      contents: write
+    steps:
+      - name: Post deploy reminder as commit comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Write body to a temp file — avoids backtick escaping in shell.
+          cat > /tmp/deploy-reminder.md << 'BODY'
+          ## Canvas build passed ✅ — deploy required
+
+          The canvas container is **not auto-deployed**. Merged canvas changes are invisible until the host container is rebuilt.
+
+          Run this on the host machine to apply:
+          ```bash
+          cd /g/personal_programs/molecule-monorepo
+          git pull origin main
+          docker compose build canvas && docker compose up -d canvas
+          ```
+          BODY
+          printf '\n> Posted automatically by CI · commit `%s` · [build log](%s)\n' \
+            "$COMMIT_SHA" "$RUN_URL" >> /tmp/deploy-reminder.md
+
+          gh api \
+            --method POST \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/comments" \
+            --field "body=@/tmp/deploy-reminder.md"
+
   python-lint:
     name: Python Lint & Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

5 consecutive merge cycles (PRs #21, #25, #30, #32, #34) went undeployed because the canvas container is not auto-rebuilt after CI passes and the manual rebuild step was silently forgotten each time.

## Solution

Adds a `canvas-deploy-reminder` job to `ci.yml`. After every push to `main` where `canvas-build` passes, it posts a **commit comment** via the built-in `GITHUB_TOKEN` (no new secrets needed) with the exact commands to rebuild the container.

The comment looks like:
> ## Canvas build passed ✅ — deploy required
> The canvas container is **not auto-deployed**. Run this on the host machine to apply:
> ```bash
> cd /g/personal_programs/molecule-monorepo
> git pull origin main
> docker compose build canvas && docker compose up -d canvas
> ```

## Properties

- **No new secrets required** — uses `GITHUB_TOKEN` with `contents: write` (minimum scope for commit comments)
- **Only fires on main pushes** — `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`; PR builds are unaffected
- **Only fires after a clean build** — `needs: canvas-build` means a failing build produces no comment
- **Each merge gets one comment** — on the merge commit SHA, not a PR comment, so it's always findable via `git log`
- **Body written via heredoc + file** — avoids shell escaping issues with embedded backticks

## Test plan

- [x] CI YAML is syntactically valid (reviewed full file)
- [ ] After this merges to main, the next canvas-touching merge should produce a commit comment on that merge SHA
- [ ] Verify the comment appears under the merge commit in GitHub's commit view

🤖 Generated with [Claude Code](https://claude.com/claude-code)