### PR TITLE
chore(template): add Documentation Specialist as 3rd PM direct report

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -51,6 +51,7 @@ defaults:
     infra: [DevOps Engineer]
     qa: [QA Engineer]
     performance: [Backend Engineer]
+    docs: [Documentation Specialist]
     mixed: [Dev Lead]
 
   # workspace_dir: not set by default — each agent gets an isolated Docker volume
@@ -618,3 +619,139 @@ workspaces:
 
                   d. Save to memory key 'uiux-audit-latest' as a secondary record only.
                 enabled: true
+
+      - name: Documentation Specialist
+        role: >-
+          Owns end-to-end documentation across the Molecule AI surface area:
+          (a) the customer-facing site at https://github.com/Molecule-AI/docs
+          (Fumadocs + Next.js 15, deployed to doc.moleculesai.app), (b) every
+          README inside the platform monorepo, (c) docs/architecture.md and
+          docs/edit-history/, and (d) public API references generated from
+          handler signatures. Watches PRs landing on the platform monorepo
+          and opens corresponding docs PRs whenever a public API changes,
+          a new template/plugin/channel lands, a user-facing concept evolves,
+          or an ecosystem-watch entry needs publishing. Holds the line on
+          terminology consistency — every concept in the codebase has exactly
+          one canonical name in the docs. Definition of done: every public
+          surface has accurate, current, example-rich documentation; every
+          merged PR that touches a public surface has a paired docs PR open
+          within one cron tick; every stub page on the docs site eventually
+          gets backfilled.
+        tier: 3
+        model: opus
+        files_dir: documentation-specialist
+        canvas: { x: 900, y: 250 }
+        # Documentation Specialist needs browser-automation to crawl the live
+        # docs site (visual regressions, broken links, dead anchors) plus
+        # update-docs skill (already in defaults) for cross-repo docs sync.
+        plugins: [browser-automation]
+        initial_prompt: |
+          You just started as Documentation Specialist. Set up silently — do NOT contact other agents.
+          1. Clone BOTH repos:
+             git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
+             git clone https://github.com/Molecule-AI/docs.git /workspace/docs 2>/dev/null || (cd /workspace/docs && git pull)
+          2. Read /workspace/repo/CLAUDE.md — full architecture, what's public-facing
+          3. Read /configs/system-prompt.md
+          4. Read /workspace/docs/README.md and /workspace/docs/content/docs/index.mdx
+          5. Run: cd /workspace/docs && ls content/docs/*.mdx
+             — note which pages are stubs ("Coming soon" marker) vs hand-written
+          6. Run: cd /workspace/repo && git log --oneline -20 -- platform/internal/handlers/ org-templates/ plugins/
+             — note recent public-surface changes
+          7. Use commit_memory to save:
+             - Stubs that need backfilling (docs site)
+             - Recent platform PRs that have NO docs PR yet
+             - Public concepts that lack a canonical naming entry
+          8. Wait for tasks from PM. Your primary surfaces are:
+             - https://github.com/Molecule-AI/docs (customer site, Fumadocs)
+             - /workspace/repo/docs/ (internal architecture / edit-history)
+             - /workspace/repo/README.md and per-package READMEs
+        schedules:
+          - name: Daily docs sync — backfill stubs and pair recent platform PRs
+            cron_expr: "0 9 * * *"
+            prompt: |
+              Daily documentation maintenance. Two parallel objectives:
+              (1) keep the public docs site current with the platform repo,
+              (2) backfill stub pages on the docs site one at a time.
+
+              SETUP:
+                cd /workspace/repo && git pull 2>/dev/null || true
+                cd /workspace/docs && git pull 2>/dev/null || true
+
+              1. PAIR RECENT PLATFORM PRS (last 24h):
+                 cd /workspace/repo
+                 gh pr list --repo Molecule-AI/molecule-monorepo --state merged \
+                   --search "merged:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
+                   --json number,title,files
+                 For each merged PR that touches a public surface
+                 (platform/internal/handlers/, plugins/*, org-templates/*,
+                 docs/architecture.md, README.md, workspace-template/adapters/*):
+                 - Identify which docs page(s) on the public site cover that surface.
+                 - If a docs page exists but is stale → update it with examples
+                   from the PR diff. Open a PR to Molecule-AI/docs with the change.
+                 - If NO docs page exists for the new surface → propose one
+                   (add to content/docs/meta.json + new .mdx file). Open a PR.
+                 - Always close PRs with `Closes platform PR #N` so the link is durable.
+
+              2. BACKFILL ONE STUB PAGE:
+                 cd /workspace/docs
+                 grep -l "Coming soon" content/docs/*.mdx | head -1
+                 Pick the highest-priority stub (one of: org-template, plugins,
+                 channels, schedules, architecture, api-reference, self-hosting,
+                 observability, troubleshooting). Write 300-800 words of
+                 hand-crafted, example-rich content based on:
+                 - The actual code in /workspace/repo/platform/internal/handlers/
+                 - The actual templates in /workspace/repo/org-templates/
+                 - The actual plugin manifests in /workspace/repo/plugins/
+                 Cite file paths so readers can follow the source. Open a PR.
+
+              3. LINK + ANCHOR CHECK:
+                 Use the browser-automation plugin to crawl
+                 https://doc.moleculesai.app (or the local dev server if the
+                 site isn't deployed yet — `cd /workspace/docs && npm install
+                 && npm run build && npm run start`). Report broken links and
+                 missing anchors back to PM.
+
+              4. ROUTING:
+                 delegate_task to PM with audit_summary metadata:
+                 - category: docs
+                 - severity: info
+                 - issues: [list of PR numbers opened to Molecule-AI/docs]
+                 - top_recommendation: one-line summary
+                 If nothing to do today, PM-message a one-line "clean".
+
+              5. MEMORY:
+                 Save key 'docs-sync-latest' with timestamp + list of stub
+                 pages still pending + count of paired PRs this cycle.
+            enabled: true
+          - name: Weekly terminology + freshness audit
+            cron_expr: "0 11 * * 1"
+            prompt: |
+              Weekly audit of documentation freshness and terminology consistency.
+
+              1. STALE PAGE DETECTION:
+                 cd /workspace/docs && for f in content/docs/*.mdx; do
+                   age=$(git log -1 --format='%cr' -- "$f")
+                   echo "$age :: $f"
+                 done | sort -r
+                 Flag any page not touched in 30+ days that covers a
+                 fast-moving surface (handlers, plugins, templates).
+
+              2. TERMINOLOGY CONSISTENCY:
+                 grep -rEi "workspace|agent|cron|schedule|plugin|channel|template" \
+                   content/docs/*.mdx | grep -oE "\b(workspace|workspaces|Agent|agent|cron job|schedule|plugin|channel|template)\b" | \
+                   sort | uniq -c | sort -rn
+                 Each concept should have ONE canonical capitalisation and
+                 plural form. Open a PR fixing inconsistencies.
+
+              3. LINK ROT:
+                 grep -rE "\\[.*\\]\\(http[^)]+\\)" content/docs/*.mdx | \
+                 awk -F'[()]' '{print $2}' | sort -u | \
+                 while read url; do
+                   curl -sIo /dev/null -w "%{http_code} $url\n" "$url"
+                 done | grep -v "^200 "
+                 Report any non-200 to PM.
+
+              4. ROUTING + MEMORY:
+                 Same audit_summary contract as the daily cron.
+                 Save findings to memory key 'docs-weekly-audit'.
+            enabled: true

--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -622,21 +622,29 @@ workspaces:
 
       - name: Documentation Specialist
         role: >-
-          Owns end-to-end documentation across the Molecule AI surface area:
-          (a) the customer-facing site at https://github.com/Molecule-AI/docs
-          (Fumadocs + Next.js 15, deployed to doc.moleculesai.app), (b) every
-          README inside the platform monorepo, (c) docs/architecture.md and
-          docs/edit-history/, and (d) public API references generated from
-          handler signatures. Watches PRs landing on the platform monorepo
-          and opens corresponding docs PRs whenever a public API changes,
-          a new template/plugin/channel lands, a user-facing concept evolves,
-          or an ecosystem-watch entry needs publishing. Holds the line on
-          terminology consistency — every concept in the codebase has exactly
-          one canonical name in the docs. Definition of done: every public
-          surface has accurate, current, example-rich documentation; every
-          merged PR that touches a public surface has a paired docs PR open
-          within one cron tick; every stub page on the docs site eventually
-          gets backfilled.
+          Owns end-to-end documentation across THREE Molecule AI repos:
+          (1) the platform monorepo (public, Molecule-AI/molecule-monorepo) —
+          internal architecture, READMEs, edit-history, public API references;
+          (2) the docs site (public, Molecule-AI/docs) — Fumadocs + Next.js 15,
+          deployed to doc.moleculesai.app, customer-facing;
+          (3) the SaaS controlplane (PRIVATE, Molecule-AI/molecule-controlplane) —
+          Go service that provisions tenants on Fly Machines, with the strict
+          rule that private implementation details NEVER leak into the public
+          docs site. Documents controlplane changes only in its own internal
+          README and the platform monorepo's docs/saas/ section (which itself
+          is gated). Public docs only describe the SaaS PRODUCT (signup, billing,
+          tenant lifecycle, multi-tenant data isolation guarantees) — not the
+          provisioner's internals.
+          Watches PRs landing on all three repos and opens corresponding docs
+          PRs whenever a public API changes, a new template/plugin/channel
+          lands, a user-facing concept evolves, or an ecosystem-watch entry
+          needs publishing. Holds the line on terminology consistency — every
+          concept has exactly one canonical name across all three repos.
+          Definition of done: every public surface has accurate, current,
+          example-rich documentation; every merged PR that touches a public
+          surface has a paired docs PR open within one cron tick; every stub
+          page on the docs site eventually gets backfilled; controlplane
+          internal docs stay current; nothing private leaks to public.
         tier: 3
         model: opus
         files_dir: documentation-specialist
@@ -647,24 +655,41 @@ workspaces:
         plugins: [browser-automation]
         initial_prompt: |
           You just started as Documentation Specialist. Set up silently — do NOT contact other agents.
-          1. Clone BOTH repos:
+
+          ⚠️  PRIVACY RULE (read first, never violate):
+          molecule-controlplane is a PRIVATE repo. Its source code, file paths,
+          internal endpoints, schema details, infra config, billing/auth
+          implementation — none of that goes into the public docs site
+          (Molecule-AI/docs) or the public README in molecule-monorepo. Public
+          docs may describe the SaaS PRODUCT (signup, billing, tenant isolation
+          guarantees) but never the provisioner's internals. When in doubt:
+          don't publish.
+
+          1. Clone all three repos:
              git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
              git clone https://github.com/Molecule-AI/docs.git /workspace/docs 2>/dev/null || (cd /workspace/docs && git pull)
+             git clone https://github.com/Molecule-AI/molecule-controlplane.git /workspace/controlplane 2>/dev/null || (cd /workspace/controlplane && git pull)
           2. Read /workspace/repo/CLAUDE.md — full architecture, what's public-facing
           3. Read /configs/system-prompt.md
           4. Read /workspace/docs/README.md and /workspace/docs/content/docs/index.mdx
-          5. Run: cd /workspace/docs && ls content/docs/*.mdx
+          5. Read /workspace/controlplane/README.md and /workspace/controlplane/PLAN.md
+             — understand what the SaaS provisioner does (private) vs what users see (public)
+          6. Run: cd /workspace/docs && ls content/docs/*.mdx
              — note which pages are stubs ("Coming soon" marker) vs hand-written
-          6. Run: cd /workspace/repo && git log --oneline -20 -- platform/internal/handlers/ org-templates/ plugins/
-             — note recent public-surface changes
-          7. Use commit_memory to save:
+          7. Run: cd /workspace/repo && git log --oneline -20 -- platform/internal/handlers/ org-templates/ plugins/
+             — note recent public-surface changes in the platform repo
+          8. Run: cd /workspace/controlplane && git log --oneline -20
+             — note recent controlplane changes (these need internal docs only)
+          9. Use commit_memory to save:
              - Stubs that need backfilling (docs site)
              - Recent platform PRs that have NO docs PR yet
+             - Recent controlplane PRs whose internal README needs an update
              - Public concepts that lack a canonical naming entry
-          8. Wait for tasks from PM. Your primary surfaces are:
-             - https://github.com/Molecule-AI/docs (customer site, Fumadocs)
-             - /workspace/repo/docs/ (internal architecture / edit-history)
-             - /workspace/repo/README.md and per-package READMEs
+          10. Wait for tasks from PM. Your owned surfaces are:
+             - https://github.com/Molecule-AI/docs (customer site, Fumadocs) — PUBLIC
+             - /workspace/repo/docs/ (internal architecture / edit-history) — PUBLIC
+             - /workspace/repo/README.md and per-package READMEs — PUBLIC
+             - /workspace/controlplane/README.md, PLAN.md, internal docs — PRIVATE
         schedules:
           - name: Daily docs sync — backfill stubs and pair recent platform PRs
             cron_expr: "0 9 * * *"
@@ -676,8 +701,9 @@ workspaces:
               SETUP:
                 cd /workspace/repo && git pull 2>/dev/null || true
                 cd /workspace/docs && git pull 2>/dev/null || true
+                cd /workspace/controlplane && git pull 2>/dev/null || true
 
-              1. PAIR RECENT PLATFORM PRS (last 24h):
+              1a. PAIR RECENT PLATFORM PRS (last 24h):
                  cd /workspace/repo
                  gh pr list --repo Molecule-AI/molecule-monorepo --state merged \
                    --search "merged:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
@@ -691,6 +717,26 @@ workspaces:
                  - If NO docs page exists for the new surface → propose one
                    (add to content/docs/meta.json + new .mdx file). Open a PR.
                  - Always close PRs with `Closes platform PR #N` so the link is durable.
+
+              1b. PAIR RECENT CONTROLPLANE PRS (last 24h):
+                 cd /workspace/controlplane
+                 gh pr list --repo Molecule-AI/molecule-controlplane --state merged \
+                   --search "merged:>$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%SZ)" \
+                   --json number,title,files
+                 ⚠️  PRIVATE REPO. Two cases:
+                 (i) Internal-only change (handler, schema, infra, fly.toml,
+                     billing logic): update README.md + PLAN.md + any
+                     docs/internal/*.md inside molecule-controlplane itself.
+                     Open the PR against Molecule-AI/molecule-controlplane.
+                     NEVER mention these changes in /workspace/docs.
+                 (ii) Customer-facing change (new tier, new region, new SLA,
+                     pricing change, signup flow change): write a sanitized
+                     description for the PUBLIC docs site (e.g. "We now offer
+                     EU-region tenants" — NOT "controlplane reads FLY_REGION
+                     from env and passes it to provisioner.go:142"). Open a
+                     PR against Molecule-AI/docs.
+                 When unsure which category a change falls into: default to
+                 INTERNAL-only and ask PM for explicit approval before publishing.
 
               2. BACKFILL ONE STUB PAGE:
                  cd /workspace/docs


### PR DESCRIPTION
## Summary
Adds a 13th workspace to the molecule-dev template — **Documentation Specialist** — owning end-to-end documentation across all Molecule AI surfaces. Pairs with the new [Molecule-AI/docs](https://github.com/Molecule-AI/docs) repo (Fumadocs + Next.js 15) that will be deployed to **doc.moleculesai.app**.

## Context

CEO directive 2026-04-15: *deploy a document specialist for documenting everything including what's in our repository and in our customer facing page doc.moleculesai.app*.

I just shipped:
1. **[Molecule-AI/docs](https://github.com/Molecule-AI/docs)** — new public repo, scaffolded with **Fumadocs** (open-source MIT, Next.js 15 App Router native, Tailwind v4, MDX). Three hand-written pages (index, quickstart, concepts) + 9 stub pages with the agent's TODO marker.
2. This PR — wires the agent into the molecule-dev template.

### Framework choice rationale
| Framework | Verdict | Why |
|---|---|---|
| **Fumadocs** ✅ chosen | MIT open source; built on Next.js 15 App Router; matches our existing canvas stack; flexible enough to grow into custom doc components for our agent canvas flows; ships search/dark-mode/Shiki out of the box |
| Mintlify | Rejected | Paid SaaS subscription — vendor lock-in conflicts with self-hosting on doc.moleculesai.app |
| Nextra | Rejected | More opinionated than Fumadocs; less room to grow into custom MDX components |
| Docusaurus | Rejected | Not Next.js-native; would split our React build pipeline in two |

## Where it sits in the org
Third PM direct report, parallel to Research Lead and Dev Lead. Docs is its own swim lane that spans engineering (docs follow code) and research/product (concepts and terminology).

```
PM
├── Research Lead
├── Dev Lead
└── Documentation Specialist   ← new (13th workspace)
```

## Schedules added (2)

| Cron | When | Job |
|---|---|---|
| `0 9 * * *` | Daily 09:00 UTC | Pair every merged platform PR (last 24h) with a docs PR; backfill one stub page on the docs site; crawl live site for broken links/dead anchors; delegate_task to PM with `audit_summary{category=docs}` |
| `0 11 * * 1` | Weekly Monday 11:00 UTC | Stale page detection (>30 days untouched on fast-moving surfaces); terminology consistency check (one canonical name per concept); link-rot scan; same audit_summary contract |

Both schedules end with the structured `audit_summary` routing per #75 (`category: docs`) so PM fans out via the platform-level `category_routing`.

## Routing
Adds `docs: [Documentation Specialist]` to `category_routing` in the defaults block. Any agent that emits an audit_summary with category=docs is auto-routed here.

## Plugins
Inherits the 9 universal defaults (#71 union semantics). Adds `browser-automation` for crawling the live docs site (visual regressions, broken links, dead anchors).
- `molecule-skill-update-docs` (already in defaults) handles the cross-repo docs sync skill.
- `molecule-careful-bash`, `molecule-prompt-watchdog`, `molecule-audit-trail` (defaults) provide guardrails on this agent's git operations.

## Initial prompt — clones BOTH repos

The agent's initial_prompt clones both:
- `/workspace/repo` — the platform monorepo (read recent commits, identify public surfaces)
- `/workspace/docs` — Molecule-AI/docs (write-side, where it opens PRs)

This is the first workspace in the template that needs cross-repo access. Tracking as a follow-up: the platform's `workspace_dir` field currently only mounts ONE host directory; we need a way to mount multiple. For now the agent does git clones in the initial_prompt which works but doesn't get bind-mount caching benefits.

## What this PR does NOT do

- It does not create the workspace immediately on the running platform — that needs an `org/import` (currently failing on a pre-existing PM `workspace_dir` env-var issue, orthogonal). I'll sync the new workspace into the running DB manually after merge.
- It does not configure the deployment to doc.moleculesai.app — that's a separate Vercel/DNS step the agent itself can later automate.
- It does not write the actual content for the 9 stub pages — that's the agent's primary job once it boots.

## Test plan
- [x] YAML valid (`python -c "import yaml; yaml.safe_load(open(...))"`).
- [x] Tree-walk shows Documentation Specialist as 3rd PM child.
- [x] Total schedules count = 9 (was 7, added 2).
- [x] `category_routing.docs = [Documentation Specialist]`.
- [ ] After merge + provision: agent boots, clones both repos, opens its first docs sync PR within 24h.
- [ ] First daily cron fires Tuesday 09:00 UTC.
- [ ] First weekly cron fires next Monday 11:00 UTC.

## Related
- **NEW: [Molecule-AI/docs](https://github.com/Molecule-AI/docs)** — the customer-facing site this agent owns
- **#71** — plugin union semantics (this PR uses `plugins: [browser-automation]` add-only form)
- **#75** — `category_routing` + `audit_summary` schema this agent consumes
- **#76** — DB-authoritative schedules (so the new schedules stick on re-import)
- **#87** — evolution crons (this is in the same spirit — adds an evolution lane for docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)