### PR TITLE
fix(#249): schedule health endpoint accessible to CanCommunicate peers

### DIFF
--- a/platform/internal/handlers/schedules.go
+++ b/platform/internal/handlers/schedules.go
@@ -1,3 +1,4 @@
+// Package handlers — schedule health endpoint added in #249.
 package handlers
 
 import (

--- a/platform/internal/handlers/schedules.go
+++ b/platform/internal/handlers/schedules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/registry"
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/scheduler"
 )
 
@@ -267,6 +268,98 @@ func (h *ScheduleHandler) RunNow(c *gin.Context) {
 		"workspace_id": workspaceID,
 		"prompt":       prompt,
 	})
+}
+
+// scheduleHealthResponse is the read-only health view of a schedule.
+// It deliberately omits prompt and cron_expr so sensitive task content is
+// never exposed to peer workspaces — only execution-state fields needed to
+// detect silent cron failures are returned (issue #249).
+type scheduleHealthResponse struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Enabled    bool       `json:"enabled"`
+	LastRunAt  *time.Time `json:"last_run_at"`
+	NextRunAt  *time.Time `json:"next_run_at"`
+	RunCount   int        `json:"run_count"`
+	LastStatus string     `json:"last_status"`
+	LastError  string     `json:"last_error"`
+}
+
+// Health returns schedule health fields (last_run_at, last_status, run_count,
+// etc.) for all schedules belonging to a workspace.
+//
+// Unlike GET /workspaces/:id/schedules (which requires the workspace's own
+// bearer token), this endpoint is accessible to CanCommunicate peers — i.e.,
+// any workspace in the same org hierarchy — so peer agents can detect silent
+// cron failures without needing admin auth (issue #249).
+//
+// Auth rules (mirrors the A2A proxy pattern):
+//   - X-Workspace-ID header is required to identify the caller.
+//   - If the caller workspace has any live tokens, the Authorization: Bearer
+//     header must carry that caller's own valid token (lazy-bootstrap: legacy
+//     workspaces with no tokens are grandfathered through).
+//   - registry.CanCommunicate(callerID, workspaceID) must return true.
+//   - System callers (webhook:*, system:*, test:*) bypass token + access checks.
+//   - Self-calls (callerID == workspaceID) are always allowed.
+//
+// Prompt and cron_expr are intentionally absent from the response.
+func (h *ScheduleHandler) Health(c *gin.Context) {
+	workspaceID := c.Param("id")
+	callerID := c.GetHeader("X-Workspace-ID")
+	ctx := c.Request.Context()
+
+	// Caller identity is mandatory — anonymous reads are not permitted.
+	if callerID == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "X-Workspace-ID header required"})
+		return
+	}
+
+	// Validate the caller's own bearer token (Phase 30.5 contract).
+	// Skip for system callers and self-calls, same as the A2A proxy.
+	if !isSystemCaller(callerID) && callerID != workspaceID {
+		if err := validateCallerToken(ctx, c, callerID); err != nil {
+			return // response already written with 401
+		}
+	}
+
+	// CanCommunicate gate — only peers in the org hierarchy may read health.
+	if callerID != workspaceID && !isSystemCaller(callerID) {
+		if !registry.CanCommunicate(callerID, workspaceID) {
+			log.Printf("ScheduleHealth: access denied %s → %s", callerID, workspaceID)
+			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+			return
+		}
+	}
+
+	rows, err := db.DB.QueryContext(ctx, `
+		SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error
+		FROM workspace_schedules
+		WHERE workspace_id = $1
+		ORDER BY created_at ASC
+	`, workspaceID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query schedules"})
+		return
+	}
+	defer rows.Close()
+
+	schedules := make([]scheduleHealthResponse, 0)
+	for rows.Next() {
+		var s scheduleHealthResponse
+		if err := rows.Scan(
+			&s.ID, &s.Name, &s.Enabled, &s.LastRunAt, &s.NextRunAt,
+			&s.RunCount, &s.LastStatus, &s.LastError,
+		); err != nil {
+			log.Printf("ScheduleHealth: scan error: %v", err)
+			continue
+		}
+		schedules = append(schedules, s)
+	}
+	if err := rows.Err(); err != nil {
+		log.Printf("ScheduleHealth: rows error: %v", err)
+	}
+
+	c.JSON(http.StatusOK, schedules)
 }
 
 // History returns recent runs for a schedule from activity_logs.

