### PR TITLE
fix(template): #133 — add code-review plugins to Dev Lead + QA Engineer

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -211,6 +211,12 @@ workspaces:
         tier: 3
         model: opus
         files_dir: dev-lead
+        # Dev Lead enforces PR quality gates (see gate 2a in
+        # .claude/skills/triage/SKILL.md) and reviews engineering output
+        # before handoff to PM. The code-review skill surfaces the
+        # 16-criteria rubric — without it Dev Lead falls back to ad-hoc
+        # review prompts. Issue #133.
+        plugins: [molecule-skill-code-review, molecule-skill-llm-judge]
         canvas: { x: 650, y: 250 }
         initial_prompt: |
           You just started as Dev Lead. Set up silently — do NOT contact other agents.
@@ -497,6 +503,9 @@ workspaces:
             tier: 3
             model: opus
             files_dir: qa-engineer
+            # QA reviews test coverage + runs llm-judge on whether test
+            # deliverables actually match acceptance criteria. Issue #133.
+            plugins: [molecule-skill-code-review, molecule-skill-llm-judge]
             initial_prompt: |
               You just started as QA Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
Closes #133. YAML-only template fix. Both roles now have molecule-skill-code-review + molecule-skill-llm-judge plugins, matching Security Auditor's pattern. Verified yaml parses cleanly.