### PR TITLE
fix(canvas): WORKSPACE_PROVISIONING grid origin offset — prevent viewport clipping

### DIFF
--- a/canvas/src/store/__tests__/canvas-events.test.ts
+++ b/canvas/src/store/__tests__/canvas-events.test.ts
@@ -192,7 +192,7 @@ describe("handleCanvasEvent – WORKSPACE_PROVISIONING", () => {
     const n = newNodes[0];
     expect(n.id).toBe("ws-new");
     expect(n.type).toBe("workspaceNode");
-    expect(n.position).toEqual({ x: 0, y: 0 });
+    expect(n.position).toEqual({ x: 100, y: 100 });
     expect(n.data.name).toBe("Brand New");
     expect(n.data.tier).toBe(3);
     expect(n.data.status).toBe("provisioning");

--- a/canvas/src/store/canvas-events.ts
+++ b/canvas/src/store/canvas-events.ts
@@ -88,13 +88,15 @@ export function handleCanvasEvent(
           ),
         });
       } else {
-        // Spread new nodes in a grid so they don't stack
-        const GRID_COL_WIDTH = 320;
-        const GRID_ROW_HEIGHT = 160;
+        // Spread new nodes in a grid so they don't stack at the viewport origin
         const GRID_COLS = 4;
-        const rootIndex = nodes.filter((n) => !n.data.parentId).length;
-        const x = (rootIndex % GRID_COLS) * GRID_COL_WIDTH;
-        const y = Math.floor(rootIndex / GRID_COLS) * GRID_ROW_HEIGHT;
+        const COL_SPACING = 320;
+        const ROW_SPACING = 160;
+        const GRID_ORIGIN_X = 100;
+        const GRID_ORIGIN_Y = 100;
+        const idx = nodes.length;
+        const x = GRID_ORIGIN_X + (idx % GRID_COLS) * COL_SPACING;
+        const y = GRID_ORIGIN_Y + Math.floor(idx / GRID_COLS) * ROW_SPACING;
 
         set({
           nodes: [


### PR DESCRIPTION
## Summary
- New workspaces were spawning at `(0,0)` (or close to it), placing them behind the left toolbar/palette chrome and the top bar, requiring users to manually pan to find them
- Adds `GRID_ORIGIN_X = 100` / `GRID_ORIGIN_Y = 100` constants so the first deployed node lands in clear canvas space
- Updates the `canvas-events.test.ts` position assertion from `{ x: 0, y: 0 }` → `{ x: 100, y: 100 }` to match

## Files changed
- `canvas/src/store/canvas-events.ts` — WORKSPACE_PROVISIONING new-node branch: introduce `GRID_ORIGIN_X/Y`, rename spacing constants to `COL_SPACING`/`ROW_SPACING`, use `idx = nodes.length`
- `canvas/src/store/__tests__/canvas-events.test.ts` — update position assertion for first provisioned node

## Test plan
- [x] `canvas-events.test.ts` — 30/30 passing (run: `npx vitest run src/store/__tests__/canvas-events.test.ts`)
- [x] `npm run build` — clean, no errors
- [ ] Manual: deploy a new workspace from the template palette and confirm it appears at ~(100, 100) rather than behind the toolbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)