### PR TITLE
fix(security): workspace existence check in WorkspaceAuth (#318)

### DIFF
--- a/platform/internal/middleware/wsauth_middleware.go
+++ b/platform/internal/middleware/wsauth_middleware.go
@@ -31,6 +31,24 @@ func WorkspaceAuth(database *sql.DB) gin.HandlerFunc {
 		}
 		ctx := c.Request.Context()
 
+		// #318: verify workspace exists before the token check so fabricated
+		// workspace IDs cannot exploit the fail-open legacy path.
+		// HasAnyLiveToken returns (false, nil) for non-existent workspaces —
+		// indistinguishable from "not yet registered".  A DB EXISTS check is
+		// unambiguous and costs one additional query on this hot path.
+		var wsExists bool
+		if err := database.QueryRowContext(ctx,
+			`SELECT EXISTS(SELECT 1 FROM workspaces WHERE id = $1)`, workspaceID,
+		).Scan(&wsExists); err != nil {
+			log.Printf("wsauth: WorkspaceAuth: existence check failed for %s: %v", workspaceID, err)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "auth check failed"})
+			return
+		}
+		if !wsExists {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
+			return
+		}
+
 		hasLive, err := wsauth.HasAnyLiveToken(ctx, database, workspaceID)
 		if err != nil {
 			log.Printf("wsauth: WorkspaceAuth: HasAnyLiveToken(%s) failed: %v", workspaceID, err)


### PR DESCRIPTION
## Summary

`WorkspaceAuth` middleware was fail-open for non-existent workspace IDs, allowing unauthenticated access to protected endpoints (secrets, schedules, config, etc.).

## Root cause

`HasAnyLiveToken(workspaceID)` returns `(false, nil)` for any unknown workspace ID — it simply finds no rows. The middleware treated this identically to a legitimate pre-registration workspace and called `c.Next()` without authentication.

**Proof of concept (before fix):**
```bash
curl -s http://host.docker.internal:8080/workspaces/00000000-0000-0000-0000-000000000000/secrets
# → [{"key":"CLAUDE_CODE_OAUTH_TOKEN",...},{"key":"GITHUB_TOKEN",...}]
```

## Fix

Add a `SELECT EXISTS` check before the token validation. Non-existent workspace IDs return **404** immediately:

```go
var wsExists bool
database.QueryRowContext(ctx,
    `SELECT EXISTS(SELECT 1 FROM workspaces WHERE id = $1)`, workspaceID,
).Scan(&wsExists)
if !wsExists {
    c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": "workspace not found"})
    return
}
```

Cost: one primary-key lookup per request on this path. Legitimate pre-registration workspaces (exist in DB, no tokens yet) continue to pass through unchanged.

## Test plan
- [ ] `go test ./platform/internal/middleware/...` green
- [ ] `curl .../workspaces/00000000-.../secrets` → 404 (not 200)
- [ ] Real workspace with no token → 200 (legacy path preserved)
- [ ] Real workspace with token, valid bearer → 200
- [ ] Real workspace with token, missing bearer → 401

Closes #318