### PR TITLE
chore(ci): migrate all jobs to self-hosted macOS arm64 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   platform-build:
     name: Platform (Go)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     defaults:
       run:
         working-directory: platform
@@ -43,7 +43,7 @@ jobs:
 
   canvas-build:
     name: Canvas (Next.js)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     defaults:
       run:
         working-directory: canvas
@@ -59,7 +59,7 @@ jobs:
 
   mcp-server-build:
     name: MCP Server (Node.js)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     defaults:
       run:
         working-directory: mcp-server
@@ -75,37 +75,17 @@ jobs:
 
   e2e-api:
     name: E2E API Smoke Test
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    services:
-      postgres:
-        # Credentials match .env.example (dev:dev) so local reproduction is
-        # identical to CI. POSTGRES_DB matches the default there too.
-        image: postgres:16
-        env:
-          POSTGRES_USER: dev
-          POSTGRES_PASSWORD: dev
-          POSTGRES_DB: molecule
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U dev"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      redis:
-        image: redis:7
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
+    runs-on: [self-hosted, macos, arm64]
+    timeout-minutes: 15
+    # `services:` is Linux-only on self-hosted runners — we start postgres
+    # and redis via `docker run` instead. Ports 15432/16379 avoid collision
+    # with anything the host may already have on the standard ports.
     env:
-      DATABASE_URL: postgres://dev:dev@localhost:5432/molecule?sslmode=disable
-      REDIS_URL: redis://localhost:6379
+      DATABASE_URL: postgres://dev:dev@localhost:15432/molecule?sslmode=disable
+      REDIS_URL: redis://localhost:16379
       PORT: "8080"
+      PG_CONTAINER: molecule-ci-postgres
+      REDIS_CONTAINER: molecule-ci-redis
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -113,6 +93,38 @@ jobs:
           go-version: 'stable'
           cache: true
           cache-dependency-path: platform/go.sum
+      - name: Start Postgres (docker)
+        run: |
+          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$PG_CONTAINER" \
+            -e POSTGRES_USER=dev \
+            -e POSTGRES_PASSWORD=dev \
+            -e POSTGRES_DB=molecule \
+            -p 15432:5432 \
+            postgres:16
+          for i in $(seq 1 30); do
+            if docker exec "$PG_CONTAINER" pg_isready -U dev >/dev/null 2>&1; then
+              echo "Postgres ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Postgres did not become ready in 30s"
+          docker logs "$PG_CONTAINER" || true
+          exit 1
+      - name: Start Redis (docker)
+        run: |
+          docker rm -f "$REDIS_CONTAINER" 2>/dev/null || true
+          docker run -d --name "$REDIS_CONTAINER" -p 16379:6379 redis:7
+          for i in $(seq 1 15); do
+            if docker exec "$REDIS_CONTAINER" redis-cli ping 2>/dev/null | grep -q PONG; then
+              echo "Redis ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::Redis did not become ready in 15s"
+          exit 1
       - name: Build platform
         working-directory: platform
         run: go build -o platform-server ./cmd/server
@@ -135,17 +147,9 @@ jobs:
           exit 1
       - name: Assert migrations applied
         # Migrations auto-run at platform boot. Fail fast if they silently
-        # didn't — catches future migration-author mistakes (e.g. a new
-        # privileged op Postgres "dev" can't execute) before the E2E run.
-        # Uses docker exec into the service container's own psql — avoids
-        # a 10-20s apt-install step in the runner.
+        # didn't — catches future migration-author mistakes before the E2E run.
         run: |
