### PR TITLE
fix(liveness): raise workspace TTL 60s → 180s to survive Opus synthesis

### DIFF
--- a/platform/internal/db/redis.go
+++ b/platform/internal/db/redis.go
@@ -28,16 +28,28 @@ func InitRedis(redisURL string) error {
 	return nil
 }
 
-// SetOnline sets the workspace liveness key with a 60s TTL.
+// LivenessTTL is the TTL for the workspace liveness key in Redis.
+// Must be > heartbeat interval × (max acceptable missed heartbeats).
+// Workspace heartbeat loop fires every 30s; a busy Claude Code / Opus
+// synthesis can starve the asyncio scheduler for 60-120s, so a 60s TTL
+// triggered false-positive "unreachable — restart" cycles on busy
+// leaders every ~30 minutes (see README in this package + the commit
+// message). 180s allows up to ~5 missed heartbeats before we conclude
+// the container is actually dead, which still cleanly detects real
+// crashes (the a2a_proxy reactive IsRunning() check catches those on
+// the first failed forward, independent of TTL).
+const LivenessTTL = 180 * time.Second
+
+// SetOnline sets the workspace liveness key with the LivenessTTL.
 func SetOnline(ctx context.Context, workspaceID string) error {
 	key := fmt.Sprintf("ws:%s", workspaceID)
-	return RDB.Set(ctx, key, "online", 60*time.Second).Err()
+	return RDB.Set(ctx, key, "online", LivenessTTL).Err()
 }
 
 // RefreshTTL refreshes the liveness TTL for a workspace.
 func RefreshTTL(ctx context.Context, workspaceID string) error {
 	key := fmt.Sprintf("ws:%s", workspaceID)
-	return RDB.Expire(ctx, key, 60*time.Second).Err()
+	return RDB.Expire(ctx, key, LivenessTTL).Err()
 }
 
 // CacheURL caches a workspace URL for fast resolution.


### PR DESCRIPTION
## Summary

Hoists the workspace liveness Redis TTL into a named `LivenessTTL` constant and raises it from 60s to 180s. Stops false-positive "TTL expired → unreachable → restart" cycles on busy leaders.

## Problem

Observed 2026-04-16 ~06:40-06:49 UTC: Research Lead, Dev Lead, Security Auditor, and UIUX Designer getting force-restarted by the liveness monitor every ~30 minutes despite being healthy.

A2A callers saw regular EOFs — `A2A request to <leader-id> failed: Post http://ws-*:8000: EOF`. Platform logs showed: `Liveness: workspace <id> TTL expired` → `Auto-restart: restarting <name> (was: offline)` → `Provisioner: stopped and removed container ws-*`.

In a 10-minute window, four containers logged 4-5 EOFs each; three were force-restarted.

## Root cause

`ws:{id}` Redis key has a 60s TTL (`platform/internal/db/redis.go`). Workspace heartbeat loop (`workspace-template/heartbeat.py`) refreshes every 30s — room for exactly ONE missed heartbeat before expiry.

A busy Claude Code Opus synthesis starves the container's asyncio scheduler for 60-120s (SDK spawns the `claude` CLI subprocess and blocks the event loop until the message-reader yields). The heartbeat coroutine doesn't get scheduled during that window. Leaders running 5-minute orchestrator pulses or deep delegations routinely hit this. Platform mistakes busy-but-healthy for dead, tears the container down, re-provisions — interrupting mid-synthesis work and cascading EOFs on pending A2A calls.

## Fix

- Extract magic number into `const LivenessTTL = 180 * time.Second`
- Use in both `SetOnline` and `RefreshTTL` (no other callsites)
- Doc comment explains the reasoning so future tuning is principled

With a 30s heartbeat interval, 180s TTL tolerates ~5 missed beats — comfortably longer than any realistic Opus stall.

## Why this is safe

Dead containers are still caught immediately by `a2a_proxy`'s reactive `IsRunning()` check (`maybeMarkContainerDead` in `a2a_proxy.go:439`). That path doesn't depend on TTL — it fires on the first failed forward. So this PR only relaxes the "slow but alive" false-positive detection; dead-container detection is unchanged.

## Test plan

- [x] `go build ./...` clean (verified in golang:1.25 docker image)
- [ ] Existing tests in `platform/internal/registry/liveness_test.go` still pass — they use `miniredis` with short TTLs configurable per-test, so the constant change doesn't affect them
- [ ] Post-deploy: monitor `platform logs | grep "TTL expired"` for 2 hours. Expect drop from ~4/30min per busy leader to ~0
- [ ] Post-deploy: verify restart cadence on RL/DL/SA stabilizes (Docker `--format '{{.State.StartedAt}}'` uptime > 2 hours becomes normal)

## Alternatives considered

1. **Shorten heartbeat interval to 15s** — doesn't fix the real issue (asyncio starvation) and doubles Redis write load. Dismissed.
2. **Run heartbeat in a separate process** — architecturally cleaner but a ~week of work. File a follow-up issue if needed.
3. **Use Redis SETEX with liveness checker pinging the container** — reactive checks already exist in `a2a_proxy.go`. This would duplicate logic. Dismissed.

TTL bump is the lowest-risk change that buys us breathing room. If Opus regressions ever make 180s insufficient, the constant is now easy to bump further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)