### PR TITLE
chore(auditor): close #319 + #337 prompt drift on Security Auditor (#342)

### DIFF
--- a/org-templates/molecule-dev/org.yaml
+++ b/org-templates/molecule-dev/org.yaml
@@ -736,6 +736,19 @@ workspaces:
                      - Secret leakage in logs/errors/responses
                      - Command injection (exec.Command with user input)
                      - XSS (dangerouslySetInnerHTML, unescaped content in .tsx)
+                     - #337 class: every secret/token/HMAC comparison MUST use
+                       `subtle.ConstantTimeCompare` (Go) or `crypto.timingSafeEqual`
+                       (Node). Flag any `!=` / `==` / `bytes.Equal` against a
+                       user-supplied value that gates auth or a webhook signature.
+                     - #319 class: any new channel_config field that holds a
+                       credential (bot_token, api_key, webhook_secret, oauth_*)
+                       MUST be added to the `sensitiveFields` slice in
+                       `platform/internal/channels/secret.go`. Check both
+                       EncryptSensitiveFields (write path: Create/Update handlers)
+                       AND DecryptSensitiveFields (read boundary: List, Reload,
+                       loadChannel, Webhook). Verify the `ec1:` ciphertext prefix
+                       never leaks into API responses — decryption must happen
+                       BEFORE masking in list handlers.
 
                   4. LIVE API CHECKS against http://host.docker.internal:8080:
                      - CanCommunicate bypass: POST /workspaces/<zero-id>/a2a

--- a/org-templates/molecule-dev/security-auditor/system-prompt.md
+++ b/org-templates/molecule-dev/security-auditor/system-prompt.md
@@ -19,6 +19,8 @@ You are a senior security engineer. You review every change for vulnerabilities 
 - Input validation: at every API boundary (handler level, not deep in business logic)
 - Auth: every endpoint requires authentication, every cross-workspace call checks access
 - Secrets: tokens masked in responses, not logged, not in error messages
+- **Secret comparisons**: every place the code compares a user-supplied value against a server-side secret (bearer tokens, HMAC signatures, webhook secrets, API keys) MUST use `subtle.ConstantTimeCompare` in Go or `crypto.timingSafeEqual` in Node. Raw `==` / `!=` / `bytes.Equal` leak timing info byte-by-byte. Recent instance: #337 on `webhook_secret`. When you see `if received != expected`, flag it.
+- **Secret storage at rest**: anything that looks like a credential (bot_token, api_key, webhook_secret, oauth_token) stored in a DB column must be AES-256-GCM encrypted via `crypto.Encrypt`, not plaintext. Channel config uses the `ec1:` prefix scheme (#319): verify every new `sensitiveFields` addition appears in both `EncryptSensitiveFields` (write path) and `DecryptSensitiveFields` (read boundary), and that the ciphertext prefix never leaks into API responses (decrypt BEFORE masking in list handlers).
 - Dependencies: known CVEs in Go modules, npm packages, pip packages
 - CORS: origins list is explicit, not `*`
 - Headers: Content-Type, CSP, X-Frame-Options on responses


### PR DESCRIPTION
## Summary

Pure prompt update for #342. The Security Auditor system prompt and schedule cron prompt were missing coverage for two recent platform changes — #319 (channel_config field-level encryption) and #337 (webhook_secret constant-time compare). Without these in the auditor's checklist, a future instance of either class would slip through until a human spotted it.

## Changes

- `security-auditor/system-prompt.md` "What You Check" — 2 new bullets for secret comparisons (ConstantTimeCompare) and secret storage at rest (sensitiveFields, ec1: prefix, encrypt-before-mask).
- `org.yaml` Security Auditor 12h cron prompt — same 2 checks added to the "MANUAL REVIEW" step with concrete flag-patterns ("flag any `!=` / `==` / bytes.Equal against a user-supplied value that gates auth").

## Test plan
- [x] YAML parse clean (`python3 -c 'yaml.safe_load(...)'`)
- [x] `TestPlugins_UnionWithDefaults` passes (no regression in org merge logic)

Closes #342