### PR TITLE
chore(template): wire 9 new guardrail/skill plugins into defaults; PM + Security Auditor get role extras

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -11,15 +11,34 @@ defaults:
   # specifies its own `plugins:` list (which REPLACES defaults — not a union;
   # see platform/internal/handlers/org.go ~L345). So any workspace that
   # needs extras must re-list the defaults plus its additions.
+  # Platform union-semantics tracked in #68; until that lands, we list fully.
   #
-  # - ecc:           "Everything Claude Code" guardrails + coding skills
-  #                  (api-design, coding-standards, deep-research, security-review, tdd-workflow)
-  # - molecule-dev:  Molecule AI codebase conventions, past bugs, review-loop
-  # - superpowers:   systematic-debugging, TDD, planning, verification-before-completion
+  # Coding / guardrail essentials:
+  # - ecc:                            "Everything Claude Code" guardrails + coding skills
+  # - molecule-dev:                   Molecule AI codebase conventions, past bugs, review-loop
+  # - superpowers:                    systematic-debugging, TDD, planning, verification-before-completion
+  #
+  # Safety hooks (PreToolUse/PostToolUse/UserPromptSubmit) — universal:
+  # - molecule-careful-bash:          refuse destructive shell (rm -rf, push --force main, DROP TABLE)
+  # - molecule-prompt-watchdog:       inject warnings on destructive user prompts
+  # - molecule-audit-trail:           append every Edit/Write to .claude/audit.jsonl
+  #
+  # Operational memory — keeps agents consistent across sessions/cron ticks:
+  # - molecule-session-context:       auto-load cron learnings + PR/issue counts on SessionStart
+  # - molecule-skill-cron-learnings:  per-tick learning JSONL format (pairs with session-context)
+  #
+  # Docs hygiene:
+  # - molecule-skill-update-docs:     keep architecture / README / edit-history aligned with code
   plugins:
     - ecc
     - molecule-dev
     - superpowers
+    - molecule-careful-bash
+    - molecule-prompt-watchdog
+    - molecule-audit-trail
+    - molecule-session-context
+    - molecule-skill-cron-learnings
+    - molecule-skill-update-docs
   # workspace_dir: not set by default — each agent gets an isolated Docker volume
   # Set per-workspace to bind-mount a host directory as /workspace
 
@@ -54,6 +73,10 @@ workspaces:
     files_dir: pm
     workspace_dir: ${WORKSPACE_DIR}
     canvas: { x: 400, y: 50 }
+    # PM needs workflow-triage (/triage command for PR triage) and workflow-retro
+    # (/retro for weekly retrospectives) on top of defaults. Re-list full set
+    # (REPLACE semantics today — see #68 for the union-proposal).
+    plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, molecule-workflow-triage, molecule-workflow-retro]
     # Auto-link Telegram so the user can talk to PM directly from Telegram.
     # Bot token + chat ID come from pm/.env (TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID).
     channels:
@@ -84,7 +107,7 @@ workspaces:
         # Research roles extend defaults with browser-automation so they can
         # scrape the live web (product pages, GitHub trending, docs).
         # Per-workspace plugins REPLACE defaults, so re-list the full set.
-        plugins: [ecc, molecule-dev, superpowers, browser-automation]
+        plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, browser-automation]
         initial_prompt: |
           You just started as Research Lead. Set up silently — do NOT contact other agents.
           1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -97,15 +120,15 @@ workspaces:
           - name: Market Analyst
             role: Market sizing, trends, user research
             files_dir: market-analyst
-            plugins: [ecc, molecule-dev, superpowers, browser-automation]
+            plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, browser-automation]
           - name: Technical Researcher
             role: AI frameworks and protocol evaluation
             files_dir: technical-researcher
-            plugins: [ecc, molecule-dev, superpowers, browser-automation]
+            plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, browser-automation]
           - name: Competitive Intelligence
             role: Competitor tracking and feature comparison
             files_dir: competitive-intelligence
-            plugins: [ecc, molecule-dev, superpowers, browser-automation]
+            plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, browser-automation]
 
       - name: Dev Lead
         role: Engineering planning and team coordination
@@ -213,6 +236,13 @@ workspaces:
             tier: 3
             model: opus
             files_dir: security-auditor
