### PR TITLE
chore(template): bake working Chromium recipe into UIUX Designer cron (closes #23)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -392,20 +392,29 @@ workspaces:
               - name: Hourly UI/UX audit with live screenshots
                 cron_expr: "11 * * * *"
                 prompt: |
-                  Hourly UX audit of the live Molecule AI canvas. Prefer real screenshots;
-                  if the container sandbox prevents Chromium (see #23), fall back to HTML
-                  analysis and note the limitation in the deliverable.
+                  Hourly UX audit of the live Molecule AI canvas. Take real screenshots
+                  and analyse actual user flows. The runtime discovered a working Chromium
+                  path that bypasses the missing-libglib issue; use it rather than the
+                  bundled `playwright install --with-deps` path (which fails in our sandbox).
 
-                  1. SETUP PLAYWRIGHT (best-effort — continue on failure):
-                     pip install -q playwright 2>/dev/null || true
-                     playwright install chromium --with-deps 2>/dev/null || \
-                     playwright install chromium 2>/dev/null || true
+                  1. SETUP BROWSER (proven-working recipe from Run 6, 2026-04-14):
+                     # Install @sparticuz/chromium + puppeteer-core via npm if not present
+                     # and reuse the NSS/NSPR libs bundled with Playwright's Firefox binary.
+                     cd /tmp && [ -d uiux-browser ] || (mkdir uiux-browser && cd uiux-browser && \
+                       npm init -y >/dev/null && npm install --quiet @sparticuz/chromium puppeteer-core 2>&1 | tail -3)
+                     # Ensure Playwright's firefox is present (ships libnss3.so, libnspr4.so)
+                     npx playwright install firefox 2>/dev/null || true
+                     FIREFOX_LIBS=$(ls -d /home/agent/.cache/ms-playwright/firefox-*/firefox 2>/dev/null | head -1)
+                     [ -z "$FIREFOX_LIBS" ] && FIREFOX_LIBS=$(ls -d /root/.cache/ms-playwright/firefox-*/firefox 2>/dev/null | head -1)
 
-                  2. ATTEMPT SCREENSHOTS:
-                     Write a small playwright script to http://host.docker.internal:3000
-                     capturing: home / empty state, create-workspace modal, full canvas,
-                     viewport at 1280px. If library deps are missing, skip to step 3 and
-                     note "screenshots unavailable" in the PM report.
+                  2. TAKE SCREENSHOTS against http://host.docker.internal:3000:
+                     Write a small puppeteer script capturing: home/empty state, create-workspace
+                     modal, full canvas, help dropdown, settings panel (open + detail), template
+                     palette, mobile 375px, responsive 1280px. Save to /tmp/ux-screenshots/.
+                     Invoke with:
+                        LD_LIBRARY_PATH="$FIREFOX_LIBS" node /tmp/uiux-browser/capture.cjs
+                     Then Read each PNG in /tmp/ux-screenshots/ to analyse with vision.
+                     If the browser still won't launch, fall back to curl+HTML and note it.
 
                   3. HTML / CSS ANALYSIS (always runs):
                      - curl http://host.docker.internal:3000 — verify build ID / HTML size


### PR DESCRIPTION
## Summary
Replaces UIUX Designer's 'best-effort Playwright install + fall back to HTML' cron step with the specific command path the agent discovered at runtime and used to successfully capture 14 screenshots in Run 6.

## Background
Filed #23 yesterday: Playwright screenshots failed in the UIUX Designer container because `libglib-2.0`/`libnss3`/`libxkbcommon` weren't in the image. The workspace falls back to HTML-only analysis, which misses dynamic DOM, visual regressions, and a11y contrast checks.

Rather than wait for an image rebuild, the agent itself derived a workaround:
```bash
LD_LIBRARY_PATH="/home/agent/.cache/ms-playwright/firefox-1509/firefox" node script.cjs
```
…using `@sparticuz/chromium` + `puppeteer-core` against the NSS/NSPR libs that ship with Playwright's Firefox binary.

## Evidence it works
From UIUX Designer Run 6 memory (verified in `GET /workspaces/<uiux>/memories`):
- 14 screenshots captured across the canvas, modals, settings, help, template palette, mobile 375px, responsive 1280px
- Vision-analysed to find 2 new criticals only visible in live DOM:
  - **C4**: onboarding-guide has 3 unlabeled buttons + 2.1:1 contrast "Skip guide" text (WCAG FAIL)
  - **C5**: settings panel `Failed to fetch` error state ships a white pill-shaped Refresh button on dark zinc-950 (theme violation confirmed in production)
- Known issues visually confirmed (welcome card contrast, low-contrast hints)
- Mobile toolbar @ 375px measured as 268px wide, no overflow — passes

## Changes
One edit to `org-templates/molecule-dev/org.yaml` — UIUX Designer's `Hourly UI/UX audit` cron prompt:

- Step 1 rewritten as 'SETUP BROWSER (proven-working recipe from Run 6)' — installs `@sparticuz/chromium` + `puppeteer-core`, ensures Playwright Firefox is present for its bundled NSS libs, resolves `$FIREFOX_LIBS` path for either `/home/agent/.cache` or `/root/.cache`.
- Step 2 'ATTEMPT SCREENSHOTS' → 'TAKE SCREENSHOTS' with the concrete `LD_LIBRARY_PATH=... node ...` invocation and a full flow list (home / create / help / settings+detail / templates / mobile / 1280px).
- Fallback to curl+HTML only retained as a last resort, no longer the default path.

## Why template-level (and what the platform-level fix would look like)
Per CEO's 2026-04-14 guidance on preferring platform-level fixes: the general solution is to bake `libglib2.0-0 libnss3 libxkbcommon0` etc. into `workspace-template/Dockerfile` so no template needs this kind of recipe. Tracked as a TODO under the broader platform-side work; out of scope for this PR because:
- Image rebuild has a longer lead time and affects every runtime image
- The runtime workaround already works
- Baking the recipe into the template means even without an image change, future clones inherit day-one screenshot capability

When the platform-level image fix lands, this recipe becomes a no-op (Playwright's normal install path will work) and can be simplified back to `pip install playwright && playwright install chromium`.

## Closes
- #23 — Playwright libs symptom resolved (agent workaround + recipe baked in)

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('org-templates/molecule-dev/org.yaml'))"` — YAML valid.
- [x] Recipe already verified working in production — UIUX Designer Run 6 captured 14 screenshots using this exact command path.
- [ ] After merge + re-import / live-sync: next UIUX cron cycle takes screenshots directly via this recipe on first attempt (no rediscovery needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)