### PR TITLE
fix(ci): docker --config to bypass macOS Keychain

### DIFF
--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Log in to GHCR
         shell: bash
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker --config "${DOCKER_CONFIG}" login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Compute tags
         id: tags

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -89,11 +89,11 @@ jobs:
 
       - name: Log in to GHCR
         shell: bash
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker --config "${DOCKER_CONFIG}" login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Log in to Fly registry
         shell: bash
-        run: echo "${{ secrets.FLY_API_TOKEN }}" | docker login registry.fly.io -u x --password-stdin
+        run: echo "${{ secrets.FLY_API_TOKEN }}" | docker --config "${DOCKER_CONFIG}" login registry.fly.io -u x --password-stdin
 
       - name: Compute tags
         id: tags


### PR DESCRIPTION
## Summary
`docker login` with `DOCKER_CONFIG` env var still routes through the macOS system keychain (`osxkeychain` credential helper). The `--config` CLI flag forces Docker to use the per-run temp dir for both reading and writing credentials, fully bypassing the system keychain.

Applied to both `publish-platform-image.yml` and `publish-canvas-image.yml`.

## Root cause
Docker Desktop on macOS has a built-in `osxkeychain` credential store binding that activates regardless of `config.json` contents or `DOCKER_CONFIG` env var. Only `docker --config <dir>` overrides this at the CLI level.

## Test plan
- [x] YAML valid
- [ ] After merge, verify publish-platform-image completes "Log in to GHCR" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)