+            # Security Auditor adds three security-critical skills on top of defaults:
+            # - molecule-skill-code-review:          multi-criteria review for security-relevant PRs
+            # - molecule-skill-cross-vendor-review:  adversarial second opinion via non-Claude model
+            #                                        (use ONLY for noteworthy PRs — auth, billing, data)
+            # - molecule-skill-llm-judge:            cheap gate that catches "wrong thing shipped"
+            # REPLACE semantics — re-list the full default set. (See #68 for union proposal.)
+            plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, molecule-skill-code-review, molecule-skill-cross-vendor-review, molecule-skill-llm-judge]
             initial_prompt: |
               You just started as Security Auditor. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -376,7 +406,7 @@ workspaces:
             # Add browser-automation for live canvas screenshots via Puppeteer
             # (Chrome CDP path, works around the Playwright / libglib gap tracked in #23).
             # Per-workspace plugins REPLACE defaults — re-list the full set.
-            plugins: [ecc, molecule-dev, superpowers, browser-automation]
+            plugins: [ecc, molecule-dev, superpowers, molecule-careful-bash, molecule-prompt-watchdog, molecule-audit-trail, molecule-session-context, molecule-skill-cron-learnings, molecule-skill-update-docs, browser-automation]
             initial_prompt: |
               You just started as UIUX Designer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
## Summary
Wires the 12 new modular plugins (from PR #63) into the molecule-dev template. Defaults grow from 3 → 9 plugins (universal guardrails + safety hooks + operational memory + docs hygiene). PM gets workflow tools; Security Auditor gets review skills.

## Changes

**`defaults.plugins`** (was 3, now 9):
| Plugin | Purpose |
|---|---|
| `ecc` | Existing — Everything Claude Code coding skills |
| `molecule-dev` | Existing — codebase conventions, past bugs, review-loop |
| `superpowers` | Existing — debugging/TDD/planning/verification |
| `molecule-careful-bash` | NEW — refuse `rm -rf`, `git push --force main`, `DROP TABLE` |
| `molecule-prompt-watchdog` | NEW — warn on destructive user prompts |
| `molecule-audit-trail` | NEW — append every Edit/Write to `.claude/audit.jsonl` |
| `molecule-session-context` | NEW — auto-load cron learnings + PR/issue counts at SessionStart |
| `molecule-skill-cron-learnings` | NEW — per-tick learning JSONL format |
| `molecule-skill-update-docs` | NEW — keep architecture/README/edit-history aligned |

**Per-role overrides:**
- **PM** — defaults + `molecule-workflow-triage` + `molecule-workflow-retro` (PM owns the `/triage` and `/retro` slash-command flows)
- **Security Auditor** — defaults + `molecule-skill-code-review` + `molecule-skill-cross-vendor-review` + `molecule-skill-llm-judge` (multi-criteria + adversarial + judge gate; matches the role's "no critical without linked issue" definition of done)
- **Research Lead + Market Analyst + Technical Researcher + Competitive Intelligence + UIUX Designer** — defaults + `browser-automation` (existing wiring, synced to new default set)

Other 5 dev roles (Dev Lead, BE, FE, DevOps, QA) inherit defaults — code-review skill is available via runtime opt-in if a per-PR need arises.

## Why platform-level fix is also needed

Every per-role override has to re-list the 9 defaults to add 1 plugin. With each new plugin landing in `plugins/`, this gets worse. **Platform-level fix tracked in #68** — proposes union semantics (`plugins: { add: […], remove: […] }`) so future template editors don't duplicate the default set. Once #68 lands, the role overrides in this PR can be simplified to just the additions.

## Notes on plugin scoping rationale

- **Universal hooks** (careful-bash, prompt-watchdog, audit-trail) are safety nets — every agent benefits without any agent being penalised.
- **Operational memory** (session-context, cron-learnings) compounds — every agent that runs across sessions/cron ticks benefits from the persistence.
- **Docs hygiene** (update-docs) — every agent that edits code should be reminded to keep docs aligned.
- **Code review** (`molecule-skill-code-review`) — added only to Security Auditor, since the universal `ecc` plugin already includes a `security-review` skill.
- **Cross-vendor + LLM-judge** — Security Auditor only; expensive skills meant for noteworthy / irreversible PRs (auth, billing, data-deletion).
- **Workflow commands** (`/triage`, `/retro`) — PM only; tied to project-management role.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('org-templates/molecule-dev/org.yaml'))"` → YAML valid
- [x] `defaults.plugins` count = 9 (verified)
- [ ] After merge + live-sync (per the apply-locally rule): every workspace's `/configs/plugins/` contains the full set
- [ ] PM can invoke `/triage` and `/retro` slash commands
- [ ] Security Auditor's hourly audit can invoke `molecule-skill-cross-vendor-review` on critical findings

## Related
- **#63** (merged) — split guardrails into 12 modular plugins. This PR consumes them.
- **#68** (open) — platform-level union semantics for plugins. Will simplify this PR once landed.
- **CEO directive 2026-04-14**: "keep improving with templates, plugins, channels, and watchlist". This PR is the plugins lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)