### PR TITLE
fix(security): close IPv6 SSRF gap in validateAgentURL (C6)

### DIFF
--- a/platform/internal/handlers/registry.go
+++ b/platform/internal/handlers/registry.go
@@ -29,10 +29,19 @@ func NewRegistryHandler(b *events.Broadcaster) *RegistryHandler {
 // cloud metadata services or other internal infrastructure.
 //
 // Allowed: http:// or https:// only (no file://, ftp://, etc.).
-// Blocked: 169.254.0.0/16 (link-local — AWS/GCP/Azure metadata endpoints).
-// Allowed: RFC-1918 private ranges (Docker networking uses 172.16–31.x.x).
+// Blocked:
+//   - 169.254.0.0/16  IPv4 link-local (AWS IMDSv1/v2, GCP, Azure metadata)
+//   - fe80::/10        IPv6 link-local — same threat class as 169.254.x.x
+//   - ::1/128          IPv6 loopback
+//   - fc00::/7         IPv6 ULA (RFC-4193 private ranges)
 //
-// Returns a non-nil error string suitable for including in a 400 response.
+// Allowed: RFC-1918 private ranges — Docker networking uses 172.16–31.x.x.
+// Allowed: 127.0.0.0/8 — Docker loopback addresses.
+// IPv4-mapped IPv6 (e.g. ::ffff:169.254.169.254) is handled automatically:
+// Go's net.ParseIP.To4() normalises those to IPv4 before Contains() runs,
+// so they are caught by the IPv4 rules above without a separate range entry.
+//
+// Returns a non-nil error suitable for inclusion in a 400 response.
 func validateAgentURL(rawURL string) error {
 	if rawURL == "" {
 		return errors.New("url is required")
@@ -46,10 +55,20 @@ func validateAgentURL(rawURL string) error {
 	}
 	hostname := parsed.Hostname()
 	if ip := net.ParseIP(hostname); ip != nil {
-		// Block 169.254.0.0/16 — cloud metadata (AWS IMDSv1/v2, GCP, Azure).
-		_, linkLocal, _ := net.ParseCIDR("169.254.0.0/16")
-		if linkLocal.Contains(ip) {
-			return errors.New("url targets a link-local address (cloud metadata endpoint)")
+		blockedRanges := []struct {
+			cidr  string
+			label string
+		}{
+			{"169.254.0.0/16", "link-local address (cloud metadata endpoint)"},
+			{"fe80::/10", "IPv6 link-local address (cloud metadata analogue)"},
+			{"::1/128", "IPv6 loopback address"},
+			{"fc00::/7", "IPv6 ULA address (RFC-4193 private)"},
+		}
+		for _, r := range blockedRanges {
+			_, network, _ := net.ParseCIDR(r.cidr)
+			if network.Contains(ip) {
+				return fmt.Errorf("url targets a blocked address: %s", r.label)
+			}
 		}
 	}
 	return nil

--- a/platform/internal/handlers/registry_test.go
+++ b/platform/internal/handlers/registry_test.go
@@ -458,6 +458,16 @@ func TestValidateAgentURL(t *testing.T) {
 		{"non-http scheme file", "file:///etc/passwd", true},
 		{"non-http scheme ftp", "ftp://internal-server/secrets", true},
 		{"malformed url", "://not-a-url", true},
+		// IPv6 SSRF vectors — must be rejected (C6 gap: Go's IPv4 CIDRs do not
+		// match pure IPv6 addresses via Contains(), so each range needs an
+		// explicit IPv6 entry).
+		{"blocked IPv6 loopback [::1]", "http://[::1]:8080", true},
+		{"blocked IPv6 link-local [fe80::1]", "http://[fe80::1]:8080", true},
+		{"blocked IPv6 ULA [fd00::1]", "http://[fd00::1]:8080", true},
+		// IPv4-mapped IPv6 for a blocked range must also be rejected.
+		// Go normalises ::ffff:169.254.x.x to IPv4 via To4(), so the existing
+		// 169.254.0.0/16 entry catches it without a dedicated rule.
+		{"blocked IPv4-mapped IPv6 link-local", "http://[::ffff:169.254.169.254]:80", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Root cause:** `validateAgentURL` in `registry.go` only blocked `169.254.0.0/16`. Go's `(*IPNet).Contains()` does not match pure IPv6 addresses against IPv4 CIDRs, leaving three IPv6 ranges fully open as SSRF vectors.
- **Gap confirmed by QA:** `http://[::1]:8080`, `http://[fe80::1]:8080`, and `http://[fd00::1]:8080` all passed through without error.
- **Fix:** Restructured the single-CIDR check into a `blockedRanges` loop and added three IPv6 entries:
  - `fe80::/10` — IPv6 link-local (same threat class as `169.254.0.0/16`; cloud metadata analogue)
  - `::1/128` — IPv6 loopback
  - `fc00::/7` — IPv6 ULA (RFC-4193 private)
- **IPv4-mapped IPv6** (`::ffff:169.254.169.254`) requires no extra range: Go normalises these to IPv4 via `To4()` before `Contains()` runs, so they're already caught by the `169.254.0.0/16` entry. Documented in both code comment and a test case.
- **No allowlist changes:** `127.0.0.1` and RFC-1918 ranges remain permitted (Docker networking requirement).

## Test plan

- [ ] `go test -race -run TestValidateAgentURL ./platform/internal/handlers/` — 4 new cases added: `[::1]`, `[fe80::1]`, `[fd00::1]`, `[::ffff:169.254.169.254]` all expect `wantErr: true`
- [ ] Existing valid-URL cases (`172.18.0.5`, `127.0.0.1`, `10.x`, `192.168.x`) remain `wantErr: false`
- [ ] Full `go test -race ./...` in `platform/`
- [ ] CI `platform-build` gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)