### PR TITLE
fix(tests): add EXISTS probe mock to 4 WorkspaceUpdate tests (post #125)

### DIFF
--- a/platform/internal/handlers/handlers_additional_test.go
+++ b/platform/internal/handlers/handlers_additional_test.go
@@ -115,6 +115,11 @@ func TestWorkspaceUpdate_ParentID(t *testing.T) {
 	broadcaster := newTestBroadcaster()
 	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
 
+	// #125 guard: handler now verifies the workspace exists before applying
+	// the UPDATE. Each PATCH test must mock the EXISTS probe first.
+	mock.ExpectQuery("SELECT EXISTS.*workspaces WHERE id").
+		WithArgs("ws-child").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec("UPDATE workspaces SET parent_id").
 		WithArgs("ws-child", "ws-parent").
 		WillReturnResult(sqlmock.NewResult(0, 1))
@@ -144,6 +149,9 @@ func TestWorkspaceUpdate_NameOnly(t *testing.T) {
 	broadcaster := newTestBroadcaster()
 	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
 
+	mock.ExpectQuery("SELECT EXISTS.*workspaces WHERE id").
+		WithArgs("ws-rename").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec("UPDATE workspaces SET name").
 		WithArgs("ws-rename", "New Name").
 		WillReturnResult(sqlmock.NewResult(0, 1))

--- a/platform/internal/handlers/workspace_test.go
+++ b/platform/internal/handlers/workspace_test.go
@@ -304,6 +304,10 @@ func TestWorkspaceUpdate_MultipleFields(t *testing.T) {
 	broadcaster := newTestBroadcaster()
 	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
 
+	// #125: existence probe fires once before any field update.
+	mock.ExpectQuery("SELECT EXISTS.*workspaces WHERE id").
+		WithArgs("ws-multi").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	// Expect name, role, and tier updates
 	mock.ExpectExec("UPDATE workspaces SET name").
 		WithArgs("ws-multi", "Updated Agent").
@@ -348,6 +352,9 @@ func TestWorkspaceUpdate_RuntimeField(t *testing.T) {
 	broadcaster := newTestBroadcaster()
 	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
 
+	mock.ExpectQuery("SELECT EXISTS.*workspaces WHERE id").
+		WithArgs("ws-rt").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 	mock.ExpectExec("UPDATE workspaces SET runtime").
 		WithArgs("ws-rt", "claude-code").
 		WillReturnResult(sqlmock.NewResult(0, 1))


### PR DESCRIPTION
#125 broke the 4 WorkspaceUpdate sqlmock tests by adding an EXISTS probe before the UPDATE. CI didn't catch it because the Actions billing cap is still blocking runs; only caught locally when running full suite for #110/#119 verification. Adds the missing ExpectQuery mock. go test -race green locally.