-          pg_container=$(docker ps --filter "ancestor=postgres:16" --format "{{.ID}}" | head -1)
-          if [ -z "$pg_container" ]; then
-            echo "::error::Could not find postgres service container"
-            exit 1
-          fi
-          tables=$(docker exec "$pg_container" psql -U dev -d molecule -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='workspaces'")
+          tables=$(docker exec "$PG_CONTAINER" psql -U dev -d molecule -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_name='workspaces'")
           if [ "$tables" != "1" ]; then
             echo "::error::Migrations did not apply — 'workspaces' table missing"
             cat platform/platform.log || true
@@ -163,22 +167,31 @@ jobs:
           if [ -f platform/platform.pid ]; then
             kill "$(cat platform/platform.pid)" 2>/dev/null || true
           fi
+      - name: Stop service containers
+        if: always()
+        run: |
+          docker rm -f "$PG_CONTAINER" 2>/dev/null || true
+          docker rm -f "$REDIS_CONTAINER" 2>/dev/null || true
 
   shellcheck:
     name: Shellcheck (E2E scripts)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     steps:
       - uses: actions/checkout@v4
       - name: Run shellcheck on tests/e2e/*.sh
-        uses: ludeeus/action-shellcheck@master
-        env:
-          SHELLCHECK_OPTS: --severity=warning
-        with:
-          scandir: tests/e2e
+        # `ludeeus/action-shellcheck` is a Docker action (Linux-only). We rely
+        # on shellcheck being pre-installed on the self-hosted runner instead.
+        run: |
+          if ! command -v shellcheck >/dev/null 2>&1; then
+            echo "::error::shellcheck is not installed on the runner"
+            exit 1
+          fi
+          find tests/e2e -type f -name '*.sh' -print0 \
+            | xargs -0 shellcheck --severity=warning
 
   canvas-deploy-reminder:
     name: Canvas Deploy Reminder
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     needs: canvas-build
     # Only fires on direct pushes to main (i.e. after a PR merges).
     # PRs get canvas-build CI but no reminder — no deployment happens on PRs.
@@ -216,7 +229,7 @@ jobs:
 
   python-lint:
     name: Python Lint & Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     defaults:
       run:
         working-directory: workspace-template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,11 @@ jobs:
   python-lint:
     name: Python Lint & Test
     runs-on: [self-hosted, macos, arm64]
+    env:
+      # setup-python@v5 defaults to /Users/runner/hostedtoolcache which does
+      # not exist on the self-hosted runner (user is hongming-claw). Point it
+      # to the runner user's writable directory so Python 3.11 can be cached.
+      AGENT_TOOLSDIRECTORY: /Users/hongming-claw/hostedtoolcache
     defaults:
       run:
         working-directory: workspace-template

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -32,10 +32,18 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        # Required on the Apple-silicon self-hosted runner — Fly tenant machines
+        # pull linux/amd64, and buildx needs binfmt handlers in Docker Desktop's
+        # VM to emulate amd64 during the build.
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64
 
       - name: Set up Docker Buildx
         # Buildx enables cache-from/cache-to via GHA cache and multi-arch
@@ -75,10 +83,13 @@ jobs:
         # GHCR (or vice versa) — each registry's failure mode is isolated.
         # GHA cache is shared because both steps re-use the same Dockerfile
         # context + build args.
+        # Explicit linux/amd64 target: the runner is Apple-silicon (arm64),
+        # but Fly tenant machines are amd64. QEMU handles the emulation.
         uses: docker/build-push-action@v5
         with:
           context: ./platform
           file: ./platform/Dockerfile
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:latest
@@ -99,6 +110,7 @@ jobs:
         with:
           context: ./platform
           file: ./platform/Dockerfile
+          platforms: linux/amd64
           push: true
           tags: |
             ${{ env.FLY_IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary

Migrates every CI job in this repo from GitHub-hosted `ubuntu-latest` to a self-hosted Apple-silicon runner (`[self-hosted, macos, arm64]`, registered at the Molecule-AI org level) to sidestep GitHub-hosted minute rate limits.

## What changed

**`.github/workflows/ci.yml`** — all 7 jobs migrated:

| Job | Adaptation |
|---|---|
| platform-build | `runs-on` swap only (setup-go has native darwin-arm64) |
| canvas-build | `runs-on` swap only |
| mcp-server-build | `runs-on` swap only |
| e2e-api | **Non-trivial:** replaced `services: postgres/redis` with inline `docker run` startup steps (GHA `services:` is Linux-only on self-hosted runners). Ports remapped to `15432`/`16379` to avoid collision with whatever the host exposes on the standard ports. Containers named `molecule-ci-postgres` / `molecule-ci-redis`, torn down in `if: always()`. Postgres readiness still gated on `pg_isready` via `docker exec`. |
| shellcheck | **Non-trivial:** `ludeeus/action-shellcheck` is a Docker action (Linux-only). Replaced with a native `shellcheck --severity=warning` invocation against `find tests/e2e -name '*.sh'`. |
| canvas-deploy-reminder | `runs-on` swap only (uses `gh api`, pre-installed on runner) |
| python-lint | `runs-on` swap only |

**`.github/workflows/publish-platform-image.yml`** — platform image publisher:

- Added `docker/setup-qemu-action@v3` with `platforms: linux/amd64`.
- Added `platforms: linux/amd64` to both `docker/build-push-action@v5` calls. The self-hosted runner is arm64 but Fly tenant machines pull `linux/amd64`, so QEMU-emulated cross-arch builds are required. GHA cache-from/cache-to behavior unchanged.
- ⚠️ Expect slower builds — amd64 emulation under QEMU on an 8GB M1 is measurably slower than a native ubuntu-latest amd64 build. Monitor the first run closely.

## Runner host prereqs (already set up on `hongming-m1-mini`)

- Docker Desktop installed + running (needed by `e2e-api` and `publish-platform-image`)
- `docker` symlinked into `/opt/homebrew/bin`
- `shellcheck` v0.11.0 installed into `/opt/homebrew/bin`
- `gh`, Go, Node, Python all on PATH; `setup-*` actions handle version pinning per job

## Risks & things to watch on the first run

1. **Docker Desktop must be running** — if it crashes/quits, `e2e-api` and `publish-platform-image` fail. No graceful fallback.
2. **QEMU cross-arch image builds are slow + RAM-heavy** on the 8GB M1. If `publish-platform-image` OOMs, the mitigation is to split Dockerfile builds into multi-stage with a native Go cross-compile (no emulation needed for the Go build stage) — can be a follow-up PR.
3. **Self-hosted runner has persistent filesystem state.** Cached `node_modules`, Go build cache, etc. will grow across runs. Add a workspace-cleanup step or monitor `_work/` disk usage.
4. **Concurrency** — this one runner processes jobs serially. Multiple PRs will queue.
5. **Port collisions** — CI postgres/redis use `15432`/`16379`. If something else on the host takes those later, `e2e-api` will fail loudly.
6. **`services:` removal means migrations check uses the known container name** (`$PG_CONTAINER` env) instead of `docker ps --filter ancestor=postgres:16`, which is actually more reliable.

## Test plan

- [ ] Watch the first run on this PR end-to-end — every job must turn green
- [ ] Confirm `e2e-api` postgres/redis containers are cleaned up after both success and failure runs
- [ ] Confirm `publish-platform-image` pushes a working `linux/amd64` image to GHCR + Fly registry (manual `workflow_dispatch` on main after merge is a safer way to validate than waiting for the next platform-touching merge)
- [ ] Watch runner disk usage after a few runs — add cleanup step if `_work/` grows unbounded