### PR TITLE
fix(security): close WorkspaceAuth fail-open on non-existent workspace IDs (#318)

### DIFF
--- a/platform/internal/middleware/wsauth_middleware.go
+++ b/platform/internal/middleware/wsauth_middleware.go
@@ -47,6 +47,25 @@ func WorkspaceAuth(database *sql.DB) gin.HandlerFunc {
 				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid workspace auth token"})
 				return
 			}
+			c.Next()
+			return
+		}
+
+		// #318: fail-open path. The grandfather window only exists for
+		// workspaces that actually exist in the DB but pre-date Phase 30.1
+		// token issuance. A fabricated UUID must NOT be let through —
+		// without this check, unauthenticated callers could probe
+		// `/workspaces/<fake>/secrets` and enumerate global-secret key
+		// names via the fall-through 200 OK.
+		exists, err := wsauth.WorkspaceExists(ctx, database, workspaceID)
+		if err != nil {
+			log.Printf("wsauth: WorkspaceAuth: WorkspaceExists(%s) failed: %v", workspaceID, err)
+			c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": "auth check failed"})
+			return
+		}
+		if !exists {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
 		}
 		c.Next()
 	}

--- a/platform/internal/middleware/wsauth_middleware_test.go
+++ b/platform/internal/middleware/wsauth_middleware_test.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"crypto/sha256"
+	"database/sql"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,9 +45,15 @@ func newWorkspaceAuthRouter(db sqlmock.Sqlmock, realDB interface{ Close() error 
 	return r
 }
 
+// workspaceExistsQuery is matched by sqlmock for wsauth.WorkspaceExists.
+// Matches the SELECT EXISTS(SELECT 1 FROM workspaces WHERE id = $1) query.
+const workspaceExistsQuery = "SELECT EXISTS.*FROM workspaces WHERE id"
+
 // TestWorkspaceAuth_FailOpen_NoTokens — C4/C8: when a workspace has no live
 // token on file (first boot / pre-Phase-30), the middleware must let the
 // request through so in-flight agents are not bricked during rolling upgrades.
+// #318: the fail-open path now ALSO requires the workspace row to exist —
+// fabricated UUIDs no longer leak through.
 func TestWorkspaceAuth_FailOpen_NoTokens(t *testing.T) {
 	mockDB, mock, err := sqlmock.New()
 	if err != nil {
@@ -58,6 +65,10 @@ func TestWorkspaceAuth_FailOpen_NoTokens(t *testing.T) {
 	mock.ExpectQuery(hasLiveTokenQuery).
 		WithArgs("ws-bootstrap").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// WorkspaceExists returns true — the workspace is real, just pre-token.
+	mock.ExpectQuery(workspaceExistsQuery).
+		WithArgs("ws-bootstrap").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
 	r := gin.New()
 	r.GET("/workspaces/:id/test", WorkspaceAuth(mockDB), func(c *gin.Context) {
@@ -69,7 +80,79 @@ func TestWorkspaceAuth_FailOpen_NoTokens(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Errorf("fail-open (no tokens): expected 200, got %d: %s", w.Code, w.Body.String())
+		t.Errorf("fail-open (no tokens, workspace exists): expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestWorkspaceAuth_318_NonexistentWorkspace_Returns401 — #318: a request
+// with no bearer token against a fabricated workspace UUID (no row in the
+// workspaces table) must be rejected with 401, not leaked through the
+// pre-fix fail-open grandfather. This closes the secret-key enumeration
+// vector reported by the security-auditor cycle 13 DAST run.
+func TestWorkspaceAuth_318_NonexistentWorkspace_Returns401(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer mockDB.Close()
+
+	// HasAnyLiveToken returns 0 — no tokens for this (fake) workspace.
+	mock.ExpectQuery(hasLiveTokenQuery).
+		WithArgs("00000000-0000-0000-0000-000000000000").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// WorkspaceExists returns false — the workspace does not exist.
+	mock.ExpectQuery(workspaceExistsQuery).
+		WithArgs("00000000-0000-0000-0000-000000000000").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	r := gin.New()
+	r.GET("/workspaces/:id/secrets", WorkspaceAuth(mockDB), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/workspaces/00000000-0000-0000-0000-000000000000/secrets", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("non-existent workspace: expected 401, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestWorkspaceAuth_318_ExistsQueryError_Returns500 — DB error on the
+// #318 existence check must NOT fall through to c.Next(); it must return
+// 500 so operators know the auth gate failed rather than silently allowing.
+func TestWorkspaceAuth_318_ExistsQueryError_Returns500(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer mockDB.Close()
+
+	mock.ExpectQuery(hasLiveTokenQuery).
+		WithArgs("ws-existsfail").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	mock.ExpectQuery(workspaceExistsQuery).
+		WithArgs("ws-existsfail").
+		WillReturnError(sql.ErrConnDone)
+
+	r := gin.New()
+	r.GET("/workspaces/:id/test", WorkspaceAuth(mockDB), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/workspaces/ws-existsfail/test", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("exists-query error: expected 500, got %d: %s", w.Code, w.Body.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet sqlmock expectations: %v", err)
@@ -536,6 +619,11 @@ func TestWorkspaceAuth_Issue170_SecretDelete_FailOpen_NoTokens(t *testing.T) {
 	mock.ExpectQuery(hasLiveTokenQuery).
 		WithArgs("ws-legacy").
 		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+	// #318: fail-open branch also checks WorkspaceExists. Legacy row exists
+	// (real workspace, just pre-token) so this must pass.
+	mock.ExpectQuery(workspaceExistsQuery).
+		WithArgs("ws-legacy").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
 
 	r := gin.New()
 	r.DELETE("/workspaces/:id/secrets/:key",

--- a/platform/internal/wsauth/tokens.go
+++ b/platform/internal/wsauth/tokens.go
@@ -117,6 +117,25 @@ func RevokeAllForWorkspace(ctx context.Context, db *sql.DB, workspaceID string) 
 	return nil
 }
 
+// WorkspaceExists reports whether a workspace row is present in the
+// database. Used by WorkspaceAuth to close the #318 fail-open gap —
+// the lazy-bootstrap grace period is meant for real workspaces that
+// haven't yet been issued a token, NOT for fabricated UUIDs an
+// unauthenticated caller is using to probe our API surface.
+//
+// Kept in this package (rather than handlers) so the middleware does not
+// need to reach across the handlers boundary for a 1-column EXISTS query.
+func WorkspaceExists(ctx context.Context, db *sql.DB, workspaceID string) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM workspaces WHERE id = $1)`, workspaceID,
+	).Scan(&exists)
+	if err != nil {
+		return false, err
+	}
+	return exists, nil
+}
+
 // HasAnyLiveToken reports whether the given workspace has at least one
 // live (non-revoked) token on file. Used by the lazy-bootstrap path in
 // the heartbeat handler — a legacy workspace that registered before

--- a/platform/internal/wsauth/tokens_test.go
+++ b/platform/internal/wsauth/tokens_test.go
@@ -155,6 +155,36 @@ func TestHasAnyLiveToken(t *testing.T) {
 }
 
 // ------------------------------------------------------------
+// WorkspaceExists — #318
+// ------------------------------------------------------------
+
+func TestWorkspaceExists(t *testing.T) {
+	cases := []struct {
+		name   string
+		exists bool
+	}{
+		{"present", true},
+		{"absent", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db, mock := setupMock(t)
+			mock.ExpectQuery(`SELECT EXISTS\(SELECT 1 FROM workspaces WHERE id = \$1\)`).
+				WithArgs("ws-id-42").
+				WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(tc.exists))
+
+			got, err := WorkspaceExists(context.Background(), db, "ws-id-42")
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != tc.exists {
+				t.Errorf("got %v, want %v", got, tc.exists)
+			}
+		})
+	}
+}
+
+// ------------------------------------------------------------
 // RevokeAllForWorkspace
 // ------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Close the HIGH-severity fail-open reported in #318. Unauthenticated `GET /workspaces/<fake-uuid>/secrets` was returning 200 with global-secret key names because `HasAnyLiveToken` returned 0 both for real-but-pre-token workspaces AND for fabricated UUIDs — the middleware couldn't distinguish.

Option B from the triage: add an existence check that preserves the pre-Phase-30 grandfather window for real workspaces while rejecting fabricated IDs.

## Changes

- `platform/internal/wsauth/tokens.go` — new `WorkspaceExists(ctx, db, id)` helper.
- `platform/internal/middleware/wsauth_middleware.go` — `WorkspaceAuth` now calls `WorkspaceExists` in the no-token branch and returns 401 when the row is absent.
- `platform/internal/wsauth/tokens_test.go` — `TestWorkspaceExists` covering present / absent.
- `platform/internal/middleware/wsauth_middleware_test.go` — new `TestWorkspaceAuth_318_NonexistentWorkspace_Returns401` (the regression), `TestWorkspaceAuth_318_ExistsQueryError_Returns500` (fail-closed on DB error), and updated existing fail-open tests to mock the new call returning `true`.

`AdminAuth` and `CanvasOrBearer` are untouched — they are not workspace-scoped so the fabricated-ID vector doesn't apply.

## Test plan
- [x] `go test -race ./internal/wsauth/... ./internal/middleware/...` — all green
- [x] Full `go test ./...` in platform/ — all packages green
- [ ] CI (`e2e-api` + Platform Go) green before merge
- [ ] Cross-vendor review before merge (auth-scope)

Closes #318