### PR TITLE
fix(security): add bearer token auth to /transcript endpoint (#287)

### DIFF
--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -290,12 +290,15 @@ async def main():  # pragma: no cover
     from starlette.routing import Route
 
     async def _transcript_handler(request):
-        # No bearer check here — same model as POST / (A2A): the workspace's
-        # HTTP server only listens on the internal Docker network, and the
-        # platform's TranscriptHandler is the only intended caller. Phase 30
-        # remote workspaces will need a proper auth story (TODO #N) — likely
-        # the existing wsauth bearer, but with a callback to the platform to
-        # validate (since the workspace doesn't see all live tokens).
+        # Require workspace bearer token — the same token issued at registration
+        # and stored in /configs/.auth_token. Any container on molecule-monorepo-net
+        # could otherwise read the full session log. Closes #287.
+        from platform_auth import get_token
+        expected = get_token()
+        if expected:
+            auth_header = request.headers.get("Authorization", "")
+            if auth_header != f"Bearer {expected}":
+                return JSONResponse({"error": "unauthorized"}, status_code=401)
         try:
             since = int(request.query_params.get("since", "0"))
             limit = int(request.query_params.get("limit", "100"))


### PR DESCRIPTION
## Summary

The `/transcript` endpoint in `workspace-template/main.py` had an explicit TODO comment noting it had no authentication. Any container on `molecule-monorepo-net` could read the full Claude session log without credentials.

**Root cause:** The handler was written with a note that auth was deferred, and no one followed up.

## Fix

Added bearer token validation at the top of `_transcript_handler`:

```python
from platform_auth import get_token
expected = get_token()
if expected:
    auth_header = request.headers.get("Authorization", "")
    if auth_header != f"Bearer {expected}":
        return JSONResponse({"error": "unauthorized"}, status_code=401)
```

- Uses `get_token()` from `platform_auth` — the same function that reads `/configs/.auth_token` (set at workspace registration).
- Guard is skipped only when `get_token()` returns `None` (workspace not yet registered / dev-mode startup). This matches the existing auth pattern elsewhere in the file.
- Removed the TODO comment explaining the missing auth.

## Test plan

- [ ] `python -m pytest workspace-template/tests/` green
- [ ] Curl test: `curl -s http://localhost:PORT/transcript` → `{"error":"unauthorized"}` (401)
- [ ] Curl test: `curl -s -H "Authorization: Bearer <token>" http://localhost:PORT/transcript` → transcript JSON

Closes #287