### PR TITLE
feat(template): add molecule-skill-llm-judge to Backend + Frontend Engineer (#310)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -483,7 +483,9 @@ workspaces:
             files_dir: frontend-engineer
             # #280: self-review rubric before raising a PR. Dev Lead uses
             # the same rubric, so catching issues here cuts the review loop.
-            plugins: [molecule-skill-code-review]
+            # #310: molecule-skill-llm-judge — gate own PR against issue body
+            # before requesting review ("shipped the wrong thing" early catch).
+            plugins: [molecule-skill-code-review, molecule-skill-llm-judge]
             initial_prompt: |
               You just started as Frontend Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -515,7 +517,8 @@ workspaces:
             # #303: molecule-security-scan — CVE gate at dev time, not
             # just at Security Auditor's 12h cron. Catches supply-chain
             # deps + secret patterns before they reach PR review.
-            plugins: [molecule-hitl, molecule-skill-code-review, molecule-security-scan]
+            # #310: molecule-skill-llm-judge — self-gate before PR review.
+            plugins: [molecule-hitl, molecule-skill-code-review, molecule-security-scan, molecule-skill-llm-judge]
             initial_prompt: |
               You just started as Backend Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
## Summary

Backend Engineer and Frontend Engineer had `molecule-skill-code-review` (added in PR #289) but were missing `molecule-skill-llm-judge`. Dev Lead, QA Engineer, and Security Auditor already have both plugins.

`llm-judge` lets engineers self-gate their PR against the issue body *before* requesting review — catching "shipped the wrong thing" before Dev Lead sees it. This cuts the review loop at source rather than at review time.

## Changes

```yaml
# Frontend Engineer (was: [molecule-skill-code-review])
plugins: [molecule-skill-code-review, molecule-skill-llm-judge]

# Backend Engineer (was: [molecule-hitl, molecule-skill-code-review, molecule-security-scan])
plugins: [molecule-hitl, molecule-skill-code-review, molecule-security-scan, molecule-skill-llm-judge]
```

No new plugins installed — `molecule-skill-llm-judge` already exists on Dev Lead, QA Engineer, and Security Auditor.

## Test plan
- [ ] CI green (YAML lint + schema check)
- [ ] `grep molecule-skill-llm-judge org-templates/molecule-dev/org.yaml` shows 4 roles (Dev Lead, Security Auditor, QA Engineer, Backend Engineer, Frontend Engineer)

Closes #310