### PR TITLE
chore(template): evolution crons hourly instead of daily/weekly

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -128,8 +128,8 @@ workspaces:
           5. Use commit_memory to save key product facts for later recall
           6. Wait for tasks from PM.
         schedules:
-          - name: Daily ecosystem watch
-            cron_expr: "0 8 * * *"
+          - name: Hourly ecosystem watch
+            cron_expr: "8 * * * *"
             prompt: |
               Daily survey for new agent-infra / AI-agent projects worth tracking.
 
@@ -163,8 +163,8 @@ workspaces:
             files_dir: technical-researcher
             plugins: [browser-automation]
             schedules:
-              - name: Weekly plugin curation
-                cron_expr: "0 9 * * 1"
+              - name: Hourly plugin curation
+                cron_expr: "22 * * * *"
                 prompt: |
                   Weekly survey of `plugins/` and `workspace-template/builtin_tools/` for
                   evolution opportunities. The team should keep gaining capabilities.
@@ -210,8 +210,8 @@ workspaces:
           5. Use commit_memory to save the architecture summary and recent changes
           6. Wait for tasks from PM.
         schedules:
-          - name: Daily template fitness audit
-            cron_expr: "30 8 * * *"
+          - name: Hourly template fitness audit
+            cron_expr: "15 * * * *"
             prompt: |
               Daily audit of `org-templates/molecule-dev/`. Catches drift, stale prompts,
               missing schedules, and gaps that block the team-runs-24/7 goal. Symptom
@@ -327,8 +327,8 @@ workspaces:
               5. Use commit_memory to save CI pipeline structure
               6. Wait for tasks from Dev Lead.
             schedules:
-              - name: Weekly channel expansion survey
-                cron_expr: "0 10 * * 1"
+              - name: Hourly channel expansion survey
+                cron_expr: "47 * * * *"
                 prompt: |
                   Weekly survey of channel integrations (Telegram, Slack, Discord, email,
                   webhooks). The team should grow its external comms surface where useful,


### PR DESCRIPTION
## Summary
CEO 2026-04-15: the team's evolution loops should be **hourly**, not daily/weekly. A 24h or 7d cadence is the wrong rhythm for a team running 24/7. At hourly, every drift / new project / plugin gap / channel opportunity surfaces within an hour.

## Changes

| Schedule | Was | Now |
|---|---|---|
| Hourly ecosystem watch | \`0 8 * * *\` (daily) | \`8 * * * *\` |
| Hourly plugin curation | \`0 9 * * 1\` (Mondays) | \`22 * * * *\` |
| Hourly template fitness audit | \`30 8 * * *\` (daily) | \`15 * * * *\` |
| Hourly channel expansion survey | \`0 10 * * 1\` (Mondays) | \`47 * * * *\` |

## Spread across the hour
\`:08\` ecosystem, \`:11\` UIUX (existing), \`:15\` template fitness, \`:17\` security (existing), \`:22\` plugin curation, \`:47\` channel expansion. No collisions; PM gets one audit_summary at a time instead of buried.

## Live-applied
Per the apply-locally rule, all 4 schedules in the running DB are already updated. First evolution fire: \`Hourly channel expansion\` at **04:47 UTC** (~22 min from now).

A follow-up will sweep the prompt bodies (which still say "Daily survey...") for naming consistency. Schedules fire fine in the meantime.