### PR TITLE
fix(compose): platform build context must be repo root

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,17 @@ services:
   # --- Platform ---
   platform:
     build:
-      context: ./platform
-      dockerfile: Dockerfile
+      # Build context MUST be repo root, not ./platform — the Dockerfile
+      # COPYs `platform/migrations`, `platform/go.mod`,
+      # `workspace-configs-templates/` etc. via repo-relative paths so it
+      # can bake in templates + migrations alongside the platform binary.
+      # When context was ./platform earlier, docker silently cached an
+      # earlier image (the COPY platform/migrations resolved to nothing
+      # under ./platform/, so layers stopped invalidating) — manifested
+      # as migration 023 not landing after PR #417 merged. CI workflow
+      # already uses context=. , this aligns local with CI.
+      context: .
+      dockerfile: platform/Dockerfile
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
Fixes silent build-cache mismatch where `docker compose up -d --build platform` was a no-op because `context: ./platform` made the Dockerfile's repo-relative COPYs miss.

Caught when PR #417's migration 023 didn't apply after rebuild.

CI already uses `context: .` + `file: ./platform/Dockerfile`. This aligns local compose with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)