### PR TITLE
fix(ci): remove molecli build step — CLI in standalone repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 'stable'
       - run: go mod download
       - run: go build ./cmd/server
-      - run: go build -o molecli ./cmd/cli
+      # CLI (molecli) moved to standalone repo: github.com/Molecule-AI/molecule-cli
       - run: go vet ./...
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v4


### PR DESCRIPTION
platform/cmd/cli/ extracted to molecule-cli. CI was failing with 'directory not found'.