### PR TITLE
fix(security): sanitize registry 500 errors + strip auth headers from canvas proxy

### DIFF
--- a/platform/internal/handlers/registry.go
+++ b/platform/internal/handlers/registry.go
@@ -144,7 +144,7 @@ func (h *RegistryHandler) Register(c *gin.Context) {
 	`, payload.ID, payload.ID, payload.URL, agentCardStr)
 	if err != nil {
 		log.Printf("Registry register error: %v (id=%s)", err, payload.ID)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("failed to register: %v", err)})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "registration failed"})
 		return
 	}
 

--- a/platform/internal/router/canvas_proxy.go
+++ b/platform/internal/router/canvas_proxy.go
@@ -33,6 +33,11 @@ func newCanvasProxy(targetURL string) gin.HandlerFunc {
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
 			req.Host = target.Host
+			// Strip credentials that belong to the platform API — the canvas
+			// Next.js server is internal and should never receive workspace
+			// bearer tokens or session cookies (N2 / issue #451).
+			req.Header.Del("Authorization")
+			req.Header.Del("Cookie")
 		},
 		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, err error) {
 			log.Printf("canvas_proxy: %v", err)


### PR DESCRIPTION
## Summary

Two low-friction security fixes from the Cycle 15 audit. No behaviour change for normal flows.

- **H1 (issue #435):** `POST /registry/register` was returning raw PostgreSQL error details (table names, constraint names, SQL state) in 500 responses. Replaced with a generic `"registration failed"` message; full error still logged server-side.
- **N2 (issue #451):** The canvas reverse-proxy `Director` was forwarding `Authorization` and `Cookie` headers to the Next.js server in the combined tenant image. Added explicit `req.Header.Del()` calls so workspace bearer tokens are never forwarded to the canvas process.

## Files changed

| File | Change |
|------|--------|
| `platform/internal/handlers/registry.go:147` | `fmt.Sprintf("failed to register: %v", err)` → `"registration failed"` |
| `platform/internal/router/canvas_proxy.go` | `req.Header.Del("Authorization")` + `req.Header.Del("Cookie")` in Director |

## Test plan

- [ ] `POST /registry/register` with a duplicate UUID → 500 body is `{"error":"registration failed"}`, not `{"error":"pq: duplicate key..."}`
- [ ] Server log still contains the full pq error for operator debugging
- [ ] Canvas proxy: confirm `Authorization` header is absent on proxied requests
- [ ] `go test -race ./...` passes

## Related issues

Closes #435
Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)