### PR TITLE
fix(ci): bypass docker login + macOS Keychain for image publish

### DIFF
--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -44,25 +44,41 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Isolate Docker config (skip macOS Keychain)
-        # Same workaround as publish-platform-image.yml — launchd service
-        # runners can't reach the Keychain, so we write a disposable
-        # config.json with an empty credsStore to force auths-map storage.
+      - name: Configure GHCR auth (skip docker login + Keychain)
+        # The Mac mini self-hosted runner runs as a non-interactive launchd
+        # user agent. `docker/login-action` calls `docker login`, which on
+        # macOS unconditionally writes credentials to osxkeychain — even
+        # when DOCKER_CONFIG/config.json declares `credsStore: ""`. Docker
+        # rewrites credsStore back to "osxkeychain" after a successful
+        # login (verified locally 2026-04-16). Keychain is locked under
+        # launchd, so storage fails with `User interaction is not allowed
+        # (-25308)`. Earlier attempts (#273, #319, #322, #341) all relied
+        # on the credsStore-empty workaround; none worked.
+        #
+        # Bypass `docker login` entirely: write the base64(user:pat) auth
+        # directly into the disposable DOCKER_CONFIG. build-push-action
+        # and the Docker daemon both honor the auths map for push, no
+        # daemon login (and no Keychain) involved.
         shell: bash
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -eu
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
-          {
-            "auths": {},
-            "credsStore": "",
-            "credHelpers": {}
-          }
+          AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
+          umask 077
+          cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
+          { "auths": { "ghcr.io": { "auth": "${AUTH}" } } }
           JSON
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
+          # Diagnostics that don't leak the token.
           echo "=== Runner docker diagnostics ==="
           command -v docker || echo "(docker not in PATH)"
           docker --version 2>&1 || true
+          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
+          echo "=== auths registries (no values) ==="
+          grep -o '"[a-zA-Z0-9.-]*\.io"' "${RUNNER_TEMP}/docker-config/config.json" || true
 
       - name: Set up QEMU
         # Apple-silicon runner building linux/amd64 images for x86 hosts.
@@ -72,13 +88,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compute tags
         id: tags

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -38,47 +38,53 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Isolate Docker config (skip keychain)
+      - name: Configure registry auth (skip docker login + Keychain)
         # The Mac mini self-hosted runner runs as a non-interactive
-        # launchd service; docker/login-action's default credential store
-        # is the macOS Keychain, which raises
-        #   error storing credentials - err: exit status 1, out:
-        #   `User interaction is not allowed. (-25308)`
-        # without an unlocked desktop session.
+        # launchd user agent. `docker/login-action` calls `docker login`,
+        # which on macOS unconditionally writes credentials to osxkeychain
+        # — even when DOCKER_CONFIG/config.json declares `credsStore: ""`.
+        # Docker rewrites credsStore back to "osxkeychain" on every
+        # successful login (verified locally 2026-04-16). The Keychain is
+        # locked under launchd, so storage fails with `User interaction is
+        # not allowed (-25308)`. Earlier attempts (#273, #319, #322, #341)
+        # all relied on the credsStore-empty workaround; none worked.
         #
-        # Point DOCKER_CONFIG at a per-run temp dir. IMPORTANT: writing
-        # `{"auths": {}}` alone is NOT enough — Docker on macOS picks up
-        # `osxkeychain` as the default credential store even when
-        # config.json doesn't declare one, inheriting from Docker
-        # Desktop's bundled credsStore binding. We must explicitly set
-        # `credsStore` to an empty string AND clear `credHelpers` so the
-        # login step writes credentials into the auths map of this
-        # disposable config.json rather than reaching for the keychain.
-        # (First tried in #273 without the empty-credsStore line; #319
-        # + #322 merges showed it still regressed.)
+        # Bypass `docker login` entirely: write the base64(user:pat) auths
+        # for ghcr.io AND registry.fly.io directly into the disposable
+        # DOCKER_CONFIG. build-push-action and the Docker daemon both
+        # honor the auths map for push, no daemon login required, no
+        # Keychain involved.
         #
-        # Plus diagnostics: print the docker path so a future EACCES on
-        # /usr/local/bin/docker surfaces in the log instead of via a
-        # cryptic docker-login failure mid-step.
+        # Fly registry username MUST be literal "x" (verified 2026-04-15).
+        # FLY_API_TOKEN lives in GitHub Actions secrets AND in `fly secrets`
+        # on molecule-cp — see docs/runbooks/saas-secrets.md before rotating.
         shell: bash
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLY_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          set -euo pipefail
+          set -eu
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
+          GHCR_AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
+          FLY_AUTH=$(printf '%s:%s' 'x' "${FLY_TOKEN}" | base64)
+          umask 077
+          cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
           {
-            "auths": {},
-            "credsStore": "",
-            "credHelpers": {}
+            "auths": {
+              "ghcr.io":          { "auth": "${GHCR_AUTH}" },
+              "registry.fly.io":  { "auth": "${FLY_AUTH}" }
+            }
           }
           JSON
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
+          # Diagnostics that don't leak the tokens.
           echo "=== Runner docker diagnostics ==="
