### PR TITLE
fix(tests): hermes provider env-var leak broke test_hermes_smoke

### DIFF
--- a/workspace-template/tests/test_hermes_providers.py
+++ b/workspace-template/tests/test_hermes_providers.py
@@ -46,11 +46,30 @@ _ALL_PROVIDER_ENV_VARS = (
 
 
 @pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Clear every provider env var before each test so runs are deterministic."""
-    for key in _ALL_PROVIDER_ENV_VARS:
-        monkeypatch.delenv(key, raising=False)
-    yield
+def _clean_env():
+    """Clear every provider env var before each test and restore to the
+    exact pre-test state on teardown.
+
+    Implementation note: earlier version used pytest's monkeypatch fixture,
+    which tracks deltas from the state at fixture entry. That was buggy
+    because several tests in this file mutate os.environ directly
+    (os.environ["HERMES_API_KEY"] = ...), bypassing monkeypatch's
+    tracking. The direct mutations leaked into the NEXT test file
+    (test_hermes_smoke.py::test_create_executor_raises_without_keys),
+    causing a file-order-dependent failure. Pure snapshot/restore
+    avoids all the delta-tracking edge cases.
+    """
+    saved = {k: os.environ.get(k) for k in _ALL_PROVIDER_ENV_VARS}
+    for k in _ALL_PROVIDER_ENV_VARS:
+        os.environ.pop(k, None)
+    try:
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
 
 def test_registry_is_populated():


### PR DESCRIPTION
## Summary
Pre-existing flaky test exposed by the queue of Hermes PRs (#240, #255). When the full \`workspace-template\` suite ran in collection order, \`test_hermes_smoke.py::test_create_executor_raises_without_keys\` failed with **\"DID NOT RAISE ValueError\"**. The failure only surfaced when \`test_hermes_providers\` ran first — reproducible on main too.

## Root cause
\`test_hermes_providers\` had an autouse fixture that used \`monkeypatch.delenv\` on entry, but several tests in that file mutate \`os.environ\` directly:
\`\`\`python
os.environ[\"HERMES_API_KEY\"] = \"hermes-test-key\"
\`\`\`
\`monkeypatch\` only tracks its own deltas, so direct mutations persisted past the fixture teardown and leaked across the file boundary into \`test_hermes_smoke\`, which then saw \`HERMES_API_KEY\` set when it expected absence.

## Fix
Replace monkeypatch-based fixture with pure snapshot/restore:
\`\`\`python
@pytest.fixture(autouse=True)
def _clean_env():
    saved = {k: os.environ.get(k) for k in _ALL_PROVIDER_ENV_VARS}
    for k in _ALL_PROVIDER_ENV_VARS:
        os.environ.pop(k, None)
    try:
        yield
    finally:
        for k, v in saved.items():
            if v is None: os.environ.pop(k, None)
            else: os.environ[k] = v
\`\`\`
Deterministic regardless of whether a test uses monkeypatch, direct mutation, or neither. Comment added documenting WHY we switched away from monkeypatch so a future reviewer doesn't revert it.

## Verify
\`\`\`
python3 -m pytest tests/ --tb=no -p no:warnings
1169 passed, 9 skipped, 2 xfailed in 3.81s
\`\`\`
Fix-only file: \`workspace-template/tests/test_hermes_providers.py\`. No production code touched.

## Unblocks
- #240 Hermes Phase 2a — blocked on CI going green before merge
- #255 Hermes Phase 2b — stacked on #240, same blocker

🤖 Generated with [Claude Code](https://claude.com/claude-code)