### PR TITLE
fix(ci): switch publish workflows to ubuntu-latest

### DIFF
--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -39,39 +39,10 @@ env:
 jobs:
   build-and-push:
     name: Build & push canvas image
-    runs-on: [self-hosted, macos, arm64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Isolate Docker config (skip macOS Keychain)
-        # Same workaround as publish-platform-image.yml — launchd service
-        # runners can't reach the Keychain, so we write a disposable
-        # config.json with an empty credsStore to force auths-map storage.
-        # IMPORTANT: no indentation inside the heredoc — JSON must be valid.
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
-{
-  "auths": {},
-  "credsStore": "",
-  "credHelpers": {}
-}
-JSON
-          echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
-          echo "=== config.json ==="
-          cat "${RUNNER_TEMP}/docker-config/config.json"
-          echo "=== Runner docker diagnostics ==="
-          command -v docker || echo "(docker not in PATH)"
-          docker --version 2>&1 || true
-
-      - name: Set up QEMU
-        # Apple-silicon runner building linux/amd64 images for x86 hosts.
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -35,64 +35,12 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: [self-hosted, macos, arm64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Isolate Docker config (skip keychain)
-        # The Mac mini self-hosted runner runs as a non-interactive
-        # launchd service; docker/login-action's default credential store
-        # is the macOS Keychain, which raises
-        #   error storing credentials - err: exit status 1, out:
-        #   `User interaction is not allowed. (-25308)`
-        # without an unlocked desktop session.
-        #
-        # Point DOCKER_CONFIG at a per-run temp dir. IMPORTANT: writing
-        # `{"auths": {}}` alone is NOT enough — Docker on macOS picks up
-        # `osxkeychain` as the default credential store even when
-        # config.json doesn't declare one, inheriting from Docker
-        # Desktop's bundled credsStore binding. We must explicitly set
-        # `credsStore` to an empty string AND clear `credHelpers` so the
-        # login step writes credentials into the auths map of this
-        # disposable config.json rather than reaching for the keychain.
-        # (First tried in #273 without the empty-credsStore line; #319
-        # + #322 merges showed it still regressed.)
-        #
-        # Plus diagnostics: print the docker path so a future EACCES on
-        # /usr/local/bin/docker surfaces in the log instead of via a
-        # cryptic docker-login failure mid-step.
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
-{
-  "auths": {},
-  "credsStore": "",
-  "credHelpers": {}
-}
-JSON
-          echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
-          echo "=== Runner docker diagnostics ==="
-          echo "PATH=$PATH"
-          command -v docker || echo "(docker not in PATH — the runner is missing the Docker CLI or it's not symlinked to a visible location)"
-          docker --version 2>&1 || true
-          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
-          echo "=== config.json after setup ==="
-          cat "${RUNNER_TEMP}/docker-config/config.json"
-
-      - name: Set up QEMU
-        # Required on the Apple-silicon self-hosted runner — Fly tenant machines
-        # pull linux/amd64, and buildx needs binfmt handlers in Docker Desktop's
-        # VM to emulate amd64 during the build.
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64
-
       - name: Set up Docker Buildx
-        # Buildx enables cache-from/cache-to via GHA cache and multi-arch
-        # builds without local docker daemon wrangling.
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR


### PR DESCRIPTION
## Summary
- Both `publish-platform-image` and `publish-canvas-image` switched from `[self-hosted, macos, arm64]` to `ubuntu-latest`
- Removes macOS Keychain isolation workaround (40+ lines of heredoc/diagnostic code)
- Removes QEMU setup step (no longer needed — ubuntu-latest is native amd64)

## Why
The self-hosted Mac mini runner has been offline for 20+ consecutive runs. Every publish job queues indefinitely with 0 jobs claimed. Both workflows build `linux/amd64` images, so macOS ARM was always a cross-compilation penalty via QEMU with zero benefit.

## Still needed (user action)
`FLY_API_TOKEN` in GitHub Actions secrets is expired (#199). After merging this PR:
```bash
flyctl tokens create deploy --name github-actions-platform-publish --expiry 8760h
gh secret set FLY_API_TOKEN --repo Molecule-AI/molecule-monorepo --body '<new-token>'
```
Then trigger a workflow_dispatch to verify both GHCR + Fly pushes succeed.

Fixes #191

## Test plan
- [ ] CI passes on this PR (platform build, canvas build, e2e, shellcheck)
- [ ] After merge + FLY_API_TOKEN rotation, trigger `workflow_dispatch` on `publish-platform-image`
- [ ] Verify GHCR push succeeds (`ghcr.io/molecule-ai/platform:latest`)
- [ ] Verify Fly push succeeds (`registry.fly.io/molecule-tenant:latest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)