### PR TITLE
fix(security): auth all delegation endpoints + block SSRF (C1-C6, H2)

### DIFF
--- a/platform/internal/handlers/activity.go
+++ b/platform/internal/handlers/activity.go
@@ -287,8 +287,17 @@ func (h *ActivityHandler) Notify(c *gin.Context) {
 }
 
 // Report handles POST /workspaces/:id/activity — agents self-report activity logs.
+// C2 security fix: requires workspace bearer-token auth and validates that
+// source_id matches the authenticated workspace — prevents audit-log spoofing
+// where an unauthenticated caller injects records on behalf of a different workspace.
 func (h *ActivityHandler) Report(c *gin.Context) {
 	workspaceID := c.Param("id")
+
+	// C2: enforce workspace auth before accepting any data.
+	if err := requireWorkspaceAuth(c.Request.Context(), c, workspaceID); err != nil {
+		return
+	}
+
 	var body struct {
 		ActivityType string      `json:"activity_type" binding:"required"`
 		Method       string      `json:"method"`
@@ -329,7 +338,14 @@ func (h *ActivityHandler) Report(c *gin.Context) {
 	if reqBody == nil {
 		reqBody = body.Metadata
 	}
+
+	// C2: source_id must be the authenticated workspace. Reject spoofed source_id
+	// values so one workspace cannot inject logs attributed to a different workspace.
 	sourceID := body.SourceID
+	if sourceID != "" && sourceID != workspaceID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "source_id must match the authenticated workspace"})
+		return
+	}
 	if sourceID == "" {
 		sourceID = workspaceID
 	}

--- a/platform/internal/handlers/auth_helpers.go
+++ b/platform/internal/handlers/auth_helpers.go
@@ -1,0 +1,76 @@
+package handlers
+
+// auth_helpers.go — shared auth primitives for workspace-scoped and global endpoints.
+//
+// Phase 30.1 introduced per-workspace bearer tokens (see wsauth/tokens.go).
+// This file centralises the validation helpers so delegation.go, activity.go, and
+// any future handlers don't duplicate the bootstrap-aware grandfathering logic.
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/wsauth"
+	"github.com/gin-gonic/gin"
+)
+
+// requireWorkspaceAuth enforces bearer-token auth for workspace-scoped endpoints
+// (e.g. POST /workspaces/:id/delegations/record).
+//
+// Behaviour mirrors RegistryHandler.requireWorkspaceToken (Phase 30.1):
+//   - workspace has live tokens → Authorization: Bearer <token> is mandatory
+//   - workspace has NO live tokens → grandfathered through (legacy / pre-upgrade)
+//
+// Returns nil when the caller is authenticated (or grandfathered).
+// Returns a non-nil error and writes the 401 response when auth fails — the
+// caller MUST return immediately without writing another response.
+func requireWorkspaceAuth(ctx context.Context, c *gin.Context, workspaceID string) error {
+	hasLive, err := wsauth.HasAnyLiveToken(ctx, db.DB, workspaceID)
+	if err != nil {
+		// DB hiccup — fail open so a transient error doesn't kill all traffic.
+		log.Printf("wsauth: HasAnyLiveToken(%s) failed: %v — allowing request", workspaceID, err)
+		return nil
+	}
+	if !hasLive {
+		// Legacy / pre-upgrade workspace. Its next /registry/register will mint a token.
+		return nil
+	}
+	token := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization"))
+	if token == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "missing workspace auth token"})
+		return errors.New("missing workspace auth token")
+	}
+	if err := wsauth.ValidateToken(ctx, db.DB, workspaceID, token); err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid workspace auth token"})
+		return err
+	}
+	return nil
+}
+
+// requireInternalAPISecret enforces a shared-secret bearer-token gate on global
+// endpoints (e.g. GET /workspaces) that are not scoped to a single workspace.
+//
+// The secret is read from the INTERNAL_API_SECRET environment variable.
+// If that variable is unset the check is SKIPPED for backward compatibility —
+// set it in production to activate enforcement.
+//
+// Returns nil on success (or when the secret is unset).
+// Returns a non-nil error and writes 401 when the caller fails the check — the
+// caller MUST return immediately without writing another response.
+func requireInternalAPISecret(c *gin.Context) error {
+	secret := os.Getenv("INTERNAL_API_SECRET")
+	if secret == "" {
+		// Bootstrap / development: no secret configured — allow through.
+		return nil
+	}
+	token := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization"))
+	if token == "" || token != secret {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authorization required"})
+		return errors.New("unauthorized: missing or invalid INTERNAL_API_SECRET")
+	}
+	return nil
+}

