### PR TITLE
fix(provisioner): rebuild_config flag recovers workspace from destroyed config volume

### DIFF
--- a/platform/internal/handlers/workspace_provision.go
+++ b/platform/internal/handlers/workspace_provision.go
@@ -248,6 +248,25 @@ func findTemplateByName(configsDir, name string) string {
 	return ""
 }
 
+// resolveOrgTemplate looks for a matching role directory under
+// configsDir/org-templates/ and returns the absolute path and a short label
+// ("org-templates/<dir>"). Used by the restart handler's rebuild_config path
+// (#239) so a workspace can recover from a destroyed config volume without
+// admin intervention.
+// Returns ("", "") when no match is found.
+func resolveOrgTemplate(configsDir, wsName string) (path, label string) {
+	orgDir := filepath.Join(configsDir, "org-templates")
+	match := findTemplateByName(orgDir, wsName)
+	if match == "" {
+		return "", ""
+	}
+	full := filepath.Join(orgDir, match)
+	if _, err := os.Stat(full); err != nil {
+		return "", ""
+	}
+	return full, "org-templates/" + match
+}
+
 // configDirName returns the standard config directory name for a workspace ID.
 // Used by resolveConfigDir in templates.go for host-side template resolution.
 func configDirName(workspaceID string) string {

--- a/platform/internal/handlers/workspace_provision_test.go
+++ b/platform/internal/handlers/workspace_provision_test.go
@@ -121,6 +121,66 @@ func TestFindTemplateByName_InvalidDir(t *testing.T) {
 	}
 }
 
