### PR TITLE
feat(template): add molecule-skill-code-review to Frontend/Backend/DevOps Engineer (#280)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -481,6 +481,9 @@ workspaces:
             tier: 3
             model: opus
             files_dir: frontend-engineer
+            # #280: self-review rubric before raising a PR. Dev Lead uses
+            # the same rubric, so catching issues here cuts the review loop.
+            plugins: [molecule-skill-code-review]
             initial_prompt: |
               You just started as Frontend Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -507,7 +510,9 @@ workspaces:
             # DB migrations + runtime config changes; the @requires_approval
             # decorator stops an unattended agent from shipping a prod
             # schema mutation without a human click. UNION with defaults.
-            plugins: [molecule-hitl]
+            # #280: molecule-skill-code-review — self-review rubric before
+            # raising a PR (same rubric Dev Lead applies in review).
+            plugins: [molecule-hitl, molecule-skill-code-review]
             initial_prompt: |
               You just started as Backend Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -537,7 +542,9 @@ workspaces:
             # registry pushes, CI pipeline mutations. Any of these going
             # wrong affects every tenant; @requires_approval before
             # destructive infra ops is the point.
-            plugins: [molecule-hitl]
+            # #280: molecule-skill-code-review — self-review rubric for
+            # Dockerfiles, CI workflows, infra scripts before PR.
+            plugins: [molecule-hitl, molecule-skill-code-review]
             initial_prompt: |
               You just started as DevOps Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
Closes #280.

## Problem
\`molecule-skill-code-review\` (16-criteria rubric) was on Dev Lead + Security Auditor but NOT on the engineers who actually write the PR'd code. First rubric pass was always in review, not in self-review.

## Fix
Added the plugin to all three engineer roles. Union with defaults (PR #71 semantics). Pre-PR self-review cuts the review loop.

| Role | Before | After |
|---|---|---|
| Frontend Engineer | (defaults only) | \`[molecule-skill-code-review]\` |
| Backend Engineer | \`[molecule-hitl]\` | \`[molecule-hitl, molecule-skill-code-review]\` |
| DevOps Engineer | \`[molecule-hitl]\` | \`[molecule-hitl, molecule-skill-code-review]\` |

Issue called out FE + BE; added DevOps for consistency (Dockerfiles/CI workflows get reviewed with the same rubric).

## Test plan
- [x] YAML parses
- [x] Walk-script confirms all 5 reviewer/engineer roles' plugin lists
- [ ] Next org re-import activates the plugin on each container

🤖 Generated with [Claude Code](https://claude.com/claude-code)