### PR TITLE
fix(hermes): align config.yaml required_env with executor (HERMES_API_KEY)

### DIFF
--- a/workspace-configs-templates/hermes/config.yaml
+++ b/workspace-configs-templates/hermes/config.yaml
@@ -15,10 +15,11 @@ runtime_config:
   model: nous-hermes-3-70b
 
   # Authentication — supply ONE of these env vars (checked in order):
-  #   NOUS_API_KEY       — Nous Research portal (https://portal.nousresearch.com)
-  #   OPENROUTER_API_KEY — OpenRouter as a Nous proxy (useful for dev / cost control)
+  #   HERMES_API_KEY     — Nous Research portal key (https://portal.nousresearch.com)
+  #   OPENROUTER_API_KEY — OpenRouter as a Hermes proxy (useful for dev / cost control)
+  # Both are checked by adapters/hermes/executor.py; at least one must be set.
   required_env:
-    - NOUS_API_KEY
+    - HERMES_API_KEY
 
   # 0 = no timeout; increase for long-running research tasks.
   timeout: 0


### PR DESCRIPTION
Config template's \`required_env: NOUS_API_KEY\` didn't match the executor's actual check (\`HERMES_API_KEY\` / \`OPENROUTER_API_KEY\` from PR #49). A workspace created from this template would fail provisioning or executor init despite HERMES_API_KEY being correctly set as a global secret.

## Change
\`workspace-configs-templates/hermes/config.yaml\`:
- \`required_env: [NOUS_API_KEY]\` → \`required_env: [HERMES_API_KEY]\`
- Updated comments to reflect the executor's actual env-var fallback order

## Test plan
- [x] Matches env vars read in \`adapters/hermes/executor.py\`
- [x] Matches \`.env.example\` entry added in PR #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)