+// ==================== resolveOrgTemplate ====================
+
+// TestResolveOrgTemplate_HitByDirName verifies the happy path: org-templates/<role>
+// dir exists with a normalized name match.
+func TestResolveOrgTemplate_HitByDirName(t *testing.T) {
+	configsDir := t.TempDir()
+	orgDir := filepath.Join(configsDir, "org-templates")
+	roleDir := filepath.Join(orgDir, "technical-researcher")
+	os.MkdirAll(roleDir, 0755)
+
+	path, label := resolveOrgTemplate(configsDir, "Technical Researcher")
+	if path != roleDir {
+		t.Errorf("expected path %q, got %q", roleDir, path)
+	}
+	if label != "org-templates/technical-researcher" {
+		t.Errorf("expected label %q, got %q", "org-templates/technical-researcher", label)
+	}
+}
+
+// TestResolveOrgTemplate_HitByConfigYAML verifies the config.yaml name-field
+// fallback works when the dir name doesn't match the workspace name directly.
+func TestResolveOrgTemplate_HitByConfigYAML(t *testing.T) {
+	configsDir := t.TempDir()
+	orgDir := filepath.Join(configsDir, "org-templates")
+	roleDir := filepath.Join(orgDir, "org-backend")
+	os.MkdirAll(roleDir, 0755)
+	os.WriteFile(filepath.Join(roleDir, "config.yaml"), []byte("name: Backend Engineer\n"), 0644)
+
+	path, label := resolveOrgTemplate(configsDir, "Backend Engineer")
+	if path != roleDir {
+		t.Errorf("expected path %q, got %q", roleDir, path)
+	}
+	if label != "org-templates/org-backend" {
+		t.Errorf("expected label %q, got %q", "org-templates/org-backend", label)
+	}
+}
+
+// TestResolveOrgTemplate_NoOrgTemplatesDir returns empty when the org-templates
+// directory does not exist.
+func TestResolveOrgTemplate_NoOrgTemplatesDir(t *testing.T) {
+	configsDir := t.TempDir() // no org-templates subdir created
+
+	path, label := resolveOrgTemplate(configsDir, "Technical Researcher")
+	if path != "" || label != "" {
+		t.Errorf("expected empty, got path=%q label=%q", path, label)
+	}
+}
+
+// TestResolveOrgTemplate_NoMatchInOrgTemplates returns empty when org-templates
+// exists but has no entry matching the workspace name.
+func TestResolveOrgTemplate_NoMatchInOrgTemplates(t *testing.T) {
+	configsDir := t.TempDir()
+	os.MkdirAll(filepath.Join(configsDir, "org-templates", "seo-agent"), 0755)
+
+	path, label := resolveOrgTemplate(configsDir, "Backend Engineer")
+	if path != "" || label != "" {
+		t.Errorf("expected empty, got path=%q label=%q", path, label)
+	}
+}
+
 // ==================== ensureDefaultConfig ====================
 
 func TestEnsureDefaultConfig_LangGraph(t *testing.T) {

--- a/platform/internal/handlers/workspace_restart.go
+++ b/platform/internal/handlers/workspace_restart.go
@@ -107,6 +107,7 @@ func (h *WorkspaceHandler) Restart(c *gin.Context) {
 		Template      string `json:"template"`
 		ApplyTemplate bool   `json:"apply_template"` // force re-apply runtime-default template (e.g. after runtime change)
 		Reset         bool   `json:"reset"`          // #12: discard claude-sessions volume before restart
+		RebuildConfig bool   `json:"rebuild_config"` // #239: re-render config volume from org-template source (recovery path when volume was destroyed)
 	}
 	c.ShouldBindJSON(&body)
 
@@ -128,6 +129,17 @@ func (h *WorkspaceHandler) Restart(c *gin.Context) {
 		if _, err := os.Stat(candidatePath); err == nil {
 			templatePath = candidatePath
 			configLabel = template
+		}
+	}
+
+	// #239: rebuild_config=true — try org-templates as last-resort source so a
+	// workspace with a destroyed config volume can self-recover without admin
+	// intervention. Only fires when no other template was resolved above.
+	if templatePath == "" && body.RebuildConfig {
+		if p, label := resolveOrgTemplate(h.configsDir, wsName); p != "" {
+			templatePath = p
+			configLabel = label
+			log.Printf("Restart: rebuild_config — using org-template %s for %s (%s)", label, wsName, id)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Adds `rebuild_config: true` to `POST /workspaces/:id/restart` request body
- When set, the provisioner falls back to `configsDir/org-templates/<role>/` as template source — enabling self-recovery when both the container and its `/configs` volume were destroyed
- New pure helper `resolveOrgTemplate(configsDir, wsName)` extracted and independently tested (4 test cases)

## Root cause (from #239)

`findTemplateByName` only searches the top-level `configsDir`, which holds workspace-instance dirs (`ws-{id[:12]}/`). Org-template role dirs live one level deeper under `org-templates/`. A workspace in `failed` state with a missing volume had no recovery path short of a full `docker-compose down -v`.

## Fix

New `resolveOrgTemplate` helper + three-line change in the `Restart` handler (per PM spec in #239):

```go
if templatePath == "" && body.RebuildConfig {
    if p, label := resolveOrgTemplate(h.configsDir, wsName); p != "" {
        templatePath = p
        configLabel = label
    }
}
```

The workspace calls the endpoint with its own bearer token — no admin credentials needed.

## Usage

```bash
curl -s -X POST \
  -H "Authorization: Bearer $(cat /configs/.auth_token)" \
  -H "Content-Type: application/json" \
  -d '{"rebuild_config": true}' \
  http://host.docker.internal:8080/workspaces/$WORKSPACE_ID/restart
```

## Test plan

- [x] `TestResolveOrgTemplate_HitByDirName` — normalized name match
- [x] `TestResolveOrgTemplate_HitByConfigYAML` — config.yaml name-field match
- [x] `TestResolveOrgTemplate_NoOrgTemplatesDir` — graceful no-op when org-templates missing
- [x] `TestResolveOrgTemplate_NoMatchInOrgTemplates` — graceful no-op when no role matches
- [x] Existing restart handler tests unchanged

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)