### PR TITLE
chore(template): widen idle-loop to Market Analyst + Competitive Intelligence (wave 2)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -273,6 +273,31 @@ workspaces:
             role: Market sizing, trends, user research
             files_dir: market-analyst
             plugins: [browser-automation]
+            # Idle-loop rollout wave 2 (#216 → #285 → #304 validated on Technical
+            # Researcher 2026-04-16 02:40 UTC). Market Analyst gets the same
+            # reflection-on-completion pattern tuned for market research work.
+            idle_interval_seconds: 600
+            idle_prompt: |
+              You have no active task. Backlog-pull + reflect, under 60 seconds:
+
+              1. search_memory "research-backlog:market-analyst" — pull any
+                 stashed market-research questions. If found:
+                 - delegate_task to Research Lead with a concrete spec:
+                   "Market research: <topic>. Target audience, TAM, pricing
+                    comparables. Report in <N> words. Route audit_summary to
+                    PM with category=research."
+                 - commit_memory removing that item from the backlog.
+
+              2. If backlog empty, look at your LAST memory entry. Did a prior
+                 task surface a market-sizing follow-up, a user-research gap,
+                 or a pricing comparison worth doing? If yes:
+                 - File a GH issue with the question, label `research`.
+                 - commit_memory "research-backlog:market-analyst" for next tick.
+
+              3. If neither, write "ma-idle HH:MM — clean" to memory and stop.
+                 No fabricating busy work.
+
+              Max 1 A2A per tick. Skip step 1 if Research Lead busy. Under 60s.
           - name: Technical Researcher
             role: AI frameworks and protocol evaluation
             files_dir: technical-researcher
@@ -348,6 +373,30 @@ workspaces:
             role: Competitor tracking and feature comparison
             files_dir: competitive-intelligence
             plugins: [browser-automation]
+            # Idle-loop rollout wave 2 (sibling to Market Analyst).
+            idle_interval_seconds: 600
+            idle_prompt: |
+              You have no active task. Backlog-pull + reflect, under 60 seconds:
+
+              1. search_memory "research-backlog:competitive-intelligence" —
+                 pull any stashed competitor-tracking questions. If found:
+                 - delegate_task to Research Lead with a concrete spec:
+                   "Competitive: <competitor/feature>. What shipped, when, who
+                    it's aimed at, gaps vs ours. Report in <N> words. Route
+                    audit_summary to PM with category=research."
+                 - commit_memory removing from backlog.
+
+              2. If backlog empty, look at your LAST memory entry. Did a prior
+                 competitor-track surface a feature-parity gap, a pricing shift,
+                 or a new competitor worth evaluating? If yes:
+                 - File a GH issue with the question, label `research`.
+                 - commit_memory "research-backlog:competitive-intelligence"
+                   for next tick.
+
+              3. If neither, write "ci-idle HH:MM — clean" to memory and stop.
+                 No fabricating busy work.
+
+              Max 1 A2A per tick. Skip step 1 if Research Lead busy. Under 60s.
 
       - name: Dev Lead
         role: Engineering planning and team coordination


### PR DESCRIPTION
## Pilot validated — widening
Technical Researcher (wave 1, #216) fired its first successful end-to-end idle-loop dispatch at 2026-04-16 02:40 UTC after the #285 + #304 auth chain finally landed (two separate Python paths to the same endpoint, both needed the fix).

TR response body at that tick:
> *"Backlog item dispatched and cleared. Done in one A2A send. Step 1: Memory search found one..."*

Followed by correct idle-clean behavior once the seeded backlog was consumed.

**Pilot is validated. Time to widen.**

## What this PR does
Adds role-tuned `idle_prompt` + `idle_interval_seconds: 600` to **Market Analyst** and **Competitive Intelligence** (both sit under Research Lead, same level as TR).

Each gets a prompt that:
- Searches its own `research-backlog:<role>` namespace
- Delegates to Research Lead with a role-shaped spec
  - Market Analyst → TAM / pricing comparables
  - Competitive Intel → feature-parity / competitor track
  - Technical Researcher → framework eval (unchanged)
- Falls through to reflection on last memory entry if backlog empty
- Writes `<role>-idle HH:MM — clean` if neither produced work

All 3 share: 10-min cadence, max 1 A2A per tick, skip step 1 if Research Lead busy, <60s wall-clock budget.

## Rollout scoreboard
| Wave | Workspaces | Status |
|---|---|---|
| 1 | Technical Researcher | ✅ Validated (#216 merged, pilot fired at 02:40 UTC) |
| **2** | **Market Analyst + Competitive Intelligence** | **This PR** |
| 3 (future) | Auditors / other specialists | TBD after wave 2 |

Not including leaders (PM, Dev Lead, Research Lead already have 5-min Orchestrator pulses from #159). Not including engineers (reactive-only per orchestrator/worker split).

## Related
- #216 TR pilot (merged)
- #205 idle-loop mechanism (merged)
- #285 + #304 auth chain (merged — unblocked the pilot)
- `project_north_star_24_7.md` — this is the "team runs 24/7" lever in action