### PR TITLE
fix(workspace-template): send auth_headers() on register

### DIFF
--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -17,6 +17,7 @@ from a2a.types import AgentCard, AgentCapabilities, AgentSkill
 
 from adapters import get_adapter, AdapterConfig
 from config import load_config
+from platform_auth import auth_headers
 from heartbeat import HeartbeatLoop
 from preflight import run_preflight, render_preflight_report
 from builtin_tools.awareness_client import get_awareness_config
@@ -192,6 +193,7 @@ async def main():  # pragma: no cover
                     "url": workspace_url,
                     "agent_card": agent_card_dict,
                 },
+                headers=auth_headers(),
             )
             print(f"Registered with platform: {resp.status_code}")
             # Phase 30.1 — capture the auth token issued at first register.


### PR DESCRIPTION
## Summary
- `workspace-template/main.py` was posting to `/registry/register` without an `Authorization` header. First-ever register works (bootstrap path), but every re-register (container restart, crash recovery, redeploy) hits C18 hijack-prevention and 401s.
- Symptom: workspace status stuck at `provisioning` even though the agent is healthy — `heartbeat.py` already uses `auth_headers()` so heartbeats succeed, but status never transitions back to `online`.
- Fix: import `auth_headers` in `main.py` and attach it to the register call. Unchanged bootstrap behavior (first boot returns `{}`), authenticated on every subsequent register.

Closes #215

## Test plan
- [x] Reproduced locally: restart an online workspace → register returns 401, status stuck at `provisioning`.
- [x] With patch applied: restart → register returns 200, status transitions `provisioning` → `online`.
- [x] `python3 -c "import ast; ast.parse(open('workspace-template/main.py').read())"` passes.
- [ ] CI: `python-lint` + `e2e-api` should pass unchanged (no route behavior changed, only client-side header addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)