### PR TITLE
fix(workspace-template): add auth_headers() to /registry/register POST

### DIFF
--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -30,6 +30,7 @@ from initial_prompt import (
     mark_initial_prompt_attempted,
     resolve_initial_prompt_marker,
 )
+from platform_auth import auth_headers
 
 
 def get_machine_ip() -> str:  # pragma: no cover
@@ -195,6 +196,7 @@ async def main():  # pragma: no cover
                     "url": workspace_url,
                     "agent_card": agent_card_dict,
                 },
+                headers=auth_headers(),
             )
             print(f"Registered with platform: {resp.status_code}")
             # Phase 30.1 — capture the auth token issued at first register.


### PR DESCRIPTION
## Summary

- `workspace-template/main.py` register call was missing `headers=auth_headers()` on the `POST /registry/register` request
- Workspaces that already have a persisted token (every restart after first boot) sent an unauthenticated request and received 401 from the platform — breaking re-registration after restart
- Fix: import `auth_headers` at module level, pass `headers=auth_headers()` to the POST
- **No regression on first boot**: `auth_headers()` returns `{}` when no token file exists yet, so the initial register call is unchanged; the platform still issues a token on the 200 response and `save_token()` persists it for subsequent restarts

## Files Changed

- `workspace-template/main.py` — import `auth_headers` from `platform_auth`, pass it to register POST

## Test plan

- [ ] Fresh workspace: boots, registers (200), saves token — same as before
- [ ] Restarted workspace: re-registers with `Authorization: Bearer <token>` header, no 401
- [ ] `cd workspace-template && python -m pytest -v` passes
- [ ] CI python-lint green

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)