### PR TITLE
fix(security): N1 — Python callers missing auth headers for /workspaces/* routes

### DIFF
--- a/workspace-template/a2a_client.py
+++ b/workspace-template/a2a_client.py
@@ -10,6 +10,8 @@ import uuid
 
 import httpx
 
+from platform_auth import auth_headers
+
 logger = logging.getLogger(__name__)
 
 WORKSPACE_ID = os.environ.get("WORKSPACE_ID", "")
@@ -94,7 +96,10 @@ async def get_workspace_info() -> dict:
     """Get this workspace's info from the platform."""
     async with httpx.AsyncClient(timeout=10.0) as client:
         try:
-            resp = await client.get(f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}")
+            resp = await client.get(
+                f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}",
+                headers=auth_headers(),
+            )
             if resp.status_code == 200:
                 return resp.json()
             return {"error": "not found"}

--- a/workspace-template/consolidation.py
+++ b/workspace-template/consolidation.py
@@ -14,6 +14,8 @@ import os
 
 import httpx
 
+from platform_auth import auth_headers
+
 logger = logging.getLogger(__name__)
 
 PLATFORM_URL = os.environ.get("PLATFORM_URL", "http://platform:8080")
@@ -53,6 +55,7 @@ class ConsolidationLoop:
             resp = await client.get(
                 f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories",
                 params={"scope": "LOCAL"},
+                headers=auth_headers(),
             )
             if resp.status_code != 200:
                 return
@@ -95,12 +98,14 @@ class ConsolidationLoop:
                         resp = await client.post(
                             f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories",
                             json={"content": f"[Consolidated] {summary}", "scope": "TEAM"},
+                            headers=auth_headers(),
                         )
                         if resp.status_code in (200, 201):
                             # Safe to delete originals — consolidated version is saved
                             for m in memories:
                                 await client.delete(
-                                    f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories/{m['id']}"
+                                    f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories/{m['id']}",
+                                    headers=auth_headers(),
                                 )
                             logger.info("Consolidated %d memories into team knowledge", len(memories))
                         else:
@@ -118,6 +123,7 @@ class ConsolidationLoop:
                 await client.post(
                     f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories",
                     json={"content": f"[Consolidated] {combined}", "scope": "TEAM"},
+                    headers=auth_headers(),
                 )
                 logger.info("Consolidated %d memories via concatenation fallback", len(memories))
 

--- a/workspace-template/heartbeat.py
+++ b/workspace-template/heartbeat.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 import httpx
 
+from platform_auth import auth_headers
+
 logger = logging.getLogger(__name__)
 
 HEARTBEAT_INTERVAL = 30  # seconds
@@ -83,7 +85,6 @@ class HeartbeatLoop:
                 while True:
                     # 1. Send heartbeat (Phase 30.1: include auth header if token known)
                     try:
-                        from platform_auth import auth_headers
                         await client.post(
                             f"{self.platform_url}/registry/heartbeat",
                             json={
@@ -135,7 +136,8 @@ class HeartbeatLoop:
         """Check for completed delegations and store results for the agent."""
         try:
             resp = await client.get(
-                f"{self.platform_url}/workspaces/{self.workspace_id}/delegations"
+                f"{self.platform_url}/workspaces/{self.workspace_id}/delegations",
+                headers=auth_headers(),
             )
             if resp.status_code != 200:
                 return
@@ -208,13 +210,15 @@ class HeartbeatLoop:
                 if self._parent_name is None:
                     try:
                         parent_resp = await client.get(
-                            f"{self.platform_url}/workspaces/{self.workspace_id}"
+                            f"{self.platform_url}/workspaces/{self.workspace_id}",
+                            headers=auth_headers(),
                         )
                         if parent_resp.status_code == 200:
                             parent_id = parent_resp.json().get("parent_id", "")
                             if parent_id:
                                 parent_info = await client.get(
-                                    f"{self.platform_url}/workspaces/{parent_id}"
+                                    f"{self.platform_url}/workspaces/{parent_id}",
+                                    headers=auth_headers(),
                                 )
                                 if parent_info.status_code == 200:
                                     self._parent_name = parent_info.json().get("name", "")
@@ -262,6 +266,7 @@ class HeartbeatLoop:
                                     },
                                 },
                             },
+                            headers=auth_headers(),
                             timeout=120.0,
                         )
                         logger.info("Heartbeat: self-message sent to process delegation results")
@@ -277,6 +282,7 @@ class HeartbeatLoop:
                         await client.post(
                             f"{self.platform_url}/workspaces/{self.workspace_id}/notify",
                             json={"message": msg, "type": "delegation_result"},
+                            headers=auth_headers(),
                         )
                     except Exception:
                         pass


### PR DESCRIPTION
## ⚠️ MUST DEPLOY WITH PR #31 — deploying #31 alone breaks all delegation

PR #31 adds WorkspaceAuth middleware to every `/workspaces/*` route. Without this companion PR, every heartbeat poll, delegation wake-up, memory consolidation, and canvas notification immediately starts returning 401 and fails silently. The entire multi-agent coordination system stops delivering results.

## Problem (N1 — HIGH)

Three Python modules make calls to `/workspaces/*` endpoints with **no `Authorization` header**. After PR #31 ships, all of these return `401 Unauthorized`:

| File | Endpoint | Impact |
|------|----------|--------|
| `heartbeat.py` | `GET /workspaces/:id/delegations` | Delegation poll → no results processed |
| `heartbeat.py` | `GET /workspaces/:id` | Parent name lookup fails |
| `heartbeat.py` | `GET /workspaces/{parent_id}` | Parent name lookup fails |
| `heartbeat.py` | `POST /workspaces/:id/a2a` | **Agent never wakes up after task completes** |
| `heartbeat.py` | `POST /workspaces/:id/notify` | Canvas notifications stop |
| `consolidation.py` | `GET /workspaces/:id/memories` | Memory consolidation stops |
| `consolidation.py` | `POST /workspaces/:id/memories` | Consolidated memory never written |
| `consolidation.py` | `DELETE /workspaces/:id/memories/:id` | Original memories never cleaned up |
| `consolidation.py` | `POST /workspaces/:id/memories` (fallback) | Fallback consolidation stops |
| `a2a_client.py` | `GET /workspaces/:id` (`get_workspace_info`) | Workspace info unavailable |

## Fix

Apply `headers=auth_headers()` to every affected call — the same pattern already used for `POST /registry/heartbeat` (line 97 of heartbeat.py). The `auth_headers()` function from `platform_auth` returns `{"Authorization": "Bearer <token>"}` when a token is available, or `{}` when not (legacy/bootstrap workspaces pass through unchanged).

**heartbeat.py:** Moved `from platform_auth import auth_headers` from inline-per-call to module-level import so `_check_delegations()` can use it. Applied to all 5 unauthenticated `/workspaces/*` calls.

**consolidation.py:** Added `from platform_auth import auth_headers` import. Applied to all 4 memory CRUD calls.

**a2a_client.py:** Added `from platform_auth import auth_headers` import. Applied to `get_workspace_info()`.

## Test compatibility

`auth_headers()` returns `{}` when no token file exists (the test environment). Passing `headers={}` to httpx is identical to passing no headers — all existing `AsyncMock`-based tests pass unchanged, no assertions about header values are affected.

## Checklist

- [x] All 10 affected call sites patched
- [x] Python syntax validated (`ast.parse` — all 3 files clean)
- [x] Existing tests unaffected (auth_headers() → {} in test env, mocks don't check headers)
- [x] Uses established `platform_auth.auth_headers()` pattern (no new auth logic)
- [x] Commit message includes deployment warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)