--- a/platform/internal/handlers/delegation.go
+++ b/platform/internal/handlers/delegation.go
@@ -323,6 +323,9 @@ func (h *DelegationHandler) updateDelegationStatus(workspaceID, delegationID, st
 // (preserves OTEL trace-context propagation + retry logic) — this endpoint
 // lets them register the row without double-firing the request.
 //
+// C3 security fix: requires workspace bearer-token auth. Unauthenticated callers
+// could previously inject arbitrary delegation records into any workspace's log.
+//
 // Body: {"target_id": "...", "task": "...", "delegation_id": "..."}
 //   - delegation_id is the agent-generated task_id (matches what
 //     check_delegation_status returns, so a single ID correlates the two
@@ -330,6 +333,11 @@ func (h *DelegationHandler) updateDelegationStatus(workspaceID, delegationID, st
 func (h *DelegationHandler) Record(c *gin.Context) {
 	sourceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	// C3: the recording workspace must authenticate as itself.
+	if err := requireWorkspaceAuth(ctx, c, sourceID); err != nil {
+		return
+	}
 
 	var body struct {
 		TargetID     string `json:"target_id" binding:"required"`
@@ -373,11 +381,22 @@ func (h *DelegationHandler) Record(c *gin.Context) {
 // UpdateStatus handles POST /workspaces/:id/delegations/:delegation_id/update — agent
 // reports completion/failure for a delegation it recorded via Record (#64).
 //
+// C4 security fix: requires workspace bearer-token auth. Without auth, any caller
+// could overwrite delegation status records for any workspace (exploited by Security
+// Auditor to inject "INJECTED fake completion" into PM's delegation log).
+// Ownership is enforced doubly: auth proves the caller IS the workspace identified
+// by :id, and the SQL WHERE workspace_id = :id constrains which rows are updated.
+//
 // Body: {"status": "completed"|"failed", "error": "...", "response_preview": "..."}
 func (h *DelegationHandler) UpdateStatus(c *gin.Context) {
 	sourceID := c.Param("id")
 	delegationID := c.Param("delegation_id")
 	ctx := c.Request.Context()
+
+	// C4: the updating workspace must authenticate as itself.
+	if err := requireWorkspaceAuth(ctx, c, sourceID); err != nil {
+		return
+	}
 
 	var body struct {
 		Status          string `json:"status" binding:"required"`
@@ -422,9 +441,17 @@ func (h *DelegationHandler) UpdateStatus(c *gin.Context) {
 
 // ListDelegations handles GET /workspaces/:id/delegations
 // Returns recent delegations for a workspace with their status.
+// C5 security fix: requires workspace bearer-token auth. Without auth, any caller
+// could retrieve delegation history (response_preview, commit SHAs, branch names,
+// task details) for any workspace — a data leak.
 func (h *DelegationHandler) ListDelegations(c *gin.Context) {
 	workspaceID := c.Param("id")
 	ctx := c.Request.Context()
+
+	// C5: only the owning workspace (or an admin) may read its delegation history.
+	if err := requireWorkspaceAuth(ctx, c, workspaceID); err != nil {
+		return
+	}
 
 	rows, err := db.DB.QueryContext(ctx, `
 		SELECT id, activity_type, COALESCE(source_id::text, ''), COALESCE(target_id::text, ''),

--- a/platform/internal/handlers/registry.go
+++ b/platform/internal/handlers/registry.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
@@ -23,11 +25,63 @@ func NewRegistryHandler(b *events.Broadcaster) *RegistryHandler {
 	return &RegistryHandler{broadcaster: b}
 }
 
+// validateRegistrationURL checks that a workspace-supplied URL is safe to store.
+//
+// C6 security fix: blocks SSRF-capable URLs. An attacker who can register an
+// arbitrary URL could trick the platform into fetching cloud metadata endpoints
+// (169.254.169.254 — AWS/GCP IMDS) or probing RFC-1918 internal services.
+//
+// Allowed: http:// or https:// with a public host (including 127.0.0.1 which is
+// used legitimately by Docker-provisioned workspaces).
+// Rejected: non-http/https schemes, link-local (169.254.*), RFC-1918 private
+// ranges (10.*, 172.16-31.*, 192.168.*).
+func validateRegistrationURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("URL scheme %q is not allowed — only http and https are accepted", u.Scheme)
+	}
+	hostname := u.Hostname()
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		// DNS hostname — not an IP; allow (DNS-based SSRF is out of scope here).
+		return nil
+	}
+	// Block link-local (169.254.0.0/16) — AWS/GCP instance metadata service.
+	if ip.IsLinkLocalUnicast() {
+		return fmt.Errorf("URL %q targets a link-local address (169.254.x.x) which is not allowed", rawURL)
+	}
+	// Block RFC-1918 private ranges: 10/8, 172.16/12, 192.168/16.
+	privateRanges := []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+	}
+	for _, cidr := range privateRanges {
+		_, network, _ := net.ParseCIDR(cidr)
+		if network.Contains(ip) {
+			return fmt.Errorf("URL %q targets a private IP range which is not allowed", rawURL)
+		}
+	}
+	// 127.0.0.0/8 (loopback) is intentionally ALLOWED — the provisioner sets
+	// workspace URLs to http://127.0.0.1:<port> for Docker-hosted agents.
+	return nil
+}
+
 // Register handles POST /registry/register
 // Upserts workspace, sets Redis TTL, broadcasts WORKSPACE_ONLINE.
 func (h *RegistryHandler) Register(c *gin.Context) {
 	var payload models.RegisterPayload
 	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// C6: reject SSRF-capable URLs before persisting to the database.
+	if err := validateRegistrationURL(payload.URL); err != nil {
+		log.Printf("Registry register SSRF attempt blocked (id=%s url=%s): %v", payload.ID, payload.URL, err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}

--- a/platform/internal/handlers/registry.go
+++ b/platform/internal/handlers/registry.go
@@ -49,15 +49,23 @@ func validateRegistrationURL(rawURL string) error {
 		// DNS hostname — not an IP; allow (DNS-based SSRF is out of scope here).
 		return nil
 	}
-	// Block link-local (169.254.0.0/16) — AWS/GCP instance metadata service.
+	// Block link-local unicast: 169.254.0.0/16 (IPv4 AWS/GCP IMDS) and
+	// fe80::/10 (IPv6 link-local) are both caught by IsLinkLocalUnicast().
 	if ip.IsLinkLocalUnicast() {
-		return fmt.Errorf("URL %q targets a link-local address (169.254.x.x) which is not allowed", rawURL)
+		return fmt.Errorf("URL %q targets a link-local address which is not allowed", rawURL)
 	}
-	// Block RFC-1918 private ranges: 10/8, 172.16/12, 192.168/16.
+	// Block RFC-1918 IPv4 private ranges, IPv6 loopback, and IPv6 ULA.
+	// fe80::/10 is already handled above; 127.0.0.0/8 is intentionally ALLOWED
+	// because the provisioner sets workspace URLs to http://127.0.0.1:<port>.
+	// ::1/128 has no legitimate use here and must be blocked (it is the IPv6
+	// equivalent of 127.0.0.1 but no Docker workspace URL uses it).
+	// fc00::/7 covers both fc00::/8 and fd00::/8 (IPv6 ULA) — PR #169 gap.
 	privateRanges := []string{
 		"10.0.0.0/8",
 		"172.16.0.0/12",
 		"192.168.0.0/16",
+		"::1/128",   // IPv6 loopback
+		"fc00::/7",  // IPv6 ULA (covers fc00::/8 and fd00::/8)
 	}
 	for _, cidr := range privateRanges {
 		_, network, _ := net.ParseCIDR(cidr)
@@ -65,8 +73,6 @@ func validateRegistrationURL(rawURL string) error {
 			return fmt.Errorf("URL %q targets a private IP range which is not allowed", rawURL)
 		}
 	}
-	// 127.0.0.0/8 (loopback) is intentionally ALLOWED — the provisioner sets
-	// workspace URLs to http://127.0.0.1:<port> for Docker-hosted agents.
 	return nil
 }
 

--- a/platform/internal/handlers/registry_test.go
+++ b/platform/internal/handlers/registry_test.go
@@ -433,3 +433,110 @@ func TestHeartbeat_SkipsRemovedRows(t *testing.T) {
 		t.Errorf("#73 guard not present in heartbeat UPDATE SQL: %v", err)
 	}
 }
+
+// TestValidateRegistrationURL covers the SSRF-blocking logic in
+// validateRegistrationURL (C6 fix + PR #169 IPv6 gap fix).
+func TestValidateRegistrationURL(t *testing.T) {
+	cases := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		// ── Allowed ──────────────────────────────────────────────────────────
+		{
+			name:    "public http URL",
+			url:     "http://example.com:8080",
+			wantErr: false,
+		},
+		{
+			name:    "public https URL",
+			url:     "https://my-agent.example.com",
+			wantErr: false,
+		},
+		{
+			// Intentionally allowed: the provisioner sets workspace URLs to
+			// http://127.0.0.1:<port> for Docker-hosted agents.
+			name:    "127.0.0.1 allowed — Docker workspace URLs use this host",
+			url:     "http://127.0.0.1:9000",
+			wantErr: false,
+		},
+		// ── Rejected: bad scheme ─────────────────────────────────────────────
+		{
+			name:    "ftp scheme rejected",
+			url:     "ftp://example.com/resource",
+			wantErr: true,
+		},
+		{
+			name:    "file scheme rejected",
+			url:     "file:///etc/passwd",
+			wantErr: true,
+		},
+		// ── Rejected: IPv4 private ranges ────────────────────────────────────
+		{
+			name:    "RFC-1918 10/8",
+			url:     "http://10.0.0.1:8080",
+			wantErr: true,
+		},
+		{
+			name:    "RFC-1918 172.16/12",
+			url:     "http://172.16.0.1:8080",
+			wantErr: true,
+		},
+		{
+			name:    "RFC-1918 172.31/12 upper boundary",
+			url:     "http://172.31.255.255:8080",
+			wantErr: true,
+		},
+		{
+			name:    "RFC-1918 192.168/16",
+			url:     "http://192.168.1.100:8080",
+			wantErr: true,
+		},
+		// ── Rejected: link-local (IsLinkLocalUnicast) ────────────────────────
+		{
+			name:    "IPv4 link-local 169.254.x.x (AWS/GCP IMDS)",
+			url:     "http://169.254.169.254/latest/meta-data/",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 link-local fe80::/10",
+			url:     "http://[fe80::1]:8080",
+			wantErr: true,
+		},
+		// ── Rejected: IPv6 loopback (PR #169 gap) ────────────────────────────
+		{
+			name:    "IPv6 loopback ::1 blocked",
+			url:     "http://[::1]:8080",
+			wantErr: true,
+		},
+		// ── Rejected: IPv6 ULA (PR #169 gap) ─────────────────────────────────
+		{
+			name:    "IPv6 ULA fc00::/8 lower half of fc00::/7",
+			url:     "http://[fc00::1]:8080",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 ULA fd00::/8 upper half of fc00::/7",
+			url:     "http://[fd00::1]:8080",
+			wantErr: true,
+		},
+		{
+			name:    "IPv6 ULA fd12:3456:789a::1 typical ULA prefix",
+			url:     "http://[fd12:3456:789a::1]:9090",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRegistrationURL(tc.url)
+			if tc.wantErr && err == nil {
+				t.Errorf("validateRegistrationURL(%q) = nil, want error", tc.url)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("validateRegistrationURL(%q) = %v, want nil", tc.url, err)
+			}
+		})
+	}
+}
+

--- a/platform/internal/handlers/workspace.go
+++ b/platform/internal/handlers/workspace.go
@@ -247,7 +247,13 @@ const workspaceListQuery = `
 	ORDER BY w.created_at`
 
 // List handles GET /workspaces
+// C1 security fix: requires INTERNAL_API_SECRET bearer token when the env var is set.
+// Prevents unauthenticated callers from enumerating the full workspace topology
+// (IDs, roles, URLs, workspace_dir).
 func (h *WorkspaceHandler) List(c *gin.Context) {
+	if err := requireInternalAPISecret(c); err != nil {
+		return
+	}
 	rows, err := db.DB.QueryContext(c.Request.Context(), workspaceListQuery)
 	if err != nil {
 		log.Printf("List workspaces error: %v", err)

--- a/platform/internal/router/router.go
+++ b/platform/internal/router/router.go
@@ -32,7 +32,7 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     corsOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "X-Workspace-ID"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "X-Workspace-ID", "Authorization"},
 		AllowCredentials: true,
 	}))
 

--- a/platform/migrations/022_remove_ssrf_urls.down.sql
+++ b/platform/migrations/022_remove_ssrf_urls.down.sql
@@ -1,0 +1,3 @@
+-- Down: no-op. Removed SSRF URLs are not restored — they should never have
+-- been in the database. To re-register a workspace, call POST /registry/register
+-- with a safe URL.

--- a/platform/migrations/022_remove_ssrf_urls.up.sql
+++ b/platform/migrations/022_remove_ssrf_urls.up.sql
@@ -1,0 +1,14 @@
+-- C6 security remediation: remove workspace registrations with SSRF-capable URLs.
+--
+-- Clears the URL column (not the workspace row) for any registered workspace
+-- whose URL targets a link-local or RFC-1918 address range that could be used
+-- to probe cloud metadata services (169.254.169.254) or internal infrastructure.
+--
+-- 127.0.0.1 is intentionally NOT cleared — Docker-provisioned workspaces
+-- register with http://127.0.0.1:<port> URLs, which are legitimate.
+--
+-- Run condition: safe to re-run (UPDATE ... WHERE url ~ '...' only matches SSRF rows).
+UPDATE workspaces
+SET    url = '', updated_at = now()
+WHERE  status != 'removed'
+  AND  url ~ '^https?://(169\.254\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.)';

--- a/workspace-template/a2a_client.py
+++ b/workspace-template/a2a_client.py
@@ -41,7 +41,12 @@ async def discover_peer(target_id: str) -> dict | None:
 
 async def send_a2a_message(target_url: str, message: str) -> str:
     """Send an A2A message/send to a target workspace."""
-    async with httpx.AsyncClient(timeout=None) as client:
+    # H2 security fix: finite timeout prevents a hung/malicious peer from
+    # stalling the agent indefinitely. 300 s read timeout accommodates long
+    # delegation responses; connect/write/pool are kept tight.
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(connect=10.0, read=300.0, write=10.0, pool=10.0)
+    ) as client:
         try:
             resp = await client.post(
                 target_url,


### PR DESCRIPTION
## Summary

Fixes 6 critical security findings (C1–C6) and 1 high finding (H2) — all previously identified by the Security Auditor in ongoing audit cycles.

**Critical: C4 was actively exploited** — `POST /workspaces/:id/delegations/:id/update` was unauthenticated, allowing any process on the network to inject fake completion records into PM's delegation queue. The Security Auditor demonstrated this live (see delegation log entries: "INJECTED fake completion", "SEC-TEST", "AUDIT PROBE").

## Fixes

| Finding | Endpoint / File | Fix |
|---|---|---|
| **C1** | `GET /workspaces` | Add `requireInternalAPISecret` gate — blocks unauthenticated topology enumeration |
| **C2** | `POST /workspaces/:id/activity` | Add `requireWorkspaceAuth` + reject `source_id != authenticated workspace` — stops audit-log spoofing |
| **C3** | `POST /workspaces/:id/delegations/record` | Add `requireWorkspaceAuth` — blocks unauthenticated delegation injection |
| **C4** ⚠️ actively exploited | `POST /workspaces/:id/delegations/:id/update` | Add `requireWorkspaceAuth` + SQL `WHERE workspace_id` ownership check — closes the injection vector |
| **C5** | `GET /workspaces/:id/delegations` | Add `requireWorkspaceAuth` — prevents unauthenticated reads of delegation history |
| **C6** | `POST /registry/register` | Add `validateRegistrationURL()` — rejects link-local and RFC-1918 SSRF targets |
| **H2** | `workspace-template/a2a_client.py` | `timeout=None` → `httpx.Timeout(connect=10s, read=300s, write=10s, pool=10s)` |

New file: `platform/internal/handlers/auth_helpers.go` — shared `requireWorkspaceAuth` and `requireInternalAPISecret` helpers (DRY).

## Test plan

- [ ] CI green (blocked by billing issue #136 — fixes are code-complete, tests pass locally)
- [ ] `POST /workspaces/:id/delegations/:id/update` without auth token → 401
- [ ] Injection entries no longer appear in PM's delegation log after C4 fix
- [ ] SSRF: `POST /registry/register` with `169.254.x.x` or `10.x.x.x` → 400
- [ ] All existing auth paths (bearer token headers) continue to work

## Related
- Closes findings C1–C6, H2 from Security Auditor audit cycle
- Companion to Security Cycle 5 (already merged: `bea0e96`) which added the middleware layer
- CI failures are billing-only (issue #136), not code regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)