### PR TITLE
fix(security): add Referrer-Policy + Permissions-Policy headers (#282)

### DIFF
--- a/platform/internal/middleware/securityheaders.go
+++ b/platform/internal/middleware/securityheaders.go
@@ -9,12 +9,22 @@ import "github.com/gin-gonic/gin"
 //   - X-Frame-Options: DENY                                  — blocks iframe embedding (clickjacking)
 //   - Content-Security-Policy: default-src 'self'            — restricts resource loading to same origin
 //   - Strict-Transport-Security: max-age=31536000; includeSubDomains — enforces HTTPS for 1 year
+//   - Referrer-Policy: strict-origin-when-cross-origin       — avoids leaking full paths/queries in Referer
+//   - Permissions-Policy: camera=(), microphone=(), geolocation=() — denies sensor access for embedded content
 func SecurityHeaders() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Header("X-Content-Type-Options", "nosniff")
 		c.Header("X-Frame-Options", "DENY")
 		c.Header("Content-Security-Policy", "default-src 'self'")
 		c.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		// #282: these two were documented in CLAUDE.md but missing from
+		// the middleware. Referrer-Policy prevents browsers from leaking
+		// the full Referer URL to cross-origin resources (which can
+		// expose internal paths/queries). Permissions-Policy denies
+		// sensor access by default — especially relevant because the
+		// canvas embeds iframes for Langfuse traces.
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 		c.Next()
 	}
 }

--- a/platform/internal/middleware/securityheaders_test.go
+++ b/platform/internal/middleware/securityheaders_test.go
@@ -35,6 +35,10 @@ func TestSecurityHeaders(t *testing.T) {
 		{"X-Frame-Options", "DENY"},
 		{"Content-Security-Policy", "default-src 'self'"},
 		{"Strict-Transport-Security", "max-age=31536000; includeSubDomains"},
+		// #282: regression guards for the two headers that were
+		// documented in CLAUDE.md but missing from the implementation.
+		{"Referrer-Policy", "strict-origin-when-cross-origin"},
+		{"Permissions-Policy", "camera=(), microphone=(), geolocation=()"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #282 (LOW, defense-in-depth).

## Problem
\`CLAUDE.md\` documented \`SecurityHeaders()\` as setting 6 headers, but the implementation only set 4. \`Referrer-Policy\` and \`Permissions-Policy\` were silently missing.

## Fix
Added both headers with safe defaults + regression entries in the test table so a future edit that drops them again fails CI loudly:

| Header | Value | Why |
|---|---|---|
| \`Referrer-Policy\` | \`strict-origin-when-cross-origin\` | Prevents browsers from leaking full paths/queries in \`Referer\` on cross-origin navigation. Relevant because the canvas embeds Langfuse trace URLs that carry trace IDs. |
| \`Permissions-Policy\` | \`camera=(), microphone=(), geolocation=()\` | Denies sensor access to embedded iframes by default. Langfuse trace viewer and similar embeds can no longer request these without explicit delegation. |

## Test plan
- [x] \`go test -race -count=1 ./internal/middleware/ -run SecurityHeaders\` — green
- [x] Regression test entries added to the table-driven assertion loop
- [ ] CI runs (still queued on self-hosted runner per tick-33/34 runner-health issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)