### PR TITLE
chore(template): enable idle-loop pilot on Technical Researcher (#205 follow-up)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -268,6 +268,45 @@ workspaces:
             role: AI frameworks and protocol evaluation
             files_dir: technical-researcher
             plugins: [browser-automation]
+            # Idle-loop pilot (#205) — Technical Researcher is the first workspace
+            # to opt in to the reflection-on-completion pattern. Measure
+            # activity_logs delta over 24h, then roll to the rest of the research
+            # team if it produces useful backlog-pull dispatches.
+            idle_interval_seconds: 600
+            idle_prompt: |
+              You have no active task. Backlog-pull + reflect, under 60 seconds:
+
+              1. search_memory "research-backlog:technical-researcher" — pull any
+                 stashed research questions from prior cron fires or Research Lead
+                 delegations. If you find one:
+                 - delegate_task to Research Lead with a concrete deliverable spec:
+                   "Research <topic>. Report in <N> words. Link 2-3 primary sources.
+                    When done, route audit_summary to PM with category=research."
+                 - commit_memory removing that item from the backlog (or replacing
+                   with the next one) so you don't re-dispatch on the next tick.
+
+              2. If the backlog is empty, look at your LAST memory entry from the
+                 Hourly plugin curation cron. Did that finding surface a follow-up
+                 study worth doing? (Examples: "which providers does Hermes Agent
+                 actually support beyond our list?", "is there a newer MCP server
+                 we should evaluate?", "does <framework> have feature parity with
+                 <other framework>?") If yes:
+                 - File a GH issue with the question body, label `research`.
+                 - commit_memory "research-backlog:technical-researcher" with the
+                   same question so the NEXT idle tick picks it up via step 1.
+
+              3. If neither backlog nor reflection produced anything actionable,
+                 write "tr-idle HH:MM — clean" to memory and stop. Do NOT fabricate
+                 busy work; idle-clean is a legitimate outcome.
+
+              Hard rules:
+              - Max 1 A2A send per idle tick.
+              - If Research Lead is currently busy (check workspaces API), skip
+                step 1 and go straight to step 2 (which doesn't delegate).
+              - Under 60 seconds wall-clock per tick. If you're still thinking at
+                45s, commit to one decision, ship it, stop.
+              - NEVER call any cron's own prompt from here — idle_prompt is a
+                lightweight reflection, not a re-run of the hourly survey.
             schedules:
               - name: Hourly plugin curation
                 cron_expr: "22 * * * *"


### PR DESCRIPTION
## Summary
Opt-in first workspace for the #205 idle-loop mechanism. Technical Researcher gets a reflection-on-completion idle_prompt at 10-min cadence. This is the measurement pilot before rolling to the full team.

## Why TR first
- Research-heavy, naturally bursty, lots of idle time between hourly cron fires
- Non-user-facing (zero UX risk)
- Already has a clear backlog shape (findings from the plugin-curation cron feed follow-up studies)
- Vision-free → cost per idle tick is pure text, easy to reason about

## What the idle_prompt does
1. **Backlog-pull** — search_memory for stashed research questions. If found → delegate_task to Research Lead with a concrete spec, commit_memory to remove from backlog.
2. **Reflection fallback** — if backlog empty, look at last plugin-curation memory entry. If it surfaces a follow-up question, file a GH issue + put on backlog for next tick.
3. **Idle-clean outcome** — if neither, write `"tr-idle HH:MM — clean"` to memory and stop. No fabricated busy work.

Hard rules: max 1 A2A per tick, skip step 1 if Research Lead busy, under 60s wall-clock.

## Rollout
- **This PR** enables TR only via org.yaml
- **Apply locally** immediately per `feedback_apply_template_locally_too.md` — edit TR's live `/configs/config.yaml` and restart the container. Measurement clock starts from that restart.
- **Next 24h** measure: count idle-fired delegations vs idle-clean outcomes, confirm Research Lead isn't flooded
- **If green** → roll to Market Analyst + Competitive Intelligence in a follow-up
- **If noisy** → dial interval up to 1200-1800s

## Related
- #205 (idle-loop mechanism — just merged in commit 54eb8d7)
- #208 (Hermes Phase 1 — also just merged in commit 381a3c8)
- #212 (#211 migration runner fix — also just merged in commit 56801ce)
- `docs/ecosystem-watch.md` → `### Hermes Agent` (reflection-on-completion pattern reference)

## Test plan
- [x] YAML parses (`python -c yaml.safe_load`)
- [x] TR workspace entry validated: idle_prompt non-empty, idle_interval_seconds=600
- [ ] CI on self-hosted runner
- [ ] Apply to live TR in same cycle (see below) — not waiting for merge per the template-rule-changes feedback
- [ ] 24h measurement window + report