### PR TITLE
fix(a2a-tools): auth_headers on recall_memory + commit_memory MCP paths (companion to #285)

### DIFF
--- a/workspace-template/a2a_tools.py
+++ b/workspace-template/a2a_tools.py
@@ -226,6 +226,7 @@ async def tool_commit_memory(content: str, scope: str = "LOCAL") -> str:
             resp = await client.post(
                 f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories",
                 json={"content": content, "scope": scope},
+                headers=_auth_headers_for_heartbeat(),
             )
             data = resp.json()
             if resp.status_code in (200, 201):
@@ -247,6 +248,7 @@ async def tool_recall_memory(query: str = "", scope: str = "") -> str:
             resp = await client.get(
                 f"{PLATFORM_URL}/workspaces/{WORKSPACE_ID}/memories",
                 params=params,
+                headers=_auth_headers_for_heartbeat(),
             )
             data = resp.json()
             if isinstance(data, list):

--- a/workspace-template/tests/test_mcp_memory.py
+++ b/workspace-template/tests/test_mcp_memory.py
@@ -45,11 +45,11 @@ class FakeClient:
     async def __aexit__(self, *args):
         pass
 
-    async def post(self, url, json=None):
+    async def post(self, url, json=None, headers=None, **kwargs):
         self.calls.append(("POST", url, json))
         return FakeResponse(201, {"id": "mem-abc", "scope": json.get("scope", "LOCAL") if json else "LOCAL"})
 
-    async def get(self, url, params=None):
+    async def get(self, url, params=None, headers=None, **kwargs):
         self.calls.append(("GET", url, params))
         return FakeResponse(200, [
             {"id": "mem-1", "content": "Test memory", "scope": "LOCAL"},
@@ -124,7 +124,7 @@ async def test_recall_memory_empty(monkeypatch):
     mcp = _load_mcp()
 
     class EmptyClient(FakeClient):
-        async def get(self, url, params=None):
+        async def get(self, url, params=None, headers=None, **kwargs):
             return FakeResponse(200, [])
 
     monkeypatch.setattr("a2a_tools.httpx.AsyncClient", lambda **kw: EmptyClient())


### PR DESCRIPTION
## The shortest fix of the session: +2 lines

\`\`\`diff
- resp = await client.post(.../memories, json=...)
+ resp = await client.post(.../memories, json=..., headers=_auth_headers_for_heartbeat())
\`\`\`

Same pattern, twice (commit + recall). The helper \`_auth_headers_for_heartbeat()\` already existed at line 23 — it was used for heartbeat POSTs but not for memory calls.

## Why

#285 fixed \`builtin_tools/memory.py\` (the LangGraph tool path). But the Claude Code runtime's MCP server (\`a2a_mcp_server.py\`) calls a **separate** implementation in \`a2a_tools.py\` (\`tool_recall_memory\` + \`tool_commit_memory\`) — two DIFFERENT Python functions hitting the same endpoint, only one got authed.

**Confirmed today:** Python-imported \`search_memory\` returns 26 results with auth inside TR's container. But the agent calling \`recall_memory\` via MCP gets 401 because \`a2a_tools.py\` doesn't attach auth headers.

The TR idle-loop pilot has been broken for this reason across **4 investigation cycles** — the agent correctly reported "memory auth still broken" but I kept fixing the WRONG code path (#285 fixed memory.py, not a2a_tools.py).

## Test plan
- [x] Python syntax check
- [ ] CI
- [ ] After merge + image rebuild + TR restart: TR's next idle fire should produce a successful \`recall_memory\` returning the seeded backlog, followed by a dispatch to Research Lead. First end-to-end idle-loop dispatch ever.

## Related
- #285 — companion fix for builtin_tools/memory.py (same bug, different file, already merged)
- #216 — TR idle-loop pilot (blocked on this fix for 4 investigation cycles)
- The two files that hit \`/workspaces/:id/memories\`:
  - \`builtin_tools/memory.py\` → used by LangGraph runtime ← #285 fixed this
  - \`a2a_tools.py\` → used by Claude Code MCP server ← **this PR fixes this**