### PR TITLE
fix(ci): fix YAML parse error in publish workflows

### DIFF
--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -53,17 +53,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
-{
-  "auths": {},
-  "credsStore": "",
-  "credHelpers": {}
-}
-JSON
+          printf '{"auths":{},"credsStore":"","credHelpers":{}}\n' > "${RUNNER_TEMP}/docker-config/config.json"
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
           echo "=== config.json ==="
           cat "${RUNNER_TEMP}/docker-config/config.json"
-          echo "=== Runner docker diagnostics ==="
+          echo "=== docker ==="
           command -v docker || echo "(docker not in PATH)"
           docker --version 2>&1 || true
 

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -66,21 +66,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          cat > "${RUNNER_TEMP}/docker-config/config.json" <<'JSON'
-{
-  "auths": {},
-  "credsStore": "",
-  "credHelpers": {}
-}
-JSON
+          printf '{"auths":{},"credsStore":"","credHelpers":{}}\n' > "${RUNNER_TEMP}/docker-config/config.json"
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
-          echo "=== Runner docker diagnostics ==="
-          echo "PATH=$PATH"
-          command -v docker || echo "(docker not in PATH — the runner is missing the Docker CLI or it's not symlinked to a visible location)"
-          docker --version 2>&1 || true
-          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
-          echo "=== config.json after setup ==="
+          echo "=== config.json ==="
           cat "${RUNNER_TEMP}/docker-config/config.json"
+          echo "=== docker ==="
+          command -v docker || echo "(docker not in PATH)"
+          docker --version 2>&1 || true
 
       - name: Set up QEMU
         # Required on the Apple-silicon self-hosted runner — Fly tenant machines


### PR DESCRIPTION
## Summary
Both `publish-platform-image.yml` and `publish-canvas-image.yml` have been failing with 0 jobs (startup_failure) because the heredoc JSON block at column 1 confused GitHub Actions' YAML parser.

Replace `cat <<'JSON' ... JSON` with `printf '{"auths":{},...}\n'` — identical output, valid YAML.

## Root cause
A `{` at column 1 inside a YAML `run: |` block is ambiguous — YAML parsers can interpret it as a flow mapping start rather than literal text. GitHub Actions' stricter parser rejects the workflow entirely, producing a "completed/failure" run with 0 jobs.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` passes on both files
- [ ] After merge, trigger `workflow_dispatch` on publish-platform-image — should produce 1 job

🤖 Generated with [Claude Code](https://claude.com/claude-code)