### PR TITLE
fix(security): #113 — bind scheduleId to workspace (IDOR)

### DIFF
--- a/platform/internal/handlers/schedules.go
+++ b/platform/internal/handlers/schedules.go
@@ -150,6 +150,11 @@ type updateScheduleRequest struct {
 // Update modifies a schedule. Uses a fixed UPDATE with COALESCE so only
 // provided fields are changed — no dynamic SQL construction.
 func (h *ScheduleHandler) Update(c *gin.Context) {
+	// Issue #113: bind scheduleId to the parent workspace. The wsAuth group
+	// already verifies the caller's token against :id, so :id is the sole
+	// ownership boundary — scheduleId must live inside it or the request
+	// resolves a foreign row (IDOR). Every SQL below uses BOTH keys.
+	workspaceID := c.Param("id")
 	scheduleID := c.Param("scheduleId")
 	ctx := c.Request.Context()
 
@@ -164,7 +169,8 @@ func (h *ScheduleHandler) Update(c *gin.Context) {
 	if body.CronExpr != nil || body.Timezone != nil {
 		var currentCron, currentTZ string
 		err := db.DB.QueryRowContext(ctx,
-			`SELECT cron_expr, timezone FROM workspace_schedules WHERE id = $1`, scheduleID,
+			`SELECT cron_expr, timezone FROM workspace_schedules WHERE id = $1 AND workspace_id = $2`,
+			scheduleID, workspaceID,
 		).Scan(&currentCron, &currentTZ)
 		if err != nil {
 			c.JSON(http.StatusNotFound, gin.H{"error": "schedule not found"})
@@ -192,15 +198,15 @@ func (h *ScheduleHandler) Update(c *gin.Context) {
 
 	result, err := db.DB.ExecContext(ctx, `
 		UPDATE workspace_schedules SET
-			name      = COALESCE($2, name),
-			cron_expr = COALESCE($3, cron_expr),
-			timezone  = COALESCE($4, timezone),
-			prompt    = COALESCE($5, prompt),
-			enabled   = COALESCE($6, enabled),
-			next_run_at = COALESCE($7, next_run_at),
+			name      = COALESCE($3, name),
+			cron_expr = COALESCE($4, cron_expr),
+			timezone  = COALESCE($5, timezone),
+			prompt    = COALESCE($6, prompt),
+			enabled   = COALESCE($7, enabled),
+			next_run_at = COALESCE($8, next_run_at),
 			updated_at = now()
-		WHERE id = $1
-	`, scheduleID, body.Name, body.CronExpr, body.Timezone, body.Prompt, body.Enabled, nextRunAt)
+		WHERE id = $1 AND workspace_id = $2
+	`, scheduleID, workspaceID, body.Name, body.CronExpr, body.Timezone, body.Prompt, body.Enabled, nextRunAt)
 	if err != nil {
 		log.Printf("Schedules.Update: error: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update schedule"})
@@ -215,13 +221,17 @@ func (h *ScheduleHandler) Update(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "updated"})
 }
 
-// Delete removes a schedule.
+// Delete removes a schedule. Issue #113 — bind scheduleId to the parent
+// workspace so a member of workspace A cannot delete a schedule owned by
+// workspace B.
 func (h *ScheduleHandler) Delete(c *gin.Context) {
+	workspaceID := c.Param("id")
 	scheduleID := c.Param("scheduleId")
 	ctx := c.Request.Context()
 
 	result, err := db.DB.ExecContext(ctx,
-		`DELETE FROM workspace_schedules WHERE id = $1`, scheduleID)
+		`DELETE FROM workspace_schedules WHERE id = $1 AND workspace_id = $2`,
+		scheduleID, workspaceID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete schedule"})
 		return

--- a/platform/internal/handlers/schedules_test.go
+++ b/platform/internal/handlers/schedules_test.go
@@ -124,3 +124,75 @@ func TestList_IncludesSourceColumn(t *testing.T) {
 		t.Fatalf("unmet expectations: %v", err)
 	}
 }
+
+// Issue #113 — IDOR guard: Update and Delete must bind scheduleId to the
+// parent workspace. A member of workspace A with a cached scheduleId from
+// workspace B previously could mutate or delete that foreign row.
+
+func TestScheduleUpdate_RejectsCrossWorkspaceIDOR(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	// Bob's workspace id, Alice's scheduleId — the UPDATE must filter on
+	// both so RowsAffected=0 and the handler returns 404 (no leak).
+	bobWS := "11111111-1111-1111-1111-111111111111"
+	aliceSched := "22222222-2222-2222-2222-222222222222"
+
+	mock.ExpectExec(`UPDATE workspace_schedules SET`).
+		WithArgs(aliceSched, bobWS, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+			sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	body := []byte(`{"name":"renamed-by-bob"}`)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "id", Value: bobWS},
+		{Key: "scheduleId", Value: aliceSched},
+	}
+	c.Request = httptest.NewRequest("PATCH",
+		"/workspaces/"+bobWS+"/schedules/"+aliceSched,
+		bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Update(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("cross-workspace Update: got %d, want 404 (body=%s)", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock: %v", err)
+	}
+}
+
+func TestScheduleDelete_RejectsCrossWorkspaceIDOR(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	bobWS := "11111111-1111-1111-1111-111111111111"
+	aliceSched := "22222222-2222-2222-2222-222222222222"
+
+	mock.ExpectExec(`DELETE FROM workspace_schedules WHERE id = \$1 AND workspace_id = \$2`).
+		WithArgs(aliceSched, bobWS).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{
+		{Key: "id", Value: bobWS},
+		{Key: "scheduleId", Value: aliceSched},
+	}
+	c.Request = httptest.NewRequest("DELETE",
+		"/workspaces/"+bobWS+"/schedules/"+aliceSched, nil)
+
+	handler.Delete(c)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("cross-workspace Delete: got %d, want 404 (body=%s)", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("sqlmock: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #113 (HIGH severity — cross-workspace IDOR).

## Root cause
\`Update\` and \`Delete\` on \`workspace_schedules\` filtered by \`scheduleId\` only. A member of workspace A with a cached scheduleId from workspace B could mutate or delete that foreign row — the \`wsAuth\` middleware only gates the :id path parameter, not the sub-resource.

## Fix
Bind both :id and :scheduleId in every SQL that touches a schedule:
- Pre-update SELECT: \`WHERE id = \$1 AND workspace_id = \$2\`
- UPDATE: \`WHERE id = \$1 AND workspace_id = \$2\`
- DELETE: \`WHERE id = \$1 AND workspace_id = \$2\`

\`RunNow\` and \`History\` already had the correct two-key filter — no changes.

## Test plan
- [x] 2 new sqlmock tests: \`TestScheduleUpdate_RejectsCrossWorkspaceIDOR\`, \`TestScheduleDelete_RejectsCrossWorkspaceIDOR\` — Bob attacks Alice's scheduleId → 0 rows affected → 404
- [x] Existing \`TestRuntimeSchedule_HasSourceRuntime\`, \`TestList_IncludesSourceColumn\` still green
- [x] \`go test -race ./platform/...\` clean locally

⚠️ **CI currently blocked** by GitHub Actions org spending-limit cap — not a code failure. See #110 / #119 for the same block. Verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)