### PR TITLE
fix(canvas): show all templates in EmptyState grid (was capped at 6)

### DIFF
--- a/canvas/src/components/EmptyState.tsx
+++ b/canvas/src/components/EmptyState.tsx
@@ -108,7 +108,7 @@ export function EmptyState() {
           <div className="text-xs text-zinc-400 py-4">Loading templates...</div>
         ) : templates.length > 0 ? (
           <div className="grid grid-cols-2 gap-2.5 mb-4 text-left max-h-[240px] overflow-y-auto">
-            {templates.slice(0, 6).map((t) => {
+            {templates.map((t) => {
               const tierColor = TIER_COLORS[t.tier] || TIER_COLORS[1];
               return (
                 <button


### PR DESCRIPTION
## Problem

`EmptyState.tsx` line 111 had a hard-coded `.slice(0, 6)` cap on the template grid. The platform API returns **8 templates**, but **LangGraph Agent** and **OpenClaw Agent** were silently hidden — never rendered, never discoverable by users on the empty canvas.

The grid container already has `max-h-[240px] overflow-y-auto` (line 110) to handle overflow, making the slice entirely redundant.

## Fix

Remove `.slice(0, 6)` so `templates.map(...)` renders all API-returned templates. The container scrolls natively.

```diff
- {templates.slice(0, 6).map((t) => {
+ {templates.map((t) => {
```

## Impact

- LangGraph Agent and OpenClaw Agent now appear in the empty-state template picker
- Zero logic change — pure one-word deletion
- Existing `max-h-[240px] overflow-y-auto` container handles any future template count growth without code changes

## Test plan

- [ ] Load canvas with no workspaces — verify all 8 templates render (scroll to see LangGraph + OpenClaw)
- [ ] Click LangGraph Agent → workspace deploys correctly
- [ ] Click OpenClaw Agent → workspace deploys correctly
- [ ] Confirm scroll behaviour at `max-h-[240px]` with 8 cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)