### PR TITLE
docs: sync documentation with 2026-04-15 tick-9 merges (#79, #80)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -239,6 +239,9 @@ point for "what else is out there."
 - **GitHub issue #15** — Provisioner: auto-refresh `CLAUDE_CODE_OAUTH_TOKEN` from `global_secrets` on workspace restart → **DONE** via PR #64 (`SetGlobal` / `DeleteGlobal` now fan out `RestartByID` to every affected workspace).
 - **GitHub issue #19 Layer 1** — Platform-generated restart context → **DONE** via PR #65 (synthetic A2A `message/send` with `metadata.kind=restart_context`, `system:restart-context` caller prefix, 30s re-register wait). Layer 2 deferred to issue #66 (see Backlog item 15 above).
 
+### Recently launched (2026-04-15 tick-9)
+- **Phase 32 Phase B.2 (image pipeline)** — PR #80 (merged `c3cc8e87`) adds `.github/workflows/publish-platform-image.yml`: on every main-merge touching `platform/**`, builds `platform/Dockerfile` and pushes `ghcr.io/molecule-ai/platform:latest` + `:sha-<commit>` to GHCR. Paired with the private `molecule-controlplane` Fly + Neon provisioner (PR #3 there, merged `2e85d5ad`) that reads `TENANT_IMAGE` env and boots tenant Fly Machines from this image. Tick-8 docs-sync PR #79 (merged `d53a1287`) also landed.
+
 ### Recently launched (2026-04-14 tick-8)
 - **Phase 32 PR #1** — `TenantGuard` middleware (PR #78, merged `57a05686`). Public repo's only SaaS hook: when `MOLECULE_ORG_ID` env is set, non-allowlisted requests require matching `X-Molecule-Org-Id` header or 404. Unset → passthrough (self-hosted unchanged). Allowlist is exact-match: `/health` + `/metrics`. Paired with the private `Molecule-AI/molecule-controlplane` repo scaffolded this tick (Fly Machines provisioner stub, `/cp/orgs` CRUD, subdomain→fly-replay router, migrations 001-003 for `organizations`/`org_instances`/`org_members`). +6 `TestTenantGuard_*` tests. Phase 32 plan: follow-up PRs wire real Fly provisioner, WorkOS AuthKit, Stripe, Cloudflare, signup UX — all in the private repo except the single public middleware.
 

--- a/docs/edit-history/2026-04-15.md
+++ b/docs/edit-history/2026-04-15.md
@@ -1,0 +1,37 @@
+# Edit history — 2026-04-15
+
+## tick-9: Phase 32 Phase B.2 image pipeline (PR #80) + tick-8 docs sync (PR #79)
+
+Two merges:
+
+### PR #79 — `docs: sync documentation with 2026-04-14 tick-8 merge (#78)`
+Merge commit `d53a1287`. Tick-8 docs sync for the TenantGuard middleware.
+Pure docs; CLAUDE.md test count + PLAN.md tick-8 block + edit-history entry.
+
+### PR #80 — `feat(ci): publish-platform-image → ghcr.io/molecule-ai/platform (Phase B.2)`
+Merge commit `c3cc8e87`. Noteworthy: ci-infra.
+
+Adds `.github/workflows/publish-platform-image.yml`:
+- Trigger: push to main touching `platform/**`; also `workflow_dispatch`.
+- Builds `platform/Dockerfile` via `docker/build-push-action@v5`.
+- Pushes two tags per run: `ghcr.io/molecule-ai/platform:latest` (floating)
+  and `:sha-<short-commit>` (immutable, pin-friendly).
+- GHA cache via `cache-from/cache-to: type=gha` for warm rebuilds.
+- Permissions: `contents:read` + `packages:write`; authenticates to GHCR
+  using the built-in `GITHUB_TOKEN`, no extra secrets.
+- OCI labels propagate source URL + commit SHA for provenance.
+
+Purpose: pairs with the private `molecule-controlplane` Fly + Neon
+provisioner (PR #3 there, merged `2e85d5ad`) which reads
+`TENANT_IMAGE=ghcr.io/molecule-ai/platform:<tag>` from env and spawns
+each tenant Fly Machine from this image.
+
+### Deployment state (informational — not in any repo)
+- Fly apps (`molecule-cp`, `molecule-tenant`): **pending CEO** (`flyctl apps create`).
+- Fly billing card: **pending CEO**.
+- First real tenant provision: **blocked** on the two above.
+
+### File deltas (public repo)
+- `.github/workflows/publish-platform-image.yml` — new.
+- `CLAUDE.md` — tick-9 block for the new CI workflow.
+- `PLAN.md` — new "Recently launched (2026-04-15 tick-9)" entry.


### PR DESCRIPTION
Tick-9 docs sync for PRs #79 (docs-sync tick-8) and #80 (GHCR image pipeline, Phase B.2). Noteworthy per standing rule (touches PLAN.md). Test plan: no code changes; PLAN entry + new edit-history doc. 🤖 Generated with [Claude Code](https://claude.com/claude-code)