### PR TITLE
fix(canvas): fitView on new workspace provision — respects user zoom (#426)

### DIFF
--- a/canvas/src/components/Canvas.tsx
+++ b/canvas/src/components/Canvas.tsx
@@ -129,20 +129,19 @@ function CanvasInner() {
   }, [selectNode]);
 
   // Team zoom-in: double-click a team node to zoom to its children
-  const { fitBounds, setCenter } = useReactFlow();
+  const { fitBounds, fitView } = useReactFlow();
 
-  // Pan to newly deployed workspace
+  // Pan to newly deployed workspace.
+  // Uses fitView({ nodes }) so the viewport adapts to any current zoom level
+  // instead of forcing zoom=1 (which was jarring when the user was zoomed out).
   const panTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   useEffect(() => {
     const handler = (e: Event) => {
       const { nodeId } = (e as CustomEvent<{ nodeId: string }>).detail;
-      // Small delay so ReactFlow has time to lay out the node
+      // Small delay so ReactFlow has time to measure the newly rendered node
       clearTimeout(panTimerRef.current);
       panTimerRef.current = setTimeout(() => {
-        const node = useCanvasStore.getState().nodes.find((n) => n.id === nodeId);
-        if (node) {
-          setCenter(node.position.x + 130, node.position.y + 60, { zoom: 1, duration: 500 });
-        }
+        fitView({ nodes: [{ id: nodeId }], duration: 400, padding: 0.3 });
       }, 100);
     };
     window.addEventListener("molecule:pan-to-node", handler);
@@ -150,7 +149,7 @@ function CanvasInner() {
       window.removeEventListener("molecule:pan-to-node", handler);
       clearTimeout(panTimerRef.current);
     };
-  }, [setCenter]);
+  }, [fitView]);
   useEffect(() => {
     const handler = (e: Event) => {
       const { nodeId } = (e as CustomEvent).detail;

--- a/canvas/src/components/__tests__/Canvas.pan-to-node.test.tsx
+++ b/canvas/src/components/__tests__/Canvas.pan-to-node.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+/**
+ * Tests that Canvas.tsx responds to the "molecule:pan-to-node" custom event
+ * (fired by canvas-events.ts on WORKSPACE_PROVISIONING for new nodes) by
+ * calling fitView({ nodes: [{ id }] }) instead of setCenter with a forced
+ * zoom=1 (which was jarring when the user was zoomed out — issue #426).
+ */
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, act, cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ── Shared fitView spy — must be set up before vi.mock hoisting ──────────────
+const mockFitView = vi.fn();
+const mockFitBounds = vi.fn();
+
+vi.mock("@xyflow/react", () => {
+  const ReactFlow = ({
+    children,
+    "aria-label": ariaLabel,
+  }: {
+    children?: React.ReactNode;
+    "aria-label"?: string;
+  }) => (
+    <div role="application" data-testid="react-flow" aria-label={ariaLabel}>
+      {children}
+    </div>
+  );
+  return {
+    __esModule: true,
+    default: ReactFlow,
+    ReactFlow,
+    ReactFlowProvider: ({ children }: { children?: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    Background: () => null,
+    Controls: () => null,
+    MiniMap: () => null,
+    BackgroundVariant: { Dots: "dots" },
+    useReactFlow: () => ({
+      fitView: mockFitView,
+      fitBounds: mockFitBounds,
+      setViewport: vi.fn(),
+      getIntersectingNodes: vi.fn(() => []),
+      setCenter: vi.fn(),
+    }),
+    applyNodeChanges: vi.fn((_: unknown, nodes: unknown) => nodes),
+    useStore: vi.fn(() => ({ width: 800, height: 600 })),
+  };
+});
+
+// ── Canvas store mock ─────────────────────────────────────────────────────────
+const mockStoreState = {
+  nodes: [{ id: "ws-1", position: { x: 100, y: 100 }, data: { name: "WS1" } }],
+  edges: [],
+  selectedNodeId: null,
+  panelTab: "chat",
+  dragOverNodeId: null,
+  contextMenu: null,
+  viewport: { x: 0, y: 0, zoom: 1 },
+  searchOpen: false,
+  onNodesChange: vi.fn(),
+  savePosition: vi.fn(),
+  saveViewport: vi.fn(),
+  selectNode: vi.fn(),
+  openContextMenu: vi.fn(),
+  closeContextMenu: vi.fn(),
+  setDragOverNode: vi.fn(),
+  nestNode: vi.fn(),
+  isDescendant: vi.fn(() => false),
+  setSearchOpen: vi.fn(),
+};
+
+vi.mock("@/store/canvas", () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: typeof mockStoreState) => unknown) =>
+      selector(mockStoreState)
+    ),
+    { getState: () => mockStoreState }
+  ),
+}));
+
+vi.mock("@/store/socket", () => ({
+  connectSocket: vi.fn(),
+  disconnectSocket: vi.fn(),
+}));
+
+// ── Stub child components ─────────────────────────────────────────────────────
+vi.mock("../Toolbar", () => ({ Toolbar: () => null }));
+vi.mock("../SidePanel", () => ({ SidePanel: () => null }));
+vi.mock("../EmptyState", () => ({ EmptyState: () => null }));
+vi.mock("../ContextMenu", () => ({ ContextMenu: () => null }));
+vi.mock("../SearchDialog", () => ({ SearchDialog: () => null }));
+vi.mock("../ConfirmDialog", () => ({ ConfirmDialog: () => null }));
+vi.mock("../TemplatePalette", () => ({ TemplatePalette: () => null }));
+vi.mock("../OnboardingWizard", () => ({ OnboardingWizard: () => null }));
+vi.mock("../ApprovalBanner", () => ({ ApprovalBanner: () => null }));
+vi.mock("../BundleDropZone", () => ({ BundleDropZone: () => null }));
+vi.mock("../CreateWorkspaceDialog", () => ({ CreateWorkspaceButton: () => null }));
+vi.mock("../settings", () => ({
+  SettingsPanel: () => null,
+  DeleteConfirmDialog: () => null,
+}));
+vi.mock("../Toaster", () => ({ Toaster: () => null }));
+vi.mock("../WorkspaceNode", () => ({ WorkspaceNode: () => null }));
+
+import { Canvas } from "../Canvas";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("Canvas — molecule:pan-to-node event handler", () => {
+  beforeEach(() => {
+    mockFitView.mockClear();
+    mockFitBounds.mockClear();
+  });
+
+  it("calls fitView with the provisioned nodeId after a 100ms debounce", async () => {
+    vi.useFakeTimers();
+    render(<Canvas />);
+
+    // Simulate the custom event fired by canvas-events.ts on WORKSPACE_PROVISIONING
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("molecule:pan-to-node", { detail: { nodeId: "ws-1" } })
+      );
+    });
+
+    // fitView should NOT be called yet (100ms debounce)
+    expect(mockFitView).not.toHaveBeenCalled();
+
+    // Advance past the 100ms delay
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(mockFitView).toHaveBeenCalledOnce();
+    const [options] = mockFitView.mock.calls[0];
+    expect(options.nodes).toEqual([{ id: "ws-1" }]);
+    expect(options.duration).toBe(400);
+    expect(typeof options.padding).toBe("number");
+
+    vi.useRealTimers();
+  });
+
+  it("debounces rapid successive events — only the last nodeId is fitted", async () => {
+    vi.useFakeTimers();
+    render(<Canvas />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("molecule:pan-to-node", { detail: { nodeId: "ws-first" } })
+      );
+      window.dispatchEvent(
+        new CustomEvent("molecule:pan-to-node", { detail: { nodeId: "ws-last" } })
+      );
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(150);
+    });
+
+    // Only one fitView call — the debounce clears the first timer
+    expect(mockFitView).toHaveBeenCalledOnce();
+    expect(mockFitView.mock.calls[0][0].nodes).toEqual([{ id: "ws-last" }]);
+
+    vi.useRealTimers();
+  });
+});

