### PR TITLE
fix(security): gate /channels/discover behind AdminAuth (#250)

### DIFF
--- a/platform/internal/router/router.go
+++ b/platform/internal/router/router.go
@@ -381,7 +381,13 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 	wsAuth.DELETE("/channels/:channelId", chh.Delete)
 	wsAuth.POST("/channels/:channelId/send", chh.Send)
 	wsAuth.POST("/channels/:channelId/test", chh.Test)
-	r.POST("/channels/discover", chh.Discover)
+	// #250: /channels/discover is an admin-setup helper (takes a bot
+	// token, asks the vendor "what chats is this token a member of?").
+	// Leaving it unauthenticated turned it into a bot-token oracle plus
+	// a drive-by deleteWebhook side effect against any valid token an
+	// attacker could probe. AdminAuth matches the intent — it's a
+	// platform-operator helper, not a per-workspace route.
+	r.POST("/channels/discover", middleware.AdminAuth(db.DB), chh.Discover)
 	r.POST("/webhooks/:type", chh.Webhook)
 
 	// WebSocket


### PR DESCRIPTION
Closes #250 (MEDIUM).

## Summary
\`POST /channels/discover\` was on the open router. Any unauthenticated caller could:
1. Submit an arbitrary Telegram bot token and use a 200/400 response as a **token validity oracle**
2. Trigger \`tgbotapi.DeleteWebhookConfig\` as a side effect — calling this in a loop disables any valid target bot's webhook delivery
3. Amplify rate-limit cost against the target token (getMe + deleteWebhook + getUpdates per call)

## Fix
One-line: wrap the route with \`middleware.AdminAuth(db.DB)\`. Matches the pattern used on \`/admin/liveness\`, \`/events\`, \`/bundles/export\`, \`/templates/import\`, etc. from PRs #167/#190/#200.

## Why no new test
\`AdminAuth\` behavior is covered in \`platform/internal/middleware/wsauth_middleware_test.go\`; this PR only adds an additional route to that already-tested middleware. A full router integration test would require mocking every dependency of \`router.Setup\` — excessive for a one-line wire-up.

A load-bearing code comment cites #250 so a future reviewer can't revert without an issue citation.

## Test plan
- [x] \`go build ./...\` green
- [ ] CI runs (currently queued on self-hosted runner)
- [ ] After merge, verify \`curl -X POST http://localhost:8080/channels/discover\` without bearer returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)