### PR TITLE
chore(ci): serialize e2e-api across runs to prevent docker collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,14 @@ jobs:
     name: E2E API Smoke Test
     runs-on: [self-hosted, macos, arm64]
     timeout-minutes: 15
+    # Serialize across ALL CI runs globally. With multiple self-hosted
+    # runners, two e2e-api jobs could otherwise execute concurrently and
+    # collide on the fixed docker container names ($PG_CONTAINER /
+    # $REDIS_CONTAINER) and host ports 15432/16379. `cancel-in-progress:
+    # false` means later runs queue rather than cancel the current one.
+    concurrency:
+      group: e2e-api
+      cancel-in-progress: false
     # `services:` is Linux-only on self-hosted runners — we start postgres
     # and redis via `docker run` instead. Ports 15432/16379 avoid collision
     # with anything the host may already have on the standard ports.


### PR DESCRIPTION
## Summary

Now that the Molecule-AI org has **two** self-hosted Apple-silicon runners (`hongming-m1-mini` + `hongming-m1-mini-2`) both servicing the `[self-hosted, macos, arm64]` label set, two CI runs can execute the `e2e-api` job **concurrently**. The job starts fixed-name docker containers (`molecule-ci-postgres`, `molecule-ci-redis`) bound to host ports `15432` / `16379` — so simultaneous execution on two runners collides with either:

- `Error response from daemon: Conflict. The container name "/molecule-ci-postgres" is already in use`
- `docker: Error response from daemon: driver failed programming external connectivity: ... bind: address already in use`

## Fix

Add a workflow-level `concurrency` group on the `e2e-api` job only:

```yaml
concurrency:
  group: e2e-api
  cancel-in-progress: false
```

GitHub Actions will now serialize all `e2e-api` executions **globally**, regardless of which runner picks them up. `cancel-in-progress: false` means later runs queue rather than cancelling the in-flight one — important because every PR's e2e check should actually execute, not get silently skipped by a newer push.

## Tradeoff

`e2e-api` is now effectively single-threaded across the whole org. Measured duration is ~1–2 min per run (postgres+redis `docker run` + platform build + test_api.sh), so the added serialization latency is small relative to total CI wall time.

**Every other job in `ci.yml` still parallelizes across both runners** — the scope of this change is surgical.

## Test plan

- [ ] Merge, then observe next few CI runs — `e2e-api` jobs should run one at a time even when multiple PRs are queued
- [ ] Confirm `molecule-ci-postgres` / `molecule-ci-redis` containers are cleaned up as before (no leak due to the new serialization)
- [ ] No unintended side effect on any other job (they should still run in parallel across the two runners)