### PR TITLE
fix(template): Telegram channel for Security Auditor + DevOps Engineer (#246 #247)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -551,6 +551,14 @@ workspaces:
             # #280: molecule-skill-code-review — self-review rubric for
             # Dockerfiles, CI workflows, infra scripts before PR.
             plugins: [molecule-hitl, molecule-skill-code-review]
+            # #247: notify on build-break — DevOps routes CI failures + infra
+            # alerts via Telegram so they're not invisible until morning review.
+            channels:
+              - type: telegram
+                config:
+                  bot_token: ${TELEGRAM_BOT_TOKEN}
+                  chat_id: ${TELEGRAM_CHAT_ID}
+                enabled: true
             initial_prompt: |
               You just started as DevOps Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -625,6 +633,15 @@ workspaces:
               - molecule-skill-llm-judge
               - molecule-security-scan
               - molecule-hitl
+            # #246: notify on critical findings — Security Auditor pushes HIGH+
+            # severity alerts via Telegram so they're not invisible until next
+            # manual memory check.
+            channels:
+              - type: telegram
+                config:
+                  bot_token: ${TELEGRAM_BOT_TOKEN}
+                  chat_id: ${TELEGRAM_CHAT_ID}
+                enabled: true
             initial_prompt: |
               You just started as Security Auditor. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
## Summary

Security Auditor and DevOps Engineer had no notification channels. Critical security findings and CI build-break alerts were invisible until someone manually checked memory/logs.

## Fix

Added Telegram channel to both roles using the same env vars already wired for PM:

```yaml
channels:
  - type: telegram
    config:
      bot_token: ${TELEGRAM_BOT_TOKEN}
      chat_id: ${TELEGRAM_CHAT_ID}
    enabled: true
```

- **Security Auditor** — now has a push path for HIGH+ severity findings (#246)
- **DevOps Engineer** — now has a channel for CI build-break + infra alerts (#247)

No new env vars or infra needed — `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` are already deployed for PM.

## Related
- #245: Telegram channel proposal (this implements it for SA + DevOps)
- #243: Slack adapter (longer-term, separate channel for dedicated build-break stream)

Closes #246
Closes #247