### PR TITLE
fix(reno-stars): SEO Builder delegates code blockers to Dev Leader, not human

### DIFF
--- a/org-templates/reno-stars/marketing-leader/CLAUDE.md
+++ b/org-templates/reno-stars/marketing-leader/CLAUDE.md
@@ -2,11 +2,13 @@
 
 You are a hands-on worker agent for Reno Stars Construction Inc.
 
-## Critical Rule: DO NOT DELEGATE
+## Critical Rule: DO NOT DELEGATE SUB-AGENTS
 
-**You do ALL the work yourself.** Do NOT use `delegate_task` or `delegate_task_async` to send work to other agents. Your system prompt at `/configs/system-prompt.md` defines your full scope — execute tasks directly.
+**You do ALL marketing work yourself.** Do NOT use `delegate_task` or `delegate_task_async` to spawn sub-agents under you — your system prompt at `/configs/system-prompt.md` defines your full marketing scope; execute those tasks directly.
 
-The only exception is Business Intelligence (the root agent) which delegates to you.
+**Exception: sibling handoff for scope mismatches.** When a task in your marketing work surfaces something that isn't marketing — e.g., the seo-builder finds a code-level metadata bug that can't be fixed via DB — you MAY delegate to a PEER (sibling under Business Intelligence) whose scope covers it. Example: SEO Builder → Dev Leader for Next.js code fixes. See the individual skill docs (seo-builder.md, social-media-poster.md) for when/how.
+
+This is not "delegation down the hierarchy" — it's lateral routing. Business Intelligence still orchestrates overall; you just avoid bothering the human when a sibling agent can close the loop.
 
 ## Communication Tools (use sparingly)
 

--- a/org-templates/reno-stars/marketing-leader/seo-specialist/skills/seo-builder.md
+++ b/org-templates/reno-stars/marketing-leader/seo-specialist/skills/seo-builder.md
@@ -73,10 +73,43 @@ Chinese (zh) pages are performing well in search (zh/guides at position 4.4). Af
 - If any ZH translation is machine-generated boilerplate, flag it for human review
 - When creating new EN content (BUILD_NEW mode), always create the ZH version in the same commit
 
+**Code-level blockers (hand off to Dev Leader — do NOT escalate to human):**
+
+Some pages have metadata driven by code (e.g., `app/[locale]/services/bathroom/white-rock/page.tsx` overrides layout metadata, or `messages/en.json` strings exceed Google's 160-char description cap). You can't fix those via DB updates from this cron.
+
+When you find one, **delegate to Dev Leader** via A2A — do NOT list it under "ACTION ITEMS (human)" in the Telegram report:
+
+1. Find Dev Leader's workspace ID:
+   ```
+   list_peers()  # returns [{id, name, role, ...}]
+   ```
+   Pick the peer whose role mentions "dev" / "code" / "automation".
+
+2. Delegate with enough context to fix without a round-trip:
+   ```
+   delegate_task(
+     workspace_id=<dev-leader-id>,
+     task=f\"\"\"
+     Fix code-level SEO blockers found during SEO Builder Run {run_num} ({date}).
+     File 1: /Users/renostars/.openclaw/workspace/reno-stars-nextjs-prod/app/[locale]/services/bathroom/white-rock/page.tsx
+       - Issue: metadata override bypasses the DB-driven title/description used elsewhere
+       - GSC: 315 impressions, position 24.4, target query "bathroom renovation white rock"
+       - Fix: replace hard-coded `export const metadata` with a `generateMetadata` call that reads from the pages table (same pattern as /en/areas/*)
+     File 2: /Users/renostars/.openclaw/workspace/reno-stars-nextjs-prod/messages/en.json (key: guides.wholeHouseVancouverCost.metaDescription)
+       - Issue: 176 chars exceeds Google's 160-char cap
+       - Fix: trim to <160 while keeping the keyword "whole house renovation cost vancouver" in the first 100c
+     Deploy after merge. Reply with PR URL when done.
+     \"\"\"
+   )
+   ```
+
+3. In the Telegram report, list these under "🔧 Handed off to Dev Leader" — NOT "ACTION ITEMS (human)". Only use "ACTION ITEMS (human)" for things that genuinely need a human (e.g., Yelp email verification requires clicking a link in the owner's inbox).
+
 **DO NOT:**
 - Build any new blog post, guide, or service-area page in this mode
 - Touch the priority queue
 - Run STEP 0 audit (skip the PageSpeed/W3C/SSL/Schema/Headers checks unless something CRITICAL surfaces while editing)
+- Escalate code-level blockers to the human — always delegate to Dev Leader first
 
 Batch everything — the goal is to improve every qualifying page each run, not drip one per day.
 


### PR DESCRIPTION
## Summary
Marketing Leader's SEO Builder now hands code-level blockers to its Dev Leader sibling via A2A instead of flagging them as "ACTION ITEMS (human)".

## Why
Feedback from Run 10 (2026-04-15): agent found 2 metadata bugs that require Next.js code changes (not DB updates). It listed them under human action items even though a Dev Leader sibling exists that can fix them autonomously.

## Changes
- `seo-builder.md`: new "Code-level blockers" section with explicit `list_peers() → delegate_task(dev-leader-id, ...)` flow + context template (file path, GSC impressions/position, fix description)
- `marketing-leader/CLAUDE.md`: clarify the "DO NOT DELEGATE" rule covers sub-agents only; sibling handoff for scope mismatches is allowed

## What stays as "ACTION ITEMS (human)"
Things that genuinely need a human (Yelp email verification link clicks, Google account-linked operations, etc.) — not code bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)