### PR TITLE
docs: sync documentation with 2026-04-14 tick-2 merges (#50, #52)

### DIFF
--- a/docs/edit-history/2026-04-14.md
+++ b/docs/edit-history/2026-04-14.md
@@ -1,0 +1,44 @@
+# 2026-04-14 — edit history
+
+## Summary — tick-2: org-template polish (PRs #50, #52)
+
+Two template-only merges landed this tick. Both touch
+`org-templates/molecule-dev/org.yaml` and adjust role behavior inside the
+default `molecule-dev` org template — no Go/TS/Python code changed, no
+new env vars, no new API routes, no test-count drift.
+
+### Template tweaks
+- **PR #50 `chore(template): PM system prompt — treat audit summaries as
+  dispatch triggers, not FYIs`** — rewrites the PM (Project Manager)
+  role's system prompt so that inbound audit summaries from QA / review
+  loops are treated as actionable dispatch triggers rather than
+  informational FYIs. The PM now routes the summary to the appropriate
+  sub-team instead of acknowledging and stopping. File:
+  `org-templates/molecule-dev/org.yaml` (PM role `system_prompt`).
+  Merged commit `14fc30f`.
+- **PR #52 `chore(template): bake working Chromium recipe into UIUX
+  Designer cron (closes #23)`** — updates the UIUX Designer role's cron
+  setup to install `playwright-chromium` via the known-good recipe so
+  the scheduled UX-audit job can actually launch a headless browser.
+  Closes issue #23 (cron failed on missing Chromium). File:
+  `org-templates/molecule-dev/org.yaml` (UIUX Designer role cron /
+  setup commands). Merged commit `347faab`.
+
+### Not touched
+- No platform (`platform/`) change — no API route, handler, migration,
+  or env var added.
+- No canvas (`canvas/`) change.
+- No workspace-template (`workspace-template/`) change — the runtime
+  image already ships the base Playwright deps; this PR only fixes the
+  install invocation inside the cron script that the UIUX Designer
+  workspace runs at startup.
+- No MCP server / SDK change.
+- Test counts unchanged from the prior tick (Go 487, Vitest 357,
+  pytest platform 1078, pytest sdk 87, MCP jest per prior tick).
+  Template-only edits cannot shift these; skipped re-measurement.
+
+### Doc surface
+- This file created.
+- `CLAUDE.md` — no change (no new endpoint / env / runtime).
+- `PLAN.md` — no change (no phase boundary crossed).
+- `README.md` / `README.zh-CN.md` — no change (no user-visible surface).


### PR DESCRIPTION
## Summary

Sync docs for the second 2026-04-14 cron tick. Both merges are
template-only edits to `org-templates/molecule-dev/org.yaml` with no
code, env, API, or runtime impact.

- #50 — https://github.com/Molecule-AI/molecule-monorepo/pull/50
  `chore(template): PM system prompt — treat audit summaries as dispatch triggers, not FYIs`
- #52 — https://github.com/Molecule-AI/molecule-monorepo/pull/52
  `chore(template): bake working Chromium recipe into UIUX Designer cron (closes #23)`

## Files touched

- `docs/edit-history/2026-04-14.md` (created)

No other docs changed:
- `CLAUDE.md` — no new endpoint / env / runtime
- `PLAN.md` — no phase boundary crossed
- `README.md` / `README.zh-CN.md` — no user-visible surface

## Test counts

Unchanged from prior tick (template-only edits cannot shift test
counts; skipped re-measurement).

## Test plan

- [ ] Next cron tick's 7-gate verification runs against this branch
- [ ] DO NOT merge manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)