### PR TITLE
chore(org): wire molecule-compliance + molecule-audit + molecule-freeze-scope (#322)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -567,7 +567,11 @@ workspaces:
             # just at Security Auditor's 12h cron. Catches supply-chain
             # deps + secret patterns before they reach PR review.
             # #310: molecule-skill-llm-judge — self-gate before PR review.
-            plugins: [molecule-hitl, molecule-skill-code-review, molecule-security-scan, molecule-skill-llm-judge]
+            # #322: molecule-compliance — OA-03 excessive-agency cap; Backend
+            # Engineer is the highest tool-call-volume role (platform PRs,
+            # migrations, API changes) so a hard cap is a concrete guard
+            # against runaway loops during large refactors.
+            plugins: [molecule-hitl, molecule-skill-code-review, molecule-security-scan, molecule-skill-llm-judge, molecule-compliance]
             initial_prompt: |
               You just started as Backend Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)
@@ -599,7 +603,11 @@ workspaces:
             # destructive infra ops is the point.
             # #280: molecule-skill-code-review — self-review rubric for
             # Dockerfiles, CI workflows, infra scripts before PR.
-            plugins: [molecule-hitl, molecule-skill-code-review]
+            # #322: molecule-freeze-scope — lock edits to infra/** during
+            # risky operations (CI migrations, fly secret rotations, image
+            # rebuilds). Plugin was an orphan for 3 weekly audits; DevOps
+            # is the natural home.
+            plugins: [molecule-hitl, molecule-skill-code-review, molecule-freeze-scope]
             # #247: notify on build-break — DevOps routes CI failures + infra
             # alerts via Telegram so they're not invisible until morning review.
             channels:
@@ -676,12 +684,18 @@ workspaces:
             #                                        builtin_tools/security_scan.py — gosec/bandit/etc
             # - molecule-hitl (#266):                @requires_approval before filing critical issues
             #                                        so false-positives don't spam the tracker
+            # - molecule-compliance (#322):          OWASP Top 10 for Agentic Applications — active
+            #                                        enforcement on Security Auditor's own tool calls
+            # - molecule-audit (#322):               immutable JSON-Lines audit log (EU AI Act Art 12/13/17)
+            #                                        — Security Auditor owns the report generation path
             plugins:
               - molecule-skill-code-review
               - molecule-skill-cross-vendor-review
               - molecule-skill-llm-judge
               - molecule-security-scan
               - molecule-hitl
+              - molecule-compliance
+              - molecule-audit
             # #246: notify on critical findings — Security Auditor pushes HIGH+
             # severity alerts via Telegram so they're not invisible until next
             # manual memory check.
@@ -796,7 +810,11 @@ workspaces:
             files_dir: qa-engineer
             # QA reviews test coverage + runs llm-judge on whether test
             # deliverables actually match acceptance criteria. Issue #133.
-            plugins: [molecule-skill-code-review, molecule-skill-llm-judge]
+            # #322: molecule-compliance — OA-01 prompt-injection detection
+            # (in detect mode, not block) catches adversarial test payloads
+            # before they slip into production. OA-03 excessive-agency caps
+            # prevent runaway test loops.
+            plugins: [molecule-skill-code-review, molecule-skill-llm-judge, molecule-compliance]
             initial_prompt: |
               You just started as QA Engineer. Set up silently — do NOT contact other agents.
               1. Clone the repo: git clone https://github.com/${GITHUB_REPO}.git /workspace/repo 2>/dev/null || (cd /workspace/repo && git pull)


### PR DESCRIPTION
## Summary

Config-only fix for #322. Three plugins merged without role wiring — one line of YAML each bridges the gap.

- Security Auditor gains `molecule-compliance` (OWASP Top 10 active enforcement on their own tool calls) and `molecule-audit` (EU AI Act immutable JSONL log they generate reports from).
- Backend Engineer gains `molecule-compliance` (OA-03 excessive-agency cap on the highest tool-call-volume role).
- QA Engineer gains `molecule-compliance` (OA-01 prompt-injection detect mode for adversarial test payloads).
- DevOps Engineer gains `molecule-freeze-scope` (infra/** lock during risky CI migrations — plugin orphaned for 3 weekly audits).

## Test plan
- [x] `python3 -c 'yaml.safe_load(...)'` parses
- [x] All referenced plugins exist in `plugins/` dir
- [x] `go test -race ./...` across platform — all green
- [x] `TestPlugins_UnionWithDefaults` passes (UNION-with-defaults merge semantics preserved)

Closes #322