--- a/canvas/src/store/__tests__/canvas-events-pan.test.ts
+++ b/canvas/src/store/__tests__/canvas-events-pan.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/**
+ * Tests the molecule:pan-to-node CustomEvent dispatch from canvas-events.ts.
+ * Runs in jsdom because window.dispatchEvent is required.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleCanvasEvent, resetProvisioningSequence } from "../canvas-events";
+import type { WSMessage } from "../socket";
+import type { WorkspaceNodeData } from "../canvas";
+import type { Node, Edge } from "@xyflow/react";
+
+// ── Helpers (copied from canvas-events.test.ts) ──────────────────────────────
+
+function makeNode(
+  id: string,
+  overrides: Partial<WorkspaceNodeData> = {}
+): Node<WorkspaceNodeData> {
+  return {
+    id,
+    type: "workspaceNode",
+    position: { x: 0, y: 0 },
+    data: {
+      name: `Node-${id}`,
+      status: "online",
+      tier: 1,
+      agentCard: null,
+      activeTasks: 0,
+      collapsed: false,
+      role: "agent",
+      lastErrorRate: 0,
+      lastSampleError: "",
+      url: "http://localhost:9000",
+      parentId: null,
+      currentTask: "",
+      needsRestart: false,
+      runtime: "",
+      ...overrides,
+    },
+  };
+}
+
+function makeMsg(
+  overrides: Partial<WSMessage> & { event: string; workspace_id: string }
+): WSMessage {
+  return { timestamp: new Date().toISOString(), payload: {}, ...overrides };
+}
+
+function makeStore(
+  nodes: Node<WorkspaceNodeData>[] = [],
+  edges: Edge[] = []
+) {
+  const state = { nodes, edges, selectedNodeId: null, agentMessages: {} };
+  const get = () => state;
+  const set = vi.fn((partial: Record<string, unknown>) => { Object.assign(state, partial); });
+  return { state, get, set };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("canvas-events – molecule:pan-to-node dispatch", () => {
+  beforeEach(() => {
+    resetProvisioningSequence();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("dispatches molecule:pan-to-node with the new nodeId for a NEW provision", () => {
+    const { get, set } = makeStore([]);
+    const dispatched: Event[] = [];
+    const spy = vi.spyOn(window, "dispatchEvent").mockImplementation((e) => {
+      dispatched.push(e);
+      return true;
+    });
+
+    handleCanvasEvent(
+      makeMsg({ event: "WORKSPACE_PROVISIONING", workspace_id: "ws-new", payload: {} }),
+      get,
+      set
+    );
+
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("molecule:pan-to-node");
+    expect((dispatched[0] as CustomEvent).detail?.nodeId).toBe("ws-new");
+  });
+
+  it("does NOT dispatch molecule:pan-to-node when restarting an existing node", () => {
+    const { get, set } = makeStore([makeNode("ws-existing")]);
+    const dispatched: Event[] = [];
+    const spy = vi.spyOn(window, "dispatchEvent").mockImplementation((e) => {
+      dispatched.push(e);
+      return true;
+    });
+
+    handleCanvasEvent(
+      makeMsg({ event: "WORKSPACE_PROVISIONING", workspace_id: "ws-existing", payload: {} }),
+      get,
+      set
+    );
+
+    expect(dispatched).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces `setCenter(x, y, {zoom:1})` with `fitView({nodes:[{id}], duration:400, padding:0.3})` in the `molecule:pan-to-node` event handler (Canvas.tsx)
- The old implementation unconditionally reset zoom to 1x — jarring when the user was zoomed out to view a large canvas. `fitView` adapts to the user's current zoom and gracefully brings the new node into view
- No change to `canvas-events.ts` — the `window.dispatchEvent('molecule:pan-to-node')` mechanism already existed and remains unchanged

## Test plan

- [x] `Canvas.pan-to-node.test.tsx` (new, 2 tests): `fitView` called with `{nodes:[{id}]}` after 100ms debounce; rapid events debounced to single call
- [x] `canvas-events-pan.test.ts` (new, 2 tests): `molecule:pan-to-node` dispatched for new provisions only, not for workspace restarts
- [x] `npm test`: 489/489 passing (+4 new tests)
- [x] `npm run build`: clean

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)