### PR TITLE
fix(template): revert Security Auditor cron to 2x/day (closes #178)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -554,10 +554,10 @@ workspaces:
               5. Use commit_memory to save security patterns and concerns
               6. Wait for tasks from Dev Lead.
             schedules:
-              - name: Hourly security audit
-                cron_expr: "1,11,21,31,41,51 * * * *"
+              - name: Security audit (every 12h)
+                cron_expr: "7 6,18 * * *"
                 prompt: |
-                  Recurring hourly security audit. Be thorough on recently changed code.
+                  Recurring security audit. Be thorough and incremental.
 
                   1. SETUP:
                      cd /workspace/repo && git pull 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Reverts Security Auditor `cron_expr` from `1,11,21,31,41,51 * * * *` (every 10 min, 144×/day) back to `7 6,18 * * *` (twice daily)
- Updates schedule name from "Hourly security audit" → "Security audit (every 12h)"
- Retains all prompt improvements from PR #159 (DAST teardown, PM deliverable routing, explicit issue filing)

## Root cause

PR #159 changed Security Auditor from 2×/day → 144×/day. Combined with other hourly evolution-lever crons across the org (~50+ fires/hour org-wide), this is the likely root cause of the P0 OAuth quota exhaustion in issue #160 (token resets April 17 23:00 UTC).

## Impact

| Cadence | Fires/day | Change |
|---------|-----------|--------|
| Before fix | 2 | — |
| PR #159 regression | 144 | +144× |
| After this PR | 2 | Restored |

## What's preserved

The improved audit prompt from PR #159 is fully retained: DAST teardown (prevents test-workspace leaks like incident #17), mandatory PM deliverable routing per cycle, GH issue filing for critical/high findings, and the `last-security-audit-sha` incremental diff approach.

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)