### PR TITLE
fix(scheduler): independent heartbeat pulse so liveness doesn't false-stale during long fires (#140)

### DIFF
--- a/platform/internal/scheduler/scheduler.go
+++ b/platform/internal/scheduler/scheduler.go
@@ -113,6 +113,25 @@ func (s *Scheduler) Start(ctx context.Context) {
 	s.lastTickAt = time.Now()
 	s.mu.Unlock()
 
+	// Independent heartbeat pulse (#140). Decoupled from tick completion so
+	// a single long fire (UIUX audits routinely take 60-120s; max fireTimeout
+	// is 5min) can't make /admin/liveness look stale for the whole fire window.
+	// tick() also calls Heartbeat at its top + each fire goroutine calls it
+	// entry/exit — those are kept as redundant signals but this pulse is the
+	// one that guarantees liveness freshness regardless of tick state.
+	go func() {
+		pulseTicker := time.NewTicker(10 * time.Second)
+		defer pulseTicker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-pulseTicker.C:
+				supervised.Heartbeat("scheduler")
+			}
+		}
+	}()
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary
Closes #140. The scheduler liveness signal was going false-stale during long fires (e.g. UIUX hourly audit, which runs Playwright + vision analysis for 60-120s typical, up to 5min fireTimeout max). Observed multiple times during maintenance cron cycles.

## Root cause
#95's heartbeat scheme was:
1. Top of `tick()` — fires once per 30s poll interval
2. Per-fire goroutine entry + exit — brackets each fire

But `tick()` ends with `wg.Wait()`, so the next `tick()` call is blocked until ALL in-flight fires complete. If one fire takes 2min, no top-of-tick heartbeat fires in that 2min window. Per-fire heartbeats only bracket entry/exit — between entry and the HTTP response returning, nothing heartbeats.

Net: `/admin/liveness` reports `seconds_ago=251` while `docker logs` simultaneously shows the scheduler actively firing `Hourly ecosystem watch`. Scheduler is fine; liveness is lying.

## Fix
Independent 10s heartbeat pulse goroutine inside `Start()`, decoupled from tick completion:

```go
// Independent heartbeat pulse (#140). Decoupled from tick completion so
// a single long fire (UIUX audits routinely take 60-120s; max fireTimeout
// is 5min) can't make /admin/liveness look stale for the whole fire window.
go func() {
    pulseTicker := time.NewTicker(10 * time.Second)
    defer pulseTicker.Stop()
    for {
        select {
        case <-ctx.Done():
            return
        case <-pulseTicker.C:
            supervised.Heartbeat("scheduler")
        }
    }
}()
```

Existing heartbeats at tick top + per-fire are kept as redundant signals but this pulse is the one that guarantees liveness freshness regardless of tick state.

## Impact
`/admin/liveness` now reports `seconds_ago < 20` continuously, bounded by the 10s pulse interval, regardless of what the tick loop is doing. The maintenance cron watchdog stops false-positive-investigating during every UIUX audit window.

## Test plan
- [x] Compiles clean (`go build ./... && go vet ./internal/scheduler/...`)
- [ ] CI re-validate
- [ ] Manual: rebuild platform with this branch, wait for next UIUX audit fire (:11), verify `/admin/liveness` stays fresh while fire is in flight

## Related
- #85 scheduler silent outage (original watchdog motivation)
- #95 supervised goroutines (added the current per-fire heartbeat scheme that this PR fixes a gap in)
- #140 (this PR's tracking issue, closed on merge)