### PR TITLE
fix(auth): revoke stale tokens on apply_template restart — closes #418

### DIFF
--- a/platform/internal/handlers/workspace_restart.go
+++ b/platform/internal/handlers/workspace_restart.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/models"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/wsauth"
 	"github.com/gin-gonic/gin"
 )
 
@@ -149,6 +150,22 @@ func (h *WorkspaceHandler) Restart(c *gin.Context) {
 			templatePath = runtimeTemplate
 			configLabel = dbRuntime + "-default"
 			log.Printf("Restart: applying template %s (runtime change)", configLabel)
+		}
+	}
+
+	// #418: when apply_template is true the caller is requesting a full
+	// config reset (e.g. runtime was changed, org-template freshened, or
+	// the config volume was wiped and rebuilt). Revoke all existing auth
+	// tokens so the workspace bootstraps a fresh one on its next
+	// /registry/register call. Without this, a workspace that lost its
+	// /configs/.auth_token file (volume destroyed + rebuilt) is stuck in
+	// a 401 loop: the DB still has the old token so registration requires
+	// a bearer header the workspace no longer possesses.
+	if body.ApplyTemplate && templatePath != "" {
+		if revokeErr := wsauth.RevokeAllForWorkspace(ctx, db.DB, id); revokeErr != nil {
+			log.Printf("Restart: failed to revoke tokens for %s: %v (continuing)", id, revokeErr)
+		} else {
+			log.Printf("Restart: revoked auth tokens for %s — fresh token will be issued on next register", id)
 		}
 	}
 

--- a/workspace-template/main.py
+++ b/workspace-template/main.py
@@ -226,6 +226,22 @@ async def main():  # pragma: no cover
                         print(f"Saved workspace auth token (prefix={tok[:8]}…)")
                 except Exception as parse_exc:
                     print(f"Warning: couldn't parse register response for token: {parse_exc}")
+            elif resp.status_code == 401:
+                # #418: registration rejected — platform has a live token on file
+                # but our /configs/.auth_token is missing (e.g. config volume was
+                # wiped). The workspace is stuck: it can't re-register without the
+                # token, and it can't get a new token without registering.
+                # Recovery: restart with {"apply_template": true} via the Canvas
+                # Config tab or API — the platform will revoke stale tokens and
+                # issue a fresh one on the next register call.
+                print(
+                    "FATAL: registration rejected (401 — missing auth token). "
+                    "The /configs/.auth_token file is absent but the platform "
+                    "has a live token on record. Recovery: POST "
+                    f"/workspaces/{workspace_id}/restart {{\"apply_template\":true}} "
+                    "to revoke stale tokens and re-bootstrap auth. "
+                    "All A2A calls will fail until this is resolved."
+                )
         except Exception as e:
             print(f"Warning: failed to register with platform: {e}")
 


### PR DESCRIPTION
## Summary

- **Root cause (#418)**: When a workspace restarts with `apply_template:true` (e.g. after config-volume rebuild or runtime change), its `/configs/.auth_token` file may have been lost while the platform DB still holds a live token. The workspace is stuck in a 401 loop — registration requires a bearer header it no longer possesses, so it can never obtain a fresh one.
- **Platform fix** (`workspace_restart.go`): revoke all tokens when `apply_template:true` resolves a valid template path. On next `/registry/register`, `HasAnyLiveToken` returns false and a fresh token is issued automatically.
- **Workspace fix** (`main.py`): log a `FATAL` message with the exact recovery command when registration returns 401, making the failure self-diagnosing.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Normal restart (no `apply_template`) | token preserved | token preserved (unchanged) |
| `apply_template:true` restart, template found | 401 loop if token file lost | tokens revoked → fresh token on next register |
| `apply_template:true` restart, no template found | token preserved | token preserved (revocation skipped — volume is reused as-is) |
| Registration returns 401 | silent failure | FATAL log + recovery command printed |

## Note for PR #445 reviewer
PR #445 adds `rebuild_config:true` which similarly rebuilds the config volume from org-template. That path also needs token revocation added to it after merging — suggest amending #445 or follow-up PR to add `if body.RebuildConfig && templatePath != ""` revocation alongside the `apply_template` case.

## Test plan
- [ ] Go unit tests pass (`go test -race ./...`)
- [ ] Python tests pass (`pytest --cov`)
- [ ] Manual: restart workspace with `apply_template:true` → verify token file populated after restart
- [ ] Manual: workspace with wiped config volume → `apply_template:true` restart → A2A calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)