### PR TITLE
docs: sync documentation with 2026-04-14 tick-5 merges (#69, #70)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -239,6 +239,10 @@ point for "what else is out there."
 - **GitHub issue #15** — Provisioner: auto-refresh `CLAUDE_CODE_OAUTH_TOKEN` from `global_secrets` on workspace restart → **DONE** via PR #64 (`SetGlobal` / `DeleteGlobal` now fan out `RestartByID` to every affected workspace).
 - **GitHub issue #19 Layer 1** — Platform-generated restart context → **DONE** via PR #65 (synthetic A2A `message/send` with `metadata.kind=restart_context`, `system:restart-context` caller prefix, 30s re-register wait). Layer 2 deferred to issue #66 (see Backlog item 15 above).
 
+### Recently launched (2026-04-14 tick-5)
+- **PR #70** — Wired the 12 modular plugins from PR #63 (tick-4) into the default `molecule-dev` org template. `defaults.plugins` expands from 3 → 9 (safety hooks + operational-memory skills become universal); PM role gains `molecule-workflow-triage` + `molecule-workflow-retro`, Security Auditor gains `molecule-skill-code-review` + `molecule-skill-cross-vendor-review` + `molecule-skill-llm-judge`. Verbose per-role re-listing is a consequence of REPLACE (not UNION) semantics in `platform/internal/handlers/org.go`; union-semantics proposal tracked as issue **#68**.
+- **PR #69** — Backlog items 11–14 stripped of stale sequential refs `#64`–`#67` (see footnote near item 15 above).
+
 ---
 
 ## Test Coverage

--- a/docs/edit-history/2026-04-14.md
+++ b/docs/edit-history/2026-04-14.md
@@ -249,3 +249,79 @@ main (post-merge of all three PRs):
   is an implementation detail, and the restart-context message is an
   agent-facing system message).
 
+## Summary — tick-5: PLAN.md backlog cleanup + wire tick-4 plugins into default org template (PRs #69, #70)
+
+Two docs / template-only merges. Neither touches Go/TS/Python code,
+adds env vars, moves API routes, or shifts test counts.
+
+### PR #69 — `docs(plan): drop stale sequential refs from Backlog items 11-14`
+Merge commit `2c89e24` (squash `730bcc4`). `PLAN.md` only. Backlog
+items 11–14 previously carried placeholder sequential refs
+`#64`–`#67` that were introduced before GitHub issues/PRs with the
+same numbers merged with different scopes (PR #64 is the global-
+secrets auto-restart; PR #65 is the restart-context injector; #66
+is the new restart_prompt follow-up; #67 was tick-4's docs-sync
+PR). Leaving the stale refs in place was actively misleading
+readers cross-referencing against `gh pr list` / `gh issue list`.
+The cleanup strips the `#64`–`#67` annotations from the four
+bullets and adds a single footnote explaining the history and
+directing future prioritization to file real GitHub issues. No
+backlog item was removed; wording of items 11–14 is otherwise
+intact.
+
+### PR #70 — `chore(template): wire 9 new guardrail/skill plugins into defaults; PM + Security Auditor get role extras`
+Merge commit `e6d8cdf` (squash `def76e7`). `org-templates/molecule-dev/org.yaml`
+only. Activates the 12 modular plugins that PR #63 (tick-4) landed
+in the repo-level registry by wiring them into the default
+`molecule-dev` org template. Before this PR the plugins existed on
+disk under `plugins/molecule-*` but no org actually opted in, so
+newly-imported workspaces still only shipped the original three
+(`ecc` / `molecule-dev` / `superpowers`).
+
+- **Defaults expanded (was 3, now 9)** — universal additions:
+  `molecule-careful-bash`, `molecule-prompt-watchdog`,
+  `molecule-audit-trail`, `molecule-session-context`,
+  `molecule-skill-cron-learnings`, `molecule-skill-update-docs`
+  (plus the original three, retained).
+- **Per-role overrides**:
+  - PM: defaults + `molecule-workflow-triage` + `molecule-workflow-retro`
+    (slash commands matching PM's coordination role).
+  - Security Auditor: defaults + `molecule-skill-code-review` +
+    `molecule-skill-cross-vendor-review` + `molecule-skill-llm-judge`
+    (multi-criteria review + adversarial cross-vendor second opinion
+    + LLM-judge gate for "wrong thing shipped").
+  - Research Lead + 3 researchers + UIUX Designer: defaults +
+    `browser-automation` (existing override, resynced to new default set).
+  - Other 5 dev roles (Dev Lead, BE, FE, DevOps, QA) inherit the new
+    defaults unchanged.
+- **REPLACE-semantics caveat** — `platform/internal/handlers/org.go`
+  (~L345) treats per-workspace `plugins:` as REPLACE, not UNION, so
+  every role override has to re-list all 9 defaults to add one extra.
+  GitHub issue **#68** tracks the union-semantics proposal; once it
+  lands the per-role lists can shrink to just the deltas. No
+  platform change in this PR.
+- No new tests; plugin install is exercised by the existing
+  plugin-install integration tests.
+
+### Not touched
+- No platform (`platform/`) change — no route, handler, migration,
+  or env var moved.
+- No canvas / workspace-template / SDK / MCP change.
+- No new plugins — PR #70 only wires the existing PR #63 plugins
+  into the default template.
+
+### Test counts this tick
+Unchanged from tick-4 (neither PR added tests). Per the prior-tick
+baseline: Go 726, Canvas (Vitest) 357, MCP 97, SDK 132, workspace
+1140. Skipped re-measurement — docs/template-only diff cannot move
+these.
+
+### Doc surface touched this tick
+- `docs/edit-history/2026-04-14.md` — this tick-5 section appended.
+- `CLAUDE.md` — no change (no code-facing surface moved).
+- `PLAN.md` — PR #69 is itself the PLAN.md cleanup. Added a one-
+  line entry under "Recently launched" noting PR #70 wired the
+  tick-4 (PR #63) modular plugins into the default org template.
+- `.env.example` — no change.
+- `README.md` / `README.zh-CN.md` — no change.
+


### PR DESCRIPTION
## Summary
- Append tick-5 section to `docs/edit-history/2026-04-14.md` covering PR #69 (PLAN.md backlog stale-ref cleanup) and PR #70 (wire 12 modular plugins from PR #63 into the default `molecule-dev` org template — defaults expand 3 → 9, PM + Security Auditor get role extras).
- Add two entries under PLAN.md "Recently launched (2026-04-14 tick-5)" noting both merges.
- Both merges are docs/template-only. No code surface moved, no new env vars, no test-count drift. CLAUDE.md, .env.example, README.md, README.zh-CN.md unchanged.

## Test plan
- [x] Verified neither PR #69 nor PR #70 added tests (docs + org.yaml only)
- [x] Test counts carried forward from tick-4 (Go 726, Canvas 357, MCP 97, SDK 132, workspace 1140) — no re-measurement needed

Generated with [Claude Code](https://claude.com/claude-code)