### PR TITLE
chore(template): PM system prompt — treat audit summaries as dispatch triggers, not FYIs

### DIFF
--- a/org-templates/molecule-dev/pm/system-prompt.md
+++ b/org-templates/molecule-dev/pm/system-prompt.md
@@ -20,12 +20,38 @@ You are the PM. The user is the CEO. You own execution — turning CEO directive
 5. **Synthesize across teams.** Your value is combining work from multiple teams into a coherent answer. Don't staple reports together — distill the key findings and decisions.
 6. **Use memory.** `commit_memory` after significant decisions. `recall_memory` at conversation start.
 
+## Audit Routing — Incoming Audit Summaries Are Tasks, Not Status Reports
+
+Security Auditor, UIUX Designer, and QA Engineer run hourly/half-daily audit crons that send you a structured deliverable (per the contract in their cron prompts):
+- audit timestamp + SHA range
+- counts by severity (critical / high / medium / low / clean)
+- **list of GitHub issue numbers filed this cycle**
+- top recommendation
+
+**Every such arrival with issue numbers is a dispatch trigger, not FYI.** The moment you receive one:
+
+1. For each issue number in the summary, `gh issue view <N>` to read the full body and category.
+2. Route each issue to the right dev agent by category:
+   - `security(...)`, auth, crypto, SQL/RCE/path-traversal, missing access control → **Backend Engineer**
+   - `ui`, `ux`, theme, a11y, keyboard-nav, WCAG → **Frontend Engineer**
+   - `infra`, Dockerfile, CI, provisioner, secrets, ops, deployment → **DevOps Engineer**
+   - test suite / coverage / flake / regression → **QA Engineer**
+   - mixed / unclear → **Dev Lead** to split further.
+3. Delegate with a specific brief: issue number, proposed fix scope, acceptance criteria (close #N via `Closes #N` in PR, CI green, tests added if applicable, no `main` commits).
+4. Use parallel `delegate_task_async` when issues span multiple categories — don't serialize what can be concurrent.
+5. Track the fan-out. End of cycle, summary back to memory: "audit <X> dispatched N issues, M still in flight, P landed as PRs #…".
+
+**Clean cycles** (audit summary says "clean on SHA X", zero issue numbers) — acknowledge only; no delegation needed.
+
+**A summary with open issue numbers is never informational** — those numbers exist because the auditor decided action is required. Trust their triage.
+
 ## What You Never Do
 
 - Write code, run tests, or do research yourself
 - Forward raw delegation results without reading them
 - Report "done" without confirming QA verified
 - Let a task sit unassigned
+- **Treat an audit summary with open issue numbers as informational** — those exist because action is required
 
 ## Hard-Learned Rules (from real incidents)
 


### PR DESCRIPTION
## Summary
PM's system prompt now explicitly treats audit summaries from Security Auditor / UIUX Designer / QA Engineer as **dispatch triggers**, not informational status updates. Adds an "Audit Routing" section that specifies which dev agent each issue category goes to.

## Motivation — observed orchestration dead-end

Maintenance cron data from 2026-04-14 morning:

| Signal | Value |
|---|---|
| Audit crons still firing | ✅ Security at 14:23 UTC, UIUX at 14:21 UTC (matches `17 * * * *`, `11 * * * *`) |
| PM last received A2A msg | 2026-04-14 14:22 UTC (~7 min ago at time of investigation) |
| **PM last delegated to Dev Lead** | **2026-04-14 05:25 UTC (10+ hours ago)** |
| Dev Lead active_tasks | 0 for 17+ consecutive maintenance cycles |
| BE/FE/DevOps/QA active_tasks | 0 across the same window |
| GitHub PRs still opening | ✅ #47, #48 closing my platform issues — but authored by audits directly via `GITHUB_TOKEN`, not via Dev Lead |

So: the audit → PM chain worked. The PM → Dev Lead → sub-team chain was dead. Audits went around PM because PM wasn't acting on what they sent.

Reading PM's prompt, the delegation rules were written for "when the CEO gives a task" — audit summaries didn't match that pattern, so PM `commit_memory`'d them and stopped. Meanwhile the audit agents (who have `GITHUB_TOKEN` from the global secret) just opened their own PRs to keep throughput up.

## Change
Insert new "Audit Routing" section before "What You Never Do" in `org-templates/molecule-dev/pm/system-prompt.md`:

- Treat every audit summary with open issue numbers as a dispatch trigger.
- Route by category — security → BE, ui/ux → FE, infra → DevOps, qa → QA, mixed → Dev Lead.
- Parallel `delegate_task_async` for multi-category issues.
- Clean cycles (zero issue numbers) — acknowledge only.
- End-of-cycle memory write summarising fan-out and landed PRs.

Also adds one bullet to "What You Never Do": *"Treat an audit summary with open issue numbers as informational."*

## Why this matches the north-star goal
CEO 2026-04-14: "the goal is to keep our team running 24/7 and keep improving". 17 consecutive cycles of full-team idleness despite live findings is the opposite of that. This turns PM from a receptionist into a dispatcher so the audit output reaches the developers who can act on it.

## Related
- **#26** (merged) — audit cron routing contract that made audits send summaries to PM. This PR is the receiver-side follow-up.
- **Ecosystem-watch paused** — CEO directive to focus self-improvement; this PR is in that swim lane.

## Test plan
- [x] YAML/markdown compile — system prompt is plain markdown, no parse step required.
- [ ] Next hourly audit cycle after merge + re-deploy: PM's delegations endpoint shows new dispatches to BE/FE/DevOps.
- [ ] Maintenance cron: agents transition from idle → busy on audit arrival.
- [ ] Some audit PRs now come through Dev Lead instead of audit-direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)