### PR TITLE
docs: sync documentation with 2026-04-14 tick-6 merges (#71, #72)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,8 @@ Shared plugins in `plugins/` are auto-loaded by every workspace:
 
 These are distilled from the harness-level guardrails the orchestrator uses on itself. A workspace can install one (e.g., just `molecule-careful-bash` for safety) or stack the full set for the same posture as the Molecule AI orchestrator.
 
+**Org-template plugin resolution (PR #71, issue #68):** per-workspace `plugins:` lists in `org-templates/*/org.yaml` role overrides **UNION** with `defaults.plugins` (deduplicated, defaults first) — they do **not** REPLACE them. To opt a specific default out for a given role/workspace, prefix the plugin name with `!` or `-` (e.g. `!browser-automation`). Implemented by `mergePlugins` in `platform/internal/handlers/org.go`.
+
 ### Scripts
 ```bash
 bash scripts/setup-default-org.sh              # Create PM + 3 teams (Marketing/Research/Dev) via API
@@ -214,7 +216,7 @@ OPENAI_API_KEY=... bash scripts/test-team-e2e.sh           # E2E: Multi-template
 
 ### Unit Tests
 ```bash
-cd platform && go test -race ./...               # 726 Go tests (handlers, registry, provisioner, CLI, delegation, org, channels, wsauth — sqlmock + miniredis; +2 on 2026-04-14 tick-4 for TestSetGlobal_* / TestDeleteGlobal_* auto-restart branches (#64); +4 on 2026-04-14 tick-4 for TestRestartContext_* covering the synthetic restart-context A2A message (#65); raw PASS-line count is higher due to table-driven subtests)
+cd platform && go test -race ./...               # 731 Go tests (handlers, registry, provisioner, CLI, delegation, org, channels, wsauth — sqlmock + miniredis; +2 on 2026-04-14 tick-4 for TestSetGlobal_* / TestDeleteGlobal_* auto-restart branches (#64); +4 on 2026-04-14 tick-4 for TestRestartContext_* covering the synthetic restart-context A2A message (#65); +5 on 2026-04-14 tick-6 for TestPlugins_* covering the new UNION + `!`/`-` opt-out semantics in org.go mergePlugins (#71, resolves issue #68); raw PASS-line count is higher due to table-driven subtests)
 cd canvas && npm test                            # 357 Vitest tests (store, components, hydration, buildTree, secrets API, org template import, ConfirmDialog singleButton + 7 native-dialog replacements)
 cd workspace-template && python -m pytest -v     # 1140 pytest tests (adds platform_auth token store for Phase 30.1, memory_write activity logging)
 cd sdk/python && python -m pytest -v              # 132 SDK tests (agentskills.io spec validator, CLI, AgentskillsAdaptor round-trip, workspace/org/channel validators, RemoteAgentClient Phase 30 flows)

--- a/PLAN.md
+++ b/PLAN.md
@@ -239,6 +239,9 @@ point for "what else is out there."
 - **GitHub issue #15** — Provisioner: auto-refresh `CLAUDE_CODE_OAUTH_TOKEN` from `global_secrets` on workspace restart → **DONE** via PR #64 (`SetGlobal` / `DeleteGlobal` now fan out `RestartByID` to every affected workspace).
 - **GitHub issue #19 Layer 1** — Platform-generated restart context → **DONE** via PR #65 (synthetic A2A `message/send` with `metadata.kind=restart_context`, `system:restart-context` caller prefix, 30s re-register wait). Layer 2 deferred to issue #66 (see Backlog item 15 above).
 
+### Recently launched (2026-04-14 tick-6)
+- **GitHub issue #68** — Per-workspace `plugins:` REPLACE semantics caveat → **DONE** via PR #71 (`mergePlugins` helper in `platform/internal/handlers/org.go` now UNIONs per-workspace with `defaults.plugins`; `!plugin` or `-plugin` prefix on a per-workspace entry opts a default out; +5 `TestPlugins_*` tests). Role overrides in `org-templates/*/org.yaml` can now declare just the delta instead of restating every default.
+
 ### Recently launched (2026-04-14 tick-5)
 - **PR #70** — Wired the 12 modular plugins from PR #63 (tick-4) into the default `molecule-dev` org template. `defaults.plugins` expands from 3 → 9 (safety hooks + operational-memory skills become universal); PM role gains `molecule-workflow-triage` + `molecule-workflow-retro`, Security Auditor gains `molecule-skill-code-review` + `molecule-skill-cross-vendor-review` + `molecule-skill-llm-judge`. Verbose per-role re-listing is a consequence of REPLACE (not UNION) semantics in `platform/internal/handlers/org.go`; union-semantics proposal tracked as issue **#68**.
 - **PR #69** — Backlog items 11–14 stripped of stale sequential refs `#64`–`#67` (see footnote near item 15 above).

--- a/docs/edit-history/2026-04-14.md
+++ b/docs/edit-history/2026-04-14.md
@@ -325,3 +325,67 @@ these.
 - `.env.example` — no change.
 - `README.md` / `README.zh-CN.md` — no change.
 
+## Summary — tick-6: per-workspace plugins UNION semantics + prior doc-sync (PRs #71, #72)
+
+Two merges this tick. One resolves the REPLACE-semantics caveat called
+out in tick-5 (GitHub issue #68) by flipping per-workspace `plugins:`
+handling in `org.go` from REPLACE to UNION, with a `!`/`-` opt-out
+prefix for removing a default on a per-workspace basis. The other is
+the tick-5 docs-sync PR.
+
+### PR #71 — `fix(org): per-workspace plugins UNION with defaults; '!' prefix opts out (#68)`
+Merge commit `26622dc` (squash `d9603a7`). Resolves GitHub issue #68.
+Before this PR, `org.go` (~L345) treated a per-workspace `plugins:`
+list as a REPLACE of `defaults.plugins`, so every role override in the
+default `molecule-dev` org template had to re-list all 9 defaults to
+add one extra (e.g. Security Auditor had to restate 9 defaults to add
+3 review skills). With this fix the two lists UNION, so role-level
+entries only need to declare the delta.
+
+- **New helper** — `mergePlugins(defaultPlugins, wsPlugins)` in
+  `platform/internal/handlers/org.go` (~L645). Returns the union of
+  the two lists (deduplicated, defaults first). A per-workspace entry
+  starting with `!` or `-` opts the named plugin OUT of the union
+  (e.g. `!browser-automation` removes `browser-automation` from a
+  workspace that would otherwise inherit it from `defaults.plugins`).
+- **Wiring** — the `Plugins` field resolution at ~L344 is now
+  `plugins := mergePlugins(defaults.Plugins, ws.Plugins)` instead of
+  the prior "if ws.Plugins != nil then ws.Plugins else defaults.Plugins"
+  branch.
+- **Tests** — 5 new `TestPlugins_*` tests in
+  `platform/internal/handlers/org_test.go` covering: empty+empty,
+  defaults-only, workspace-adds, opt-out-with-`!`, opt-out-with-`-`,
+  and dedup of a plugin listed in both sides. Measured Go raw PASS
+  count is now **731** (was 726 at tick-5 baseline); delta is +5,
+  matching the new test functions.
+- **Template ripple** — `org-templates/molecule-dev/org.yaml` role
+  overrides can now shrink to just the deltas, but this PR does NOT
+  touch the template (backward compatible: re-listing defaults still
+  yields the same resolved set after UNION + dedup). Template
+  cleanup is a follow-up.
+
+### PR #72 — `docs: sync documentation with 2026-04-14 tick-5 merges (#69, #70)`
+Merge commit `3cc4e23` (squash `39bd59b`). Docs-only. Created the
+tick-5 section of this file (see above). Nothing to re-sync here.
+
+### Measured test counts this tick
+- **Go**: `go test -v ./... | grep -c "^--- PASS"` → **731** (was 726
+  at tick-5 baseline; +5 from PR #71's `TestPlugins_*` quintet). This
+  matches exactly.
+- **Canvas (Vitest)**: unchanged — no canvas change. Still 357.
+- **Workspace-template (pytest)**: unchanged — no workspace-template
+  change. Still 1140.
+- **SDK (pytest)**: unchanged. Still 132.
+- **MCP (jest)**: unchanged. Still 97.
+
+### Doc surface touched this tick
+- `docs/edit-history/2026-04-14.md` — this tick-6 section appended.
+- `CLAUDE.md` — Go test count bumped 726 → 731; Plugins / Org
+  Templates note updated from the prior REPLACE-semantics caveat to
+  the new UNION + `!`/`-` opt-out semantics.
+- `PLAN.md` — added a "Recently launched (2026-04-14 tick-6)" entry
+  for PR #71 noting GitHub issue #68 is now resolved.
+- `.env.example` — no change.
+- `README.md` / `README.zh-CN.md` — no change (semantics are internal
+  to org-template resolution).
+


### PR DESCRIPTION
## Summary
- Append tick-6 section to `docs/edit-history/2026-04-14.md` covering PR #71 (per-workspace plugins UNION with defaults, `!`/`-` opt-out prefix; resolves issue #68) and PR #72 (tick-5 docs-sync).
- `CLAUDE.md`: Go test count 726 -> 731 (+5 new `TestPlugins_*` tests); add Plugins section note documenting the new UNION + `!`/`-` opt-out semantics in `mergePlugins`.
- `PLAN.md`: add "Recently launched (2026-04-14 tick-6)" entry noting GitHub issue #68 is now resolved by PR #71.

## Test plan
- [x] Measured Go test count: `go test -v ./... | grep -c "^--- PASS"` -> 731 (was 726 at tick-5 baseline; delta +5, matches the 5 new `TestPlugins_*` functions).
- [x] Canvas / workspace-template / SDK / MCP test counts unchanged (no code change in those stacks this tick).
- [x] `.env.example` unchanged (no env-var additions in #71 / #72).
- [x] `README.md` / `README.zh-CN.md` unchanged (no user-visible surface moved).

Generated with Claude Code.