### PR TITLE
fix(reno-stars): default plugins to browser-automation

### DIFF
--- a/org-templates/reno-stars/org.yaml
+++ b/org-templates/reno-stars/org.yaml
@@ -7,6 +7,8 @@ defaults:
   runtime: claude-code
   tier: 3
   model: opus
+  plugins:
+    - browser-automation
   initial_prompt: |
     You just started. Set up silently — do NOT contact other agents yet.
     1. Read your system prompt at /configs/system-prompt.md — this defines YOUR role


### PR DESCRIPTION
## Summary
- One-line YAML: adds `plugins: [browser-automation]` to `defaults:` in `org-templates/reno-stars/org.yaml`.
- Every reno-stars agent uses the host Chrome via CDP for social / GBP / invoicing / directory work. Without the plugin on import, agents spawn their own Chromium and lose all host sessions.
- Per-agent opt-out via `!browser-automation` remains available (PR #71 UNION merge).

Closes #213

## Test plan
- [x] `POST /org/import` with `{\"dir\":\"reno-stars\"}` → every workspace has `browser-automation` in `GET /workspaces/:id/plugins`.
- [x] `/configs/plugins/browser-automation/skills/browser-automation/SKILL.md` present in every container.
- [ ] CI unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)