### PR TITLE
fix(ci): publish-platform-image keychain + path diagnostics

### DIFF
--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -37,6 +37,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Isolate Docker config (skip keychain)
+        # The Mac mini self-hosted runner runs as a non-interactive
+        # launchd service; docker/login-action's default credential store
+        # is the macOS Keychain, which raises
+        #   error storing credentials - err: exit status 1, out:
+        #   `User interaction is not allowed. (-25308)`
+        # without an unlocked desktop session. Point DOCKER_CONFIG at a
+        # per-run temp dir so the login step writes a plain config.json
+        # that never touches the keychain. Plus diagnostics: print the
+        # docker path so a future EACCES on /usr/local/bin/docker
+        # surfaces in the log instead of via a cryptic docker-login
+        # failure mid-step.
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/docker-config"
+          echo '{"auths": {}}' > "${RUNNER_TEMP}/docker-config/config.json"
+          echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
+          echo "=== Runner docker diagnostics ==="
+          echo "PATH=$PATH"
+          command -v docker || echo "(docker not in PATH — the runner is missing the Docker CLI or it's not symlinked to a visible location)"
+          docker --version 2>&1 || true
+          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
+
       - name: Set up QEMU
         # Required on the Apple-silicon self-hosted runner — Fly tenant machines
         # pull linux/amd64, and buildx needs binfmt handlers in Docker Desktop's


### PR DESCRIPTION
Root-cause fix for the publish-platform-image failures the user flagged in triage — every run since the aa41947 self-hosted-runner migration has failed with two distinct errors on the Mac mini runner.

## Failure 1 — macOS Keychain on non-interactive runner
\`\`\`
error storing credentials - err: exit status 1, out: \`User interaction is not allowed. (-25308)\`
\`\`\`
\`docker/login-action\` persists the GHCR + Fly tokens in the macOS Keychain by default, but the Mac mini runner runs as a launchd service without an unlocked desktop session — the keychain raises -25308 on every write.

**Fix**: set \`DOCKER_CONFIG\` to a per-run temp dir containing a plain \`config.json\` before the login step, so credentials land in a file, not the keychain. Same pattern GitHub's own macos-hosted runners use in docker action docs.

## Failure 2 — \`/usr/local/bin/docker\` EACCES
\`\`\`
Unexpected error attempting to determine if executable file exists '/usr/local/bin/docker': Error: EACCES: permission denied, stat '/usr/local/bin/docker'
\`\`\`
Runner literally can't stat the Docker binary. **Not a workflow bug** — needs the user to fix on the Mac mini (reinstall Docker Desktop, or switch to Colima/OrbStack, or chmod the existing install).

This PR adds a diagnostic step that prints:
- \`PATH\`
- \`command -v docker\`
- \`docker --version\`
- \`ls -la /usr/local/bin/docker /opt/homebrew/bin/docker\`

The next run will show us exactly which path is broken instead of hiding behind a cryptic buildx error.

## What this PR does NOT fix
1. **20+ queued CI runs** in \`ci.yml\` — those are stuck because the self-hosted runner's queue throughput has degraded severely. Runs are waiting 2+ hours before being picked up. Separate runner-health issue.
2. **The docker path EACCES** — needs physical runner access.

See the triage report for the full runner-health diagnosis + user action items.

## Test plan
- [x] Workflow YAML syntax valid
- [ ] CI runs this workflow → diagnostic step surfaces the path issue
- [ ] Once the Mac mini has a readable docker, the DOCKER_CONFIG workaround should let login-action succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)