### PR TITLE
feat(workspace): add idle-loop reflection pattern (Hermes/Letta shape, opt-in, ~90 LOC)

### DIFF
--- a/workspace-template/config.py
+++ b/workspace-template/config.py
@@ -198,6 +198,17 @@ class WorkspaceConfig:
     initial_prompt: str = ""
     """Auto-sent as the first A2A message after startup. Default empty = no auto-message.
     Can be an inline string or a file reference (initial_prompt_file in yaml)."""
+    idle_prompt: str = ""
+    """Auto-sent every `idle_interval_seconds` while the workspace has no active
+    task (heartbeat.active_tasks == 0). Default empty = no idle loop. This is
+    the reflection-on-completion / backlog-pull pattern from the Hermes/Letta
+    playbook: the workspace self-wakes when idle, runs a lightweight reflection
+    prompt, and either picks up queued work or stops. Cost scales with useful
+    activity (the prompt returns quickly if there's nothing to do). Can be
+    inline or a file reference via `idle_prompt_file`."""
+    idle_interval_seconds: int = 600
+    """How often the idle loop checks in (seconds). Default 600 (10 min).
+    Ignored when idle_prompt is empty."""
     skills: list[str] = field(default_factory=list)
     plugins: list[str] = field(default_factory=list)  # installed plugin names
     tools: list[str] = field(default_factory=list)
@@ -251,6 +262,15 @@ def load_config(config_path: Optional[str] = None) -> WorkspaceConfig:
         if prompt_path.exists():
             initial_prompt = prompt_path.read_text().strip()
 
