### PR TITLE
fix(security): C2 from #169 — reject spoofed source_id in activity.Report

### DIFF
--- a/platform/internal/handlers/activity.go
+++ b/platform/internal/handlers/activity.go
@@ -329,7 +329,18 @@ func (h *ActivityHandler) Report(c *gin.Context) {
 	if reqBody == nil {
 		reqBody = body.Metadata
 	}
+	// C2 (from #169) — source_id spoof defense. WorkspaceAuth middleware
+	// already proves the caller owns :id, but that check doesn't cover the
+	// body field. Without this guard, workspace A authenticated for its own
+	// /activity endpoint could still set source_id=<workspace B's UUID> in
+	// the payload and attribute the log to B. Reject any body where
+	// source_id is non-empty AND differs from the authenticated workspace.
+	// Empty source_id falls through to the default-to-self branch below.
 	sourceID := body.SourceID
+	if sourceID != "" && sourceID != workspaceID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "source_id must match authenticated workspace"})
+		return
+	}
 	if sourceID == "" {
 		sourceID = workspaceID
 	}


### PR DESCRIPTION
Cherry-picks the one unique fix from #169. Other findings (C1/C3/C4/C5/C6) are already covered on main — see #169 review comment.