-          echo "PATH=$PATH"
-          command -v docker || echo "(docker not in PATH — the runner is missing the Docker CLI or it's not symlinked to a visible location)"
+          command -v docker || echo "(docker not in PATH)"
           docker --version 2>&1 || true
           ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
-          echo "=== config.json after setup ==="
-          cat "${RUNNER_TEMP}/docker-config/config.json"
+          echo "=== auths registries (no values) ==="
+          grep -o '"[a-zA-Z0-9.-]*\.io"' "${RUNNER_TEMP}/docker-config/config.json" || true
 
       - name: Set up QEMU
         # Required on the Apple-silicon self-hosted runner — Fly tenant machines
@@ -92,26 +98,6 @@ jobs:
         # Buildx enables cache-from/cache-to via GHA cache and multi-arch
         # builds without local docker daemon wrangling.
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Log in to Fly registry
-        # username MUST be literal "x". Fly's registry returns 401 for any
-        # other value (verified locally 2026-04-15 — "molecule-ai" fails,
-        # "x" succeeds with the same token). The password is the FLY_API_TOKEN.
-        # Rotation: see docs/runbooks/saas-secrets.md — FLY_API_TOKEN lives in
-        # two places (GitHub Actions secret here + `fly secrets` on molecule-cp)
-        # and MUST be updated in both on rotation.
-        uses: docker/login-action@v3
-        with:
-          registry: registry.fly.io
-          username: x
-          password: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Compute tags
         id: tags


### PR DESCRIPTION
## TL;DR

`credsStore: ""` doesn't work. Docker on macOS rewrites it back to `"osxkeychain"` after every successful `docker login`, regardless of what config.json says. We have to skip `docker login` entirely.

## Root cause (verified locally 2026-04-16)

The Mac mini self-hosted runner runs as a non-interactive launchd user agent. `docker/login-action@v3` calls `docker login`. On macOS, `docker login` **unconditionally** writes credentials to osxkeychain — even when `DOCKER_CONFIG/config.json` declares `"credsStore": ""`.

Direct repro on the runner host:

```bash
TMP=$(mktemp -d); mkdir -p "$TMP/docker-config"
cat > "$TMP/docker-config/config.json" <<'JSON'
{ "auths": {}, "credsStore": "", "credHelpers": {} }
JSON

gh auth token | DOCKER_CONFIG="$TMP/docker-config" \
  docker login ghcr.io -u HongmingWang-Rabbit --password-stdin
# → "Login Succeeded"

cat "$TMP/docker-config/config.json"
# → {
# →   "auths": { "ghcr.io": {} },
# →   "credsStore": "osxkeychain"
# → }
```

Docker rewrote `credsStore` from `""` to `"osxkeychain"` and stored the credential in the Keychain (`auths.ghcr.io` is empty — the actual auth lives in the Keychain). When the Keychain is locked (which is the case under launchd without an interactive desktop session), this storage fails with:

```
error storing credentials - err: exit status 1,
out: `User interaction is not allowed. (-25308)`
```

Earlier attempts to work around this — #273, #319, #322, and most recently #341 — all relied on the credsStore-empty trick. None worked, because the OS-default credential helper binding wins.

## The fix

Replace `docker/login-action@v3` with a direct write of `base64(user:pat)` into `DOCKER_CONFIG/config.json`'s `auths` map:

```yaml
- name: Configure GHCR auth (skip docker login + Keychain)
  shell: bash
  env:
    GHCR_USER: ${{ github.actor }}
    GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    set -eu
    mkdir -p "${RUNNER_TEMP}/docker-config"
    AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
    umask 077
    cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
    { "auths": { "ghcr.io": { "auth": "${AUTH}" } } }
    JSON
    echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
```

`docker/build-push-action@v5` and the Docker daemon both honor the `auths` map for image push without going through `docker login`, so the Keychain is never invoked.

## Same shape in both workflows

| Workflow | Registries handled |
|---|---|
| `publish-canvas-image.yml` | `ghcr.io` |
| `publish-platform-image.yml` | `ghcr.io` + `registry.fly.io` |

Fly username remains literal `x` per the prior inline comment (verified 2026-04-15 — any other username returns 401).

## Security notes

- `AUTH` env var is never echoed. Heredoc writes it to disk via `umask 077` (file mode 600). The temp config dir lives under `RUNNER_TEMP` and is reaped at job end.
- Diagnostics are preserved (docker version, binary ls, registry list — keys only) so a future Docker-CLI permission regression remains visible without leaking secrets.
- A `grep -o '"[a-zA-Z0-9.-]*\.io"'` line lists registry keys without their auth values — confirms the config landed correctly.

## Adjacent host-side fix (not in this PR)

`/usr/local/bin` was `drwx------` on the runner, blocking the runner user from stat'ing `/usr/local/bin/docker`. Fixed live via `chmod a+rx /usr/local/bin`. The diagnostic `ls -la /usr/local/bin/docker` line in both workflows will surface a regression in the log if that permission ever flips back.

## Test plan

- [ ] Merge, then watch the next push of `canvas/**` or `platform/**` — both `Build & push` jobs should succeed
- [ ] Manually rerun the two recent failures (24506138960, 24504948138) once merged — they should go green
- [ ] Confirm pushed images are present in `ghcr.io/molecule-ai/{canvas,platform}` and `registry.fly.io/molecule-tenant`