### PR TITLE
fix(workspace): chown /workspace when root-owned bind mount (#13)

### DIFF
--- a/workspace-template/entrypoint.sh
+++ b/workspace-template/entrypoint.sh
@@ -11,10 +11,24 @@
 if [ "$(id -u)" = "0" ]; then
     # Fix /configs recursively (plugins, CLAUDE.md, skills — small directory)
     chown -R agent:agent /configs 2>/dev/null
-    # Fix /workspace top-level only — it may be a bind-mounted host repo with
-    # thousands of files. Recursive chown would take minutes and change the
-    # host filesystem's ownership. The agent only needs to write at the top level.
+    # /workspace handling:
+    #   - Always fix the top-level dir so agent can create files in it.
+    #   - If the contents are root-owned (common on Docker Desktop / Windows
+    #     bind mounts where host uid maps to 0 inside the container), do a
+    #     full recursive chown — otherwise git clone, pip install, and file
+    #     writes under /workspace fail with EACCES (issue #13). On normal
+    #     Linux Docker with matching uids this branch is skipped, so we keep
+    #     the fast startup for the common case.
     chown agent:agent /workspace 2>/dev/null
+    if [ -d /workspace ]; then
+        # Sample the first entry inside /workspace; if it's root-owned assume
+        # the whole tree is a root-owned bind mount and recursively chown.
+        first_entry=$(find /workspace -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)
+        if [ -n "$first_entry" ] && [ "$(stat -c '%u' "$first_entry" 2>/dev/null)" = "0" ]; then
+            echo "[entrypoint] /workspace contents are root-owned — chowning recursively to agent (uid 1000)"
+            chown -R agent:agent /workspace 2>/dev/null
+        fi
+    fi
     # Re-exec this script as the agent user via gosu (clean PID 1 handoff)
     exec gosu agent "$0" "$@"
 fi


### PR DESCRIPTION
Resolves #13 (Part A — chown). Part B (private-repo initial_prompt clone) was already addressed by PR #20.

## Problem
On Docker Desktop (macOS / Windows), host-path bind mounts commonly appear root-owned inside the container because the host uid doesn't map cleanly. Agents run as uid=1000, so git clone, pip install, and file edits under `/workspace/repo/*` fail with EACCES — Hermes Dev Lead saw this today and had to fall back to `/tmp/hermes-work` + emit a patch file.

The previous entrypoint chowned only the `/workspace` top-level, which wasn't enough: contents stayed root-owned.

## Approach
In `workspace-template/entrypoint.sh`, after the existing top-level chown, sample the first entry inside `/workspace`. If it's root-owned, assume the whole tree came in via a root-owned bind mount and do a full `chown -R agent:agent /workspace`. Otherwise skip — on normal Linux Docker with matching uids this stays a no-op, preserving the existing fast-startup path.

The block runs in the existing root branch of the entrypoint, before the `exec gosu agent` handoff to the agent user, so no Dockerfile changes are needed.

## Test plan
- [x] `bash -n workspace-template/entrypoint.sh` passes
- [x] `shellcheck` clean on new lines (pre-existing SC2164 on line 81 is unrelated)
- [ ] Manual: `docker build` + `docker run -v <root-owned-dir>:/workspace` → agent can write to `/workspace/repo/*`
- [ ] CI: platform/canvas/python test suites remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)