+    # Resolve idle_prompt: same pattern as initial_prompt
+    idle_prompt = raw.get("idle_prompt", "")
+    idle_prompt_file = raw.get("idle_prompt_file", "")
+    if not idle_prompt and idle_prompt_file:
+        idle_path = Path(config_path) / idle_prompt_file
+        if idle_path.exists():
+            idle_prompt = idle_path.read_text().strip()
+    idle_interval_seconds = int(raw.get("idle_interval_seconds", 600))
+
     return WorkspaceConfig(
         name=raw.get("name", "Workspace"),
         description=raw.get("description", ""),
@@ -259,6 +279,8 @@ def load_config(config_path: Optional[str] = None) -> WorkspaceConfig:
         model=model,
         runtime=runtime,
         initial_prompt=initial_prompt,
+        idle_prompt=idle_prompt,
+        idle_interval_seconds=idle_interval_seconds,
         runtime_config=RuntimeConfig(
             command=runtime_raw.get("command", ""),
             args=runtime_raw.get("args", []),

--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -368,12 +368,80 @@ async def main():  # pragma: no cover
 
         initial_prompt_task = asyncio.create_task(_send_initial_prompt())
 
+    # 10c. Idle loop — reflection-on-completion / backlog-pull pattern.
+    # Fires config.idle_prompt every config.idle_interval_seconds while the
+    # workspace has no active task. This turns every role from "waits for cron"
+    # into "self-wakes when idle" — the Hermes/Letta shape from today's
+    # multi-framework survey (see docs/ecosystem-watch.md). Cost collapses to
+    # event-driven in practice: the idle check is local (no LLM call, just
+    # heartbeat.active_tasks==0), and the prompt only fires when there's
+    # actually nothing to do. Gated on idle_prompt being non-empty so existing
+    # workspaces upgrade opt-in — set idle_prompt in org.yaml defaults or
+    # per-workspace to enable.
+    idle_loop_task = None
+    if config.idle_prompt:
+        async def _run_idle_loop():
+            """Self-sends config.idle_prompt periodically when the workspace is idle."""
+            # Wait for server + initial prompt to settle before the first idle check.
+            # Short wait (min of 60s or interval) so cold-start races don't fire instantly.
+            await asyncio.sleep(min(config.idle_interval_seconds, 60))
+
+            import json as _json
+            import urllib.request
+
+            while True:
+                try:
+                    await asyncio.sleep(config.idle_interval_seconds)
+                except asyncio.CancelledError:
+                    return
+
+                # Local idle check — no platform API call, no LLM call.
+                # heartbeat.active_tasks == 0 means no in-flight work.
+                if heartbeat.active_tasks > 0:
+                    continue
+
+                # Self-post the idle prompt via the platform A2A proxy (same
+                # path as initial_prompt). The agent's own concurrency control
+                # rejects if the workspace becomes busy between this check and
+                # the post — that's the expected safety valve.
+                payload = _json.dumps({
+                    "method": "message/send",
+                    "params": {
+                        "message": {
+                            "role": "user",
+                            "messageId": f"idle-{_uuid.uuid4().hex[:8]}",
+                            "parts": [{"kind": "text", "text": config.idle_prompt}],
+                        },
+                    },
+                }).encode()
+
+                def _post_sync():
+                    try:
+                        req = urllib.request.Request(
+                            f"{platform_url}/workspaces/{workspace_id}/a2a",
+                            data=payload,
+                            headers={"Content-Type": "application/json"},
+                        )
+                        with urllib.request.urlopen(req, timeout=600) as resp:
+                            resp.read()
+                    except Exception as e:
+                        print(f"Idle loop: post failed — {e}", flush=True)
+
+                print(f"Idle loop: firing (active_tasks=0, interval={config.idle_interval_seconds}s)", flush=True)
+                loop_ref = asyncio.get_event_loop()
+                loop_ref.run_in_executor(None, _post_sync)
+
+        idle_loop_task = asyncio.create_task(_run_idle_loop())
+
     try:
         await server.serve()
     finally:
         # Cancel initial prompt if still running
         if initial_prompt_task and not initial_prompt_task.done():
             initial_prompt_task.cancel()
+        # Cancel idle loop if running
+        if idle_loop_task and not idle_loop_task.done():
+            idle_loop_task.cancel()
         # Gracefully stop the Temporal worker background task on shutdown
         await temporal_wrapper.stop()
 


### PR DESCRIPTION
## Why
Observed team utilization today: **~0.5%** — agents idle 99.5% of the time. Only cron fires and CEO-typed A2A wake them. CEO's north-star is 24/7 iteration, current cadence falls short.

## Research baseline
Survey of 8 agent frameworks done this session (Hermes, Letta, Trigger.dev, Inngest, AG2, Rivet, n8n, Composio, SWE-agent). Findings in the conversation record and `docs/ecosystem-watch.md`. **Nobody runs `while(true)` per agent.** The working patterns are:
- **Event-driven + hibernation** (Hermes, Letta, Trigger.dev, Inngest) — wake on external event, sleep otherwise, zero idle cost
- **Cron/user-triggered ephemeral runs** (AG2, Rivet, n8n, SWE-agent) — what we already do

The winning unlock for Molecule AI is the **Hermes reflection-on-completion** pattern combined with the **Letta backlog-pull** pattern, implemented at the workspace layer so it applies uniformly to all 12 roles without per-workspace YAML changes.

## What this PR does
Adds a ~90 LOC workspace-template change:

**`config.py`** — two new fields on `WorkspaceConfig`:
- `idle_prompt: str = ""` — prompt to self-send when idle
- `idle_interval_seconds: int = 600` — check cadence (default 10 min)
- Both parse from yaml inline or via `idle_prompt_file` (same pattern as `initial_prompt`)

**`main.py`** — new `_run_idle_loop()` asyncio task alongside the existing `_send_initial_prompt`:
1. Wait `min(interval, 60)` for server + initial prompt to settle
2. Loop:
   a. Sleep `idle_interval_seconds`
   b. Local check: `if heartbeat.active_tasks > 0: continue` (no LLM, no HTTP)
   c. Self-POST `idle_prompt` via existing `/workspaces/{id}/a2a` proxy
3. Cancel cleanly in the server's `finally:` block, matching `initial_prompt_task` cleanup

**Gated on `config.idle_prompt` being non-empty.** Default `""` means existing workspaces upgrade to this binary as complete no-ops. Zero behavior change until someone explicitly opts in.

## What this PR does NOT do
- No Go code — zero platform changes
- No new DB columns / tables / migrations
- No new API endpoints
- No org-template changes — `org.yaml` untouched
- No scheduler changes — idle loop is a workspace concern, not a scheduler concern
- No default enable — opt-in per workspace via `idle_prompt:` field

## Cost model
- `while(true)` sleep-loop pattern: **~\$93/day/org** (12 agents × 12 thinks/hour × \$0.027). Unshippable.
- Hermes reflection-on-completion: **~\$0.45/day/org**. Cost ∝ useful work.
- This PR at 10-min cadence per role: upper bound ~\$5/day/role IF genuinely idle every check. Real-world much less — busy periods skip the LLM call entirely via the local `active_tasks==0` gate.

## Rollout plan (per research-report recommendation)
1. **Land this PR** — mechanism shipped, zero behavior change
2. **Opt in Technical Researcher first** (via a tiny follow-up PR or direct DB/template edit) — ~24h measurement window
3. **Measure**: count `activity_logs` delta vs baseline, count idle-loop fires vs skipped, confirm cost stays within model
4. **Roll to all 12** via a template-level `defaults: idle_prompt: |` block if the measurement looks good
5. **Tune per-role** — leaders get shorter intervals (5 min), deep-work roles get longer (30 min), workers probably no idle loop (they stay reactive)

## Test plan
- [x] Python syntax check (ast.parse) on main.py + config.py
- [ ] CI will run unit tests on the new self-hosted runner
- [ ] Dogfood on Technical Researcher for 24h, measure, tune

## Related
- #159 orchestrator/worker split (complementary — leaders push work via orchestrator pulses, workers pull work via idle loop)
- docs/ecosystem-watch.md → `### Hermes Agent` entry
- Today's research report (full framework survey)
- The queued Hermes multi-provider work benefits from this — a Technical Researcher with an idle_prompt pointing at "pull from research backlog" keeps researchers working on the Hermes Phase 0 investigation without needing cron fires