### PR TITLE
fix(platform): unblock org-template imports against modular workspace templates

### DIFF
--- a/platform/internal/handlers/org.go
+++ b/platform/internal/handlers/org.go
@@ -357,6 +357,17 @@ func (h *OrgHandler) createWorkspaceTree(ws OrgWorkspace, parentID *string, defa
 		role = ws.Role
 	}
 
+	// Expand ${VAR} references in workspace_dir against the org's .env files
+	// before validation. Without this, a template that ships
+	// `workspace_dir: ${WORKSPACE_DIR}` (so each operator can pick the host
+	// path to bind-mount) reaches validateWorkspaceDir as the literal
+	// "${WORKSPACE_DIR}" string and fails with "must be an absolute path".
+	// Other fields (channel config, prompts) already go through expandWithEnv;
+	// workspace_dir was the last hold-out.
+	if ws.WorkspaceDir != "" {
+		ws.WorkspaceDir = expandWithEnv(ws.WorkspaceDir, loadWorkspaceEnv(orgBaseDir, ws.FilesDir))
+	}
+
 	// Validate and convert workspace_dir to NULL if empty
 	var workspaceDir interface{}
 	if ws.WorkspaceDir != "" {

--- a/platform/internal/provisioner/provisioner.go
+++ b/platform/internal/provisioner/provisioner.go
@@ -380,6 +380,15 @@ func buildContainerEnv(cfg WorkspaceConfig) []string {
 		fmt.Sprintf("MOLECULE_URL=%s", cfg.PlatformURL),
 		fmt.Sprintf("TIER=%d", cfg.Tier),
 		"PLUGINS_DIR=/plugins",
+		// PYTHONPATH=/app makes ADAPTER_MODULE imports resolve regardless of
+		// runtime cwd. Standalone workspace-template repos COPY adapter.py to
+		// /app and set ENV ADAPTER_MODULE=adapter, but molecule-runtime is a
+		// pip console_script entry point so cwd isn't on sys.path automatically.
+		// Setting PYTHONPATH from the provisioner fixes every adapter image
+		// (claude-code, hermes, langgraph, …) without needing to PR each
+		// standalone template repo. Per-template ENV in the Dockerfile can
+		// still override (Dockerfile ENV is overridden by docker -e at runtime).
+		"PYTHONPATH=/app",
 	}
 	if cfg.AwarenessNamespace != "" && cfg.AwarenessURL != "" {
 		env = append(env, fmt.Sprintf("AWARENESS_NAMESPACE=%s", cfg.AwarenessNamespace))

--- a/platform/internal/provisioner/provisioner_test.go
+++ b/platform/internal/provisioner/provisioner_test.go
@@ -469,6 +469,53 @@ func TestBuildContainerEnv_InjectsBothPlatformURLAndMoleculeAIURL(t *testing.T) 
 	}
 }
 
+func TestBuildContainerEnv_InjectsPYTHONPATH(t *testing.T) {
+	// Standalone workspace-template repos COPY adapter.py to /app and rely on
+	// `import adapter` resolving via PYTHONPATH. molecule-runtime is a pip
+	// console_script entry, so cwd isn't on sys.path automatically. The
+	// provisioner injects PYTHONPATH=/app so every adapter image works
+	// without per-template Dockerfile patching. See workspace-runtime#1
+	// for the runtime-side bug this works around.
+	cfg := WorkspaceConfig{WorkspaceID: "ws-x", PlatformURL: "http://x", Tier: 1}
+	env := buildContainerEnv(cfg)
+	want := "PYTHONPATH=/app"
+	for _, e := range env {
+		if e == want {
+			return
+		}
+	}
+	t.Errorf("expected env to contain %q, got %v", want, env)
+}
+
+func TestBuildContainerEnv_WorkspaceEnvVarsCanOverridePYTHONPATH(t *testing.T) {
+	// Operator escape hatch: a per-workspace EnvVars["PYTHONPATH"] = "/custom"
+	// MUST appear AFTER the default in the env slice so Docker uses the
+	// later one. Without this, an operator who needs a custom path can't
+	// override the provisioner default.
+	cfg := WorkspaceConfig{
+		WorkspaceID: "ws-x",
+		PlatformURL: "http://x",
+		Tier:        1,
+		EnvVars:     map[string]string{"PYTHONPATH": "/custom:/app"},
+	}
+	env := buildContainerEnv(cfg)
+	defaultIdx, customIdx := -1, -1
+	for i, e := range env {
+		if e == "PYTHONPATH=/app" {
+			defaultIdx = i
+		}
+		if e == "PYTHONPATH=/custom:/app" {
+			customIdx = i
+		}
+	}
+	if defaultIdx < 0 || customIdx < 0 {
+		t.Fatalf("expected both default and custom PYTHONPATH entries, got %v", env)
+	}
+	if customIdx < defaultIdx {
+		t.Errorf("custom PYTHONPATH (idx=%d) must come AFTER default (idx=%d) so Docker takes the operator override", customIdx, defaultIdx)
+	}
+}
+
 func TestBuildContainerEnv_MoleculeAIURLAlwaysMatchesPlatformURL(t *testing.T) {
 	// Regression guard: MOLECULE_URL must never drift from PLATFORM_URL —
 	// if someone changes one they must change the other. This test pins


### PR DESCRIPTION
## Summary
Two adjacent platform fixes surfaced while bringing the dev org template back up against the new modular workspace-template-* repos. Independently shippable.

### 1. `handlers/org.go` — expand `\${VAR}` in workspace_dir before validation
Templates ship \`workspace_dir: \${WORKSPACE_DIR}\` so each operator picks the host path PM bind-mounts. Without expansion the literal \"\${WORKSPACE_DIR}\" string reaches validateWorkspaceDir and fails with \"must be an absolute path\", aborting the whole org import. Channel-config and prompt fields already go through expandWithEnv; workspace_dir was the hold-out.

### 2. `provisioner/provisioner.go` — inject `PYTHONPATH=/app`
Standalone template Dockerfiles COPY adapter.py to /app and set ADAPTER_MODULE=adapter, but molecule-runtime is a pip console_script so cwd isn't on sys.path. One-line provisioner fix avoids needing 8 PRs against each workspace-template-* repo. Operator can still override via per-workspace EnvVars (Docker takes the later duplicate).

## Important — does NOT fully unblock workspace boot
This PR makes org imports succeed and PYTHONPATH correct. Workspace containers STILL crash on boot because of a runtime-side issue: \`molecule-runtime\` does \`from adapters import …\` (top-level, not \`from molecule_runtime.adapters import …\`), which breaks against the modular template layout that no longer ships an /app/adapters/ package. Tracked at:

  https://github.com/Molecule-AI/molecule-ai-workspace-runtime/issues/1

## Test plan
- [x] \`go test ./internal/provisioner/...\` — 2 new tests + existing all green
- [x] \`go test ./internal/handlers/...\` — all green
- [x] \`go vet ./internal/handlers/... ./internal/provisioner/...\` clean
- [x] Live verification: re-importing molecule-dev no longer fails on workspace_dir; PYTHONPATH=/app shows up in every running ws-* container's env
- [ ] Reviewer: confirm the Operator-override semantics for PYTHONPATH (later-wins via Docker env) match how we want to expose this knob

## Adjacent issues filed
- workspace-runtime#1 — runtime top-level \`from adapters import\` breaks modular templates (P0, blocks all workspace boots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)