### PR TITLE
fix(ci): set AGENT_TOOLSDIRECTORY on python-lint job (self-hosted runner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,14 @@ jobs:
     defaults:
       run:
         working-directory: workspace-template
+    env:
+      # Self-hosted runner workaround: actions/setup-python hardcodes
+      # /Users/runner/hostedtoolcache, which doesn't exist on the Mac mini
+      # runner (user is hongming-claw). Redirect the tool cache into the
+      # runner's own _work/_tool dir. AGENT_TOOLSDIRECTORY is the canonical
+      # override honoured by setup-python v5.
+      AGENT_TOOLSDIRECTORY: /Users/hongming-claw/actions-runner/_work/_tool
+      RUNNER_TOOL_CACHE: /Users/hongming-claw/actions-runner/_work/_tool
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
Python lint was the last failing job on #186's runner migration. Belt-and-suspenders fix via job-level env: block since the runner's .env override didn't propagate. Testing immediately.