--- a/platform/internal/handlers/schedules_test.go
+++ b/platform/internal/handlers/schedules_test.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"bytes"
+	"database/sql"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -120,6 +122,265 @@ func TestList_IncludesSourceColumn(t *testing.T) {
 	if !strings.Contains(body, `"source":"runtime"`) {
 		t.Errorf(`response missing "source":"runtime": %s`, body)
 	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// ==================== Health — issue #249 ====================
+//
+// GET /workspaces/:id/schedules/health is accessible to CanCommunicate peers
+// without workspace bearer auth. The handler mirrors the A2A proxy's auth
+// pattern: X-Workspace-ID + caller token + CanCommunicate gate.
+
+const healthWorkspaceID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+const healthCallerID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+// healthCols is the column set returned by the Health SELECT.
+var healthCols = []string{"id", "name", "enabled", "last_run_at", "next_run_at", "run_count", "last_status", "last_error"}
+
+// TestScheduleHealth_MissingCallerID_Rejected verifies that requests without
+// X-Workspace-ID are rejected with 401 — anonymous peer reads are not allowed.
+func TestScheduleHealth_MissingCallerID_Rejected(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	c.Request = httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+
+	handler.Health(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing caller, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestScheduleHealth_SelfCall_Allowed verifies that when callerID == workspaceID
+// (self-call) the request is allowed and health fields are returned without any
+// CanCommunicate DB lookups.
+func TestScheduleHealth_SelfCall_Allowed(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	// Self-call: no token check, no CanCommunicate queries.
+	// Expect only the health SELECT.
+	mock.ExpectQuery(`SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error\s+FROM workspace_schedules`).
+		WithArgs(healthWorkspaceID).
+		WillReturnRows(sqlmock.NewRows(healthCols).
+			AddRow("sched-1", "nightly", true, &now, &now, 42, "ok", ""))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", healthWorkspaceID) // self-call
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for self-call, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []scheduleHealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 1 || resp[0].ID != "sched-1" || resp[0].RunCount != 42 {
+		t.Errorf("unexpected health response: %+v", resp)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestScheduleHealth_CanCommunicatePeer_LegacyNoToken verifies that a legacy
+// peer (no live tokens on file for the caller) is grandfathered through the
+// token check and can read health when CanCommunicate is satisfied.
+func TestScheduleHealth_CanCommunicatePeer_LegacyNoToken(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// 1. validateCallerToken: caller has zero live tokens → grandfather through.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM workspace_auth_tokens`).
+		WithArgs(healthCallerID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// 2. CanCommunicate: caller and target share the same parent (siblings → allowed).
+	mockCanCommunicate(mock, healthCallerID, healthWorkspaceID, true)
+
+	// 3. Health SELECT.
+	mock.ExpectQuery(`SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error\s+FROM workspace_schedules`).
+		WithArgs(healthWorkspaceID).
+		WillReturnRows(sqlmock.NewRows(healthCols).
+			AddRow("sched-2", "hourly", true, &now, &now, 7, "ok", ""))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", healthCallerID)
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for peer with no tokens, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []scheduleHealthResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 1 || resp[0].RunCount != 7 {
+		t.Errorf("unexpected response: %+v", resp)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestScheduleHealth_AccessDenied_NonPeer verifies that a workspace which fails
+// CanCommunicate (different org branch) receives 403 — not 401 or 500.
+func TestScheduleHealth_AccessDenied_NonPeer(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	// 1. validateCallerToken: no live tokens → grandfather.
+	mock.ExpectQuery(`SELECT COUNT\(\*\) FROM workspace_auth_tokens`).
+		WithArgs(healthCallerID).
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+	// 2. CanCommunicate: different parents → denied.
+	mockCanCommunicate(mock, healthCallerID, healthWorkspaceID, false)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", healthCallerID)
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-peer, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestScheduleHealth_SystemCaller_Allowed verifies that system callers
+// (webhook:*, system:*, test:*) bypass token + CanCommunicate checks.
+func TestScheduleHealth_SystemCaller_Allowed(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// No token check, no CanCommunicate queries — just the health SELECT.
+	mock.ExpectQuery(`SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error\s+FROM workspace_schedules`).
+		WithArgs(healthWorkspaceID).
+		WillReturnRows(sqlmock.NewRows(healthCols).
+			AddRow("sched-3", "weekly", false, nil, &now, 0, "", ""))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", "system:monitor")
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for system caller, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestScheduleHealth_NoPromptExposed verifies that the health response never
+// includes prompt or cron_expr — only execution-state fields are returned.
+func TestScheduleHealth_NoPromptExposed(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	now := time.Now().UTC().Truncate(time.Second)
+
+	// No token check, no CanCommunicate queries for system caller.
+	mock.ExpectQuery(`SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error\s+FROM workspace_schedules`).
+		WithArgs(healthWorkspaceID).
+		WillReturnRows(sqlmock.NewRows(healthCols).
+			AddRow("sched-4", "daily", true, &now, &now, 3, "ok", ""))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", "system:test")
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	rawBody := w.Body.String()
+	for _, forbidden := range []string{"prompt", "cron_expr", "timezone"} {
+		if strings.Contains(rawBody, forbidden) {
+			t.Errorf("health response must not contain %q field: %s", forbidden, rawBody)
+		}
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet expectations: %v", err)
+	}
+}
+
+// TestScheduleHealth_DBError_Returns500 verifies that a DB failure on the health
+// SELECT produces a 500, not a panic.
+func TestScheduleHealth_DBError_Returns500(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	handler := NewScheduleHandler()
+
+	// No token check, no CanCommunicate queries for system caller.
+	mock.ExpectQuery(`SELECT id, name, enabled, last_run_at, next_run_at, run_count, last_status, last_error\s+FROM workspace_schedules`).
+		WithArgs(healthWorkspaceID).
+		WillReturnError(sql.ErrConnDone)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: healthWorkspaceID}}
+	req := httptest.NewRequest("GET", "/workspaces/"+healthWorkspaceID+"/schedules/health", nil)
+	req.Header.Set("X-Workspace-ID", "system:test")
+	c.Request = req
+
+	handler.Health(c)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on DB error, got %d: %s", w.Code, w.Body.String())
+	}
+
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Fatalf("unmet expectations: %v", err)
 	}

--- a/platform/internal/router/router.go
+++ b/platform/internal/router/router.go
@@ -250,6 +250,11 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 		wsAuth.DELETE("/schedules/:scheduleId", schedh.Delete)
 		wsAuth.POST("/schedules/:scheduleId/run", schedh.RunNow)
 		wsAuth.GET("/schedules/:scheduleId/history", schedh.History)
+		// Schedule health — open to CanCommunicate peers (no workspace bearer token
+		// required) so peer agents can detect silent cron failures without admin auth.
+		// Auth is enforced inside the handler via X-Workspace-ID + CanCommunicate
+		// (mirrors the /workspaces/:id/a2a pattern). Issue #249.
+		r.GET("/workspaces/:id/schedules/health", schedh.Health)
 
 		// Memory
 		memh := handlers.NewMemoryHandler()

--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -12,7 +12,7 @@ import httpx
 import uvicorn
 from a2a.server.apps import A2AStarletteApplication
 from a2a.server.request_handlers import DefaultRequestHandler
-from a2a.server.tasks import InMemoryTaskStore
+from a2a.server.tasks import InMemoryTaskStore, InMemoryPushNotificationConfigStore, BasePushNotificationSender
 from a2a.types import AgentCard, AgentCapabilities, AgentSkill
 
 from adapters import get_adapter, AdapterConfig
@@ -158,20 +158,13 @@ async def main():  # pragma: no cover
         defaultOutputModes=["text/plain", "application/json"],
     )
 
-    # 7. Wrap in A2A.
-    #
-    # Regression fix (#204): PR #198 tried to wire push_config_store +
-    # push_sender to satisfy #175 (push notification capability), but
-    # PushNotificationSender is an abstract base class in the a2a-sdk and
-    # can't be instantiated directly. Passing it crashed main.py on startup
-    # with `TypeError: Can't instantiate abstract class`. Dropped back to
-    # DefaultRequestHandler's own defaults — pushNotifications capability
-    # in the AgentCard below is still advertised via AgentCapabilities so
-    # clients know we COULD do pushes; actually implementing them requires
-    # a concrete sender subclass, tracked as a Phase-H follow-up to #175.
+    # 7. Wrap in A2A
+    push_config_store = InMemoryPushNotificationConfigStore()
     handler = DefaultRequestHandler(
         agent_executor=executor,
         task_store=InMemoryTaskStore(),
+        push_config_store=push_config_store,
+        push_sender=BasePushNotificationSender(httpx.AsyncClient(), push_config_store),
     )
 
     app = A2AStarletteApplication(

--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -159,6 +159,9 @@ async def main():  # pragma: no cover
     )
 
     # 7. Wrap in A2A
+    # Issue #204 — use BasePushNotificationSender (concrete) not PushNotificationSender
+    # (abstract ABC with abstract send_notification). Sharing the same push_config_store
+    # instance with DefaultRequestHandler ensures registration and delivery use the same store.
     push_config_store = InMemoryPushNotificationConfigStore()
     handler = DefaultRequestHandler(
         agent_executor=executor,

--- a/workspace-template/tests/test_main_startup.py
+++ b/workspace-template/tests/test_main_startup.py
@@ -1,0 +1,229 @@
+"""Regression tests for workspace startup — issue #204.
+
+Guards against re-introducing the abstract PushNotificationSender instantiation
+in main.py that causes a TypeError crash on every workspace agent startup.
+
+Background: commit 1c07046 (PR #198) originally wired
+  push_sender=PushNotificationSender()
+PushNotificationSender is an ABC with abstract method send_notification — Python
+raises TypeError at runtime before any agent code runs.
+
+Fix: replaced with BasePushNotificationSender(httpx.AsyncClient(), push_config_store).
+These 12 tests prevent regression via source-code analysis and live SDK checks.
+"""
+
+import importlib.util
+import inspect
+import os
+import re
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_MAIN_PY = os.path.join(os.path.dirname(os.path.dirname(__file__)), "main.py")
+
+
+def _read_main() -> str:
+    with open(_MAIN_PY) as f:
+        return f.read()
+
+
+def _load_real_module(dotted_name: str):
+    """Load the real (installed) module, bypassing conftest sys.modules mocks.
+
+    conftest replaces a2a.* entries in sys.modules with stubs whose __spec__ is
+    None, causing importlib.util.find_spec to raise ValueError. Work around by
+    temporarily removing all a2a.* mocks, importing the real package, then
+    restoring the stubs so subsequent test code still sees the mocks.
+    """
+    import sys
+
+    # Save and remove all a2a.* mock entries so importlib sees the real package
+    saved = {k: v for k, v in sys.modules.items() if k == "a2a" or k.startswith("a2a.")}
+    for k in saved:
+        del sys.modules[k]
+
+    try:
+        return importlib.import_module(dotted_name)
+    except Exception:
+        return None
+    finally:
+        # Always restore the conftest mocks so other tests are unaffected
+        for k, v in saved.items():
+            if k not in sys.modules:
+                sys.modules[k] = v
+
+
+# ---------------------------------------------------------------------------
+# 1–4: Source-code regression guards — no SDK needed
+# ---------------------------------------------------------------------------
+
+def test_main_does_not_import_bare_push_notification_sender():
+    """PushNotificationSender (abstract) must never appear on an import line in main.py.
+
+    BasePushNotificationSender is acceptable; bare PushNotificationSender is not.
+    """
+    src = _read_main()
+    bad_import_lines = [
+        line for line in src.splitlines()
+        if "PushNotificationSender" in line
+        and "BasePushNotificationSender" not in line
+        and re.match(r"\s*(import|from)\s", line)
+    ]
+    assert not bad_import_lines, (
+        f"main.py imports bare (abstract) PushNotificationSender: {bad_import_lines}"
+    )
+
+
+def test_main_does_not_instantiate_bare_push_notification_sender():
+    """PushNotificationSender() call must not appear in main.py (it is abstract)."""
+    src = _read_main()
+    # Match "PushNotificationSender(" not preceded by "Base"
+    matches = re.findall(r"(?<!Base)PushNotificationSender\s*\(", src)
+    assert not matches, (
+        "main.py instantiates abstract PushNotificationSender() — "
+        "use BasePushNotificationSender instead"
+    )
+
+
+def test_main_push_sender_uses_base_concrete_class():
+    """push_sender= in DefaultRequestHandler must use BasePushNotificationSender."""
+    src = _read_main()
+    match = re.search(r"push_sender\s*=\s*(\w+)", src)
+    if match is None:
+        pytest.skip("push_sender not explicitly set in main.py (None default is also acceptable)")
+    used_class = match.group(1)
+    assert used_class == "BasePushNotificationSender", (
+        f"push_sender= uses '{used_class}' — must be BasePushNotificationSender (concrete)"
+    )
+
+
+def test_main_is_syntactically_valid():
+    """main.py must compile without SyntaxError."""
+    src = _read_main()
+    try:
+        compile(src, _MAIN_PY, "exec")
+    except SyntaxError as e:
+        raise AssertionError(f"main.py has a SyntaxError: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# 5–8: Real SDK checks — load installed a2a package bypassing conftest mocks
+# ---------------------------------------------------------------------------
+
+def test_push_notification_sender_is_abstract_in_sdk():
+    """Regression guard: PushNotificationSender must be an ABC in the installed SDK.
+
+    If the SDK ever makes it concrete, we should revisit whether BasePushNotificationSender
+    is still the right choice.
+    """
+    real = _load_real_module("a2a.server.tasks")
+    if real is None:
+        pytest.skip("Could not load real a2a.server.tasks")
+    assert inspect.isabstract(real.PushNotificationSender), (
+        "PushNotificationSender is no longer abstract in the installed SDK — "
+        "update this test and reconsider main.py wiring"
+    )
+
+
+def test_base_push_notification_sender_is_concrete_in_sdk():
+    """BasePushNotificationSender must be concrete (safe to instantiate)."""
+    real = _load_real_module("a2a.server.tasks")
+    if real is None:
+        pytest.skip("Could not load real a2a.server.tasks")
+    assert not inspect.isabstract(real.BasePushNotificationSender), (
+        "BasePushNotificationSender has become abstract — update main.py"
+    )
+
+
+def test_base_push_notification_sender_constructor_signature():
+    """BasePushNotificationSender.__init__ must accept (httpx_client, config_store)."""
+    real = _load_real_module("a2a.server.tasks")
+    if real is None:
+        pytest.skip("Could not load real a2a.server.tasks")
+    sig = inspect.signature(real.BasePushNotificationSender.__init__)
+    params = list(sig.parameters.keys())
+    assert "httpx_client" in params, (
+        f"BasePushNotificationSender.__init__ no longer has 'httpx_client' param: {params}"
+    )
+    assert "config_store" in params, (
+        f"BasePushNotificationSender.__init__ no longer has 'config_store' param: {params}"
+    )
+
+
+def test_default_request_handler_push_sender_defaults_to_none():
+    """DefaultRequestHandler must accept push_sender=None as its default.
+
+    This means omitting push_sender entirely is safe — no crash on startup.
+    """
+    real = _load_real_module("a2a.server.request_handlers")
+    if real is None:
+        pytest.skip("Could not load real a2a.server.request_handlers")
+    sig = inspect.signature(real.DefaultRequestHandler.__init__)
+    assert "push_sender" in sig.parameters, (
+        "DefaultRequestHandler no longer has a push_sender parameter"
+    )
+    assert sig.parameters["push_sender"].default is None, (
+        "DefaultRequestHandler.push_sender no longer defaults to None"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 9–12: Capability and behaviour guards (source-code + a2a_executor)
+# ---------------------------------------------------------------------------
+
+def test_main_advertises_state_transition_history():
+    """AgentCapabilities in main.py must set stateTransitionHistory=True (issue #174)."""
+    src = _read_main()
+    assert "stateTransitionHistory=True" in src, (
+        "main.py must set stateTransitionHistory=True in AgentCapabilities"
+    )
+
+
+def test_main_wires_push_notifications_from_config():
+    """AgentCapabilities.pushNotifications must be wired from config (not hardcoded False)."""
+    src = _read_main()
+    assert "pushNotifications=" in src, (
+        "AgentCapabilities must wire pushNotifications"
+    )
+    # Must not be hardcoded off
+    assert "pushNotifications=False" not in src, (
+        "pushNotifications must not be hardcoded False — read from config"
+    )
+
+
+def test_main_push_config_store_shared_between_handler_and_sender():
+    """push_config_store must be the same object passed to both DefaultRequestHandler
+    and BasePushNotificationSender, ensuring registration and delivery share state.
+    """
+    src = _read_main()
+    # Both usages must reference the same variable (not two separate InMemory... calls)
+    inline_stores = re.findall(r"InMemoryPushNotificationConfigStore\(\)", src)
+    assert len(inline_stores) <= 1, (
+        "main.py creates multiple InMemoryPushNotificationConfigStore instances — "
+        "the same store must be shared between DefaultRequestHandler and BasePushNotificationSender"
+    )
+
+
+def test_cancel_method_is_not_a_pass_stub():
+    """a2a_executor.cancel() must not be a no-op pass stub (issue #173).
+
+    Regression: cancel() was previously 'pass' with # pragma: no cover.
+    It must emit at least one event to the queue.
+    """
+    from a2a_executor import LangGraphA2AExecutor
+    src = inspect.getsource(LangGraphA2AExecutor.cancel)
+    non_trivial_lines = [
+        line.strip() for line in src.splitlines()
+        if line.strip()
+        and not line.strip().startswith(('"""', "'''", "#", "async def", "def"))
+        and line.strip() != "pass"
+    ]
+    assert non_trivial_lines, (
+        "cancel() must not be a no-op stub — it must emit a TaskStatusUpdateEvent "
+        "with state=canceled so clients see the state transition"
+    )


### PR DESCRIPTION
## Problem

`GET /workspaces/:id/schedules` is behind `WorkspaceAuth`, which requires the target workspace's own bearer token. Peer agents in the org hierarchy never hold that token — so they cannot read `last_run_at`, `last_status`, or `run_count`, making silent cron failures completely undetectable from the outside. Tracked in #249.

## Fix

New endpoint: **`GET /workspaces/:id/schedules/health`**

Registered outside the `wsAuth` group (mirrors the `/workspaces/:id/a2a` pattern). Auth is enforced by the handler itself:

1. `X-Workspace-ID` header required (else 401)
2. Self-calls (`callerID == targetID`) pass immediately
3. System callers (`system:*`, `webhook:*`, `test:*`) pass immediately
4. All other callers: `validateCallerToken` + `CanCommunicate` gate (same pattern as A2A proxy)

Response is a reduced `scheduleHealthResponse` — exposes only `id`, `name`, `enabled`, `last_run_at`, `next_run_at`, `run_count`, `last_status`, `last_error`. Never exposes `prompt` or `cron_expr`.

## Also includes (bundled since they share the branch)

- **fix(#204)**: Replace abstract `PushNotificationSender` with `BasePushNotificationSender` (concrete) in `workspace-template/main.py` — fixes startup crash introduced in PR #198.
- **test(#204)**: 12 regression tests for the BasePushNotificationSender fix.

## Test plan

- [ ] `TestScheduleHealth_MissingCallerID_Rejected` — 401 when no X-Workspace-ID
- [ ] `TestScheduleHealth_SelfCall_Allowed` — 200 self-call, no CanCommunicate queries
- [ ] `TestScheduleHealth_CanCommunicatePeer_LegacyNoToken` — grandfathered peer (0 tokens) + CanCommunicate allowed → 200
- [ ] `TestScheduleHealth_AccessDenied_NonPeer` — CanCommunicate denied → 403
- [ ] `TestScheduleHealth_SystemCaller_Allowed` — system:monitor bypasses all checks → 200
- [ ] `TestScheduleHealth_NoPromptExposed` — response must not contain prompt/cron_expr/timezone fields
- [ ] `TestScheduleHealth_DBError_Returns500` — DB error on health SELECT → 500
- [ ] `TestHistory_IncludesErrorDetail` — history endpoint surfaces error_detail
- [ ] `BasePushNotificationSender` instantiation tests (12 tests in test(#204) commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)