### PR TITLE
fix(canvas): replace AuthGate null loading state with zinc-950 backdrop

### DIFF
--- a/canvas/src/components/AuthGate.tsx
+++ b/canvas/src/components/AuthGate.tsx
@@ -56,8 +56,9 @@ export function AuthGate({ children }: { children: ReactNode }) {
   }, [state]);
 
   if (state.kind === "loading") {
-    // Minimal placeholder; canvas has its own loading UI downstream.
-    return null;
+    // Zinc-950 backdrop matches the canvas background so the browser
+    // never paints a white flash while the session round-trip resolves.
+    return <div className="fixed inset-0 bg-zinc-950" aria-hidden="true" />;
   }
   if (state.kind === "anonymous" && !state.skipRedirect) {
     // Redirect already firing from the effect above; render nothing in


### PR DESCRIPTION
Closes #430.

## Problem

`AuthGate` returned `null` during the session fetch on SaaS deployments (`getTenantSlug()` returns a slug). During the network round-trip (200–500ms on slow connections) the browser painted a blank/white screen before the zinc-950 canvas background appeared.

## Fix

One-line change in `AuthGate.tsx`:

```diff
- return null;
+ return <div className="fixed inset-0 bg-zinc-950" aria-hidden="true" />;
```

The zinc-950 backdrop matches the canvas background exactly — the browser always paints the correct dark background from the first frame. The canvas loading UI renders on top once the session resolves, no visible transition.

## Test plan
- [ ] On a SaaS deployment (slug present), hard-refresh the canvas — confirm no white flash
- [ ] On local dev (no slug), gate is a pass-through — no change in behavior
- [ ] 485/485 vitest tests pass
- [ ] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)