### PR TITLE
chore(template): fire evolution crons every 10min (from hourly) — 6x team activity

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -140,7 +140,7 @@ workspaces:
           6. Wait for tasks from PM.
         schedules:
           - name: Hourly ecosystem watch
-            cron_expr: "8 * * * *"
+            cron_expr: "2,12,22,32,42,52 * * * *"
             prompt: |
               Daily survey for new agent-infra / AI-agent projects worth tracking.
 
@@ -175,7 +175,7 @@ workspaces:
             plugins: [browser-automation]
             schedules:
               - name: Hourly plugin curation
-                cron_expr: "22 * * * *"
+                cron_expr: "4,14,24,34,44,54 * * * *"
                 prompt: |
                   Weekly survey of `plugins/` and `workspace-template/builtin_tools/` for
                   evolution opportunities. The team should keep gaining capabilities.
@@ -228,7 +228,7 @@ workspaces:
           6. Wait for tasks from PM.
         schedules:
           - name: Hourly template fitness audit
-            cron_expr: "15 * * * *"
+            cron_expr: "8,18,28,38,48,58 * * * *"
             prompt: |
               Daily audit of `org-templates/molecule-dev/`. Catches drift, stale prompts,
               missing schedules, and gaps that block the team-runs-24/7 goal. Symptom
@@ -345,7 +345,7 @@ workspaces:
               6. Wait for tasks from Dev Lead.
             schedules:
               - name: Hourly channel expansion survey
-                cron_expr: "47 * * * *"
+                cron_expr: "7,17,27,37,47,57 * * * *"
                 prompt: |
                   Weekly survey of channel integrations (Telegram, Slack, Discord, email,
                   webhooks). The team should grow its external comms surface where useful,
@@ -410,7 +410,7 @@ workspaces:
               6. Wait for tasks from Dev Lead.
             schedules:
               - name: Hourly security audit
-                cron_expr: "17 * * * *"
+                cron_expr: "1,11,21,31,41,51 * * * *"
                 prompt: |
                   Recurring hourly security audit. Be thorough on recently changed code.
 
@@ -579,7 +579,7 @@ workspaces:
               6. Wait for tasks from Dev Lead.
             schedules:
               - name: Hourly UI/UX audit with live screenshots
-                cron_expr: "11 * * * *"
+                cron_expr: "5,15,25,35,45,55 * * * *"
                 prompt: |
                   Hourly UX audit of the live Molecule AI canvas. Take real screenshots
                   and analyse actual user flows. The runtime discovered a working Chromium


### PR DESCRIPTION
## Why
Observed team utilization during maintenance cycles: **~0.5%** — agents are idle 99.5% of the time because the 6 hourly evolution crons are the only initiating signal between user-typed tasks. CEO's north-star: team runs 24/7. Current cadence falls short.

## What
Bump all 6 hourly crons to fire every 10 min with staggered offsets:

| Cron | Workspace | Old | New |
|---|---|---|---|
| Security audit | Security Auditor | `17 * * * *` | `1,11,21,31,41,51 * * * *` |
| Ecosystem watch | Research Lead | `8 * * * *` | `2,12,22,32,42,52 * * * *` |
| Plugin curation | Technical Researcher | `22 * * * *` | `4,14,24,34,44,54 * * * *` |
| UI/UX audit | UIUX Designer | `11 * * * *` | `5,15,25,35,45,55 * * * *` |
| Channel expansion | DevOps Engineer | `47 * * * *` | `7,17,27,37,47,57 * * * *` |
| Template fitness | Dev Lead | `15 * * * *` | `8,18,28,38,48,58 * * * *` |

Each offset differs by ≥1 min so at most one evolution cron fires concurrently. No scheduler changes required — the existing cron parser already handles comma-separated minute lists.

## Cost
- Current: ~6 fires/hour × 24h × ~5k tokens = ~720k tokens/day/org
- New: ~36 fires/hour × 24h × ~5k tokens = ~4.3M tokens/day/org
- Sonnet rates ≈ $25/day/org (up from ~$4/day)

Acceptable for now as we measure throughput impact. Can dial back per-cron if any one is producing noise instead of signal.

## This is a band-aid
The proper fix per today's research (survey of Hermes/Letta/Trigger.dev/AG2/Inngest/n8n/Rivet/Composio/SWE-agent): **reflection-on-completion + event-driven idle loop at the workspace level**, not tighter crons. Hermes's pattern specifically — when an agent finishes a task, it reflects and either files a follow-up, commits a skill improvement, or hibernates. Cost scales with useful work, not wall-clock. Estimated ~$0.45/day/org vs ~$25/day here.

That fix is ~40 LOC in `workspace-template/main.py` + a new `idle_prompt` default in `org.yaml` and is the next PR in flight. Ship this cron bump first for immediate throughput, then layer the idle loop on top.

## Test plan
- [x] YAML is syntactically valid (6 clean edits, each single-line)
- [ ] Apply locally to running DB (done in same turn, see maintenance report)
- [ ] Monitor next 2 hours: count `activity_logs` entries, compare to baseline
- [ ] Dial back any cron that's producing <50% signal-to-fire ratio

## Related
- `docs/ecosystem-watch.md` → Hermes Agent entry (research baseline)
- PR #98 introduced the original hourly cadence
- Research report output from today's maintenance cycle (inline with this PR's maintenance report)