### PR TITLE
fix(ci): bypass docker login + macOS Keychain (real fix)

### DIFF
--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -44,22 +44,42 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Isolate Docker config (skip macOS Keychain)
-        # Same workaround as publish-platform-image.yml — launchd service
-        # runners can't reach the Keychain, so we write a disposable
-        # config.json with an empty credsStore to force auths-map storage.
-        # IMPORTANT: no indentation inside the heredoc — JSON must be valid.
+      - name: Configure GHCR auth (write auths map; do NOT call docker login)
+        # `docker login` on macOS unconditionally writes credentials to the
+        # osxkeychain credential helper, even when DOCKER_CONFIG/config.json
+        # declares `credsStore: ""` and even when invoked with `--config`.
+        # Verified locally 2026-04-16 — after a successful login, Docker
+        # rewrites the same config file to:
+        #     { "auths": { "ghcr.io": {} }, "credsStore": "osxkeychain" }
+        # i.e. the auth lives in the Keychain, not the config file. The
+        # Mac mini runner is a launchd user agent with a locked Keychain,
+        # so storage fails with `User interaction is not allowed (-25308)`.
+        #
+        # Six prior PRs (#273, #319, #322, #341, #484, #486) all kept calling
+        # `docker login` and tried to coerce credsStore — none worked.
+        # The only reliable fix is to skip `docker login` entirely and write
+        # the auth string directly. `docker/build-push-action@v5` and the
+        # daemon honor the `auths` map for push without needing login.
         shell: bash
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          set -euo pipefail
+          set -eu
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          printf '{"auths":{},"credsStore":"","credHelpers":{}}\n' > "${RUNNER_TEMP}/docker-config/config.json"
+          AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
+          umask 077
+          cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
+          { "auths": { "ghcr.io": { "auth": "${AUTH}" } } }
+          JSON
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
-          echo "=== config.json ==="
-          cat "${RUNNER_TEMP}/docker-config/config.json"
+          # Diagnostics that don't leak the token.
           echo "=== docker ==="
           command -v docker || echo "(docker not in PATH)"
           docker --version 2>&1 || true
+          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
+          echo "=== auths registries (no values) ==="
+          grep -o '"[a-zA-Z0-9.-]*\.io"' "${RUNNER_TEMP}/docker-config/config.json" || true
 
       - name: Set up QEMU
         # Apple-silicon runner building linux/amd64 images for x86 hosts.
@@ -69,10 +89,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        shell: bash
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Compute tags
         id: tags

--- a/.github/workflows/publish-platform-image.yml
+++ b/.github/workflows/publish-platform-image.yml
@@ -40,39 +40,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Isolate Docker config (skip keychain)
-        # The Mac mini self-hosted runner runs as a non-interactive
-        # launchd service; docker/login-action's default credential store
-        # is the macOS Keychain, which raises
-        #   error storing credentials - err: exit status 1, out:
-        #   `User interaction is not allowed. (-25308)`
-        # without an unlocked desktop session.
+      - name: Configure registry auth (write auths map; do NOT call docker login)
+        # `docker login` on macOS unconditionally writes credentials to the
+        # osxkeychain credential helper, even when DOCKER_CONFIG/config.json
+        # declares `credsStore: ""` and even when invoked with `--config`.
+        # Verified locally 2026-04-16 — after a successful login, Docker
+        # rewrites the same config file to:
+        #     { "auths": { "ghcr.io": {} }, "credsStore": "osxkeychain" }
+        # i.e. the auth lives in the Keychain, not the config file. The
+        # Mac mini runner is a launchd user agent with a locked Keychain,
+        # so storage fails with `User interaction is not allowed (-25308)`.
         #
-        # Point DOCKER_CONFIG at a per-run temp dir. IMPORTANT: writing
-        # `{"auths": {}}` alone is NOT enough — Docker on macOS picks up
-        # `osxkeychain` as the default credential store even when
-        # config.json doesn't declare one, inheriting from Docker
-        # Desktop's bundled credsStore binding. We must explicitly set
-        # `credsStore` to an empty string AND clear `credHelpers` so the
-        # login step writes credentials into the auths map of this
-        # disposable config.json rather than reaching for the keychain.
-        # (First tried in #273 without the empty-credsStore line; #319
-        # + #322 merges showed it still regressed.)
+        # Six prior PRs (#273, #319, #322, #341, #484, #486) all kept calling
+        # `docker login` and tried to coerce credsStore — none worked.
+        # The only reliable fix is to skip `docker login` entirely and write
+        # the auth strings directly. `docker/build-push-action@v5` and the
+        # daemon honor the `auths` map for push without needing login.
         #
-        # Plus diagnostics: print the docker path so a future EACCES on
-        # /usr/local/bin/docker surfaces in the log instead of via a
-        # cryptic docker-login failure mid-step.
+        # Fly registry username MUST be literal "x" (verified 2026-04-15) —
+        # any other value returns 401. FLY_API_TOKEN lives in GitHub Actions
+        # secrets AND in `fly secrets` on molecule-cp; see
+        # docs/runbooks/saas-secrets.md before rotating.
         shell: bash
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          FLY_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          set -euo pipefail
+          set -eu
           mkdir -p "${RUNNER_TEMP}/docker-config"
-          printf '{"auths":{},"credsStore":"","credHelpers":{}}\n' > "${RUNNER_TEMP}/docker-config/config.json"
+          GHCR_AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
+          FLY_AUTH=$(printf '%s:%s' 'x' "${FLY_TOKEN}" | base64)
+          umask 077
+          cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
+          {
+            "auths": {
+              "ghcr.io":         { "auth": "${GHCR_AUTH}" },
+              "registry.fly.io": { "auth": "${FLY_AUTH}" }
+            }
+          }
+          JSON
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
-          echo "=== config.json ==="
-          cat "${RUNNER_TEMP}/docker-config/config.json"
+          # Diagnostics that don't leak the tokens.
           echo "=== docker ==="
           command -v docker || echo "(docker not in PATH)"
           docker --version 2>&1 || true
+          ls -la /usr/local/bin/docker /opt/homebrew/bin/docker 2>&1 || true
+          echo "=== auths registries (no values) ==="
+          grep -o '"[a-zA-Z0-9.-]*\.io"' "${RUNNER_TEMP}/docker-config/config.json" || true
 
       - name: Set up QEMU
         # Required on the Apple-silicon self-hosted runner — Fly tenant machines
@@ -86,14 +101,6 @@ jobs:
         # Buildx enables cache-from/cache-to via GHA cache and multi-arch
         # builds without local docker daemon wrangling.
         uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        shell: bash
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Log in to Fly registry
-        shell: bash
-        run: echo "${{ secrets.FLY_API_TOKEN }}" | docker login registry.fly.io -u x --password-stdin
 
       - name: Compute tags
         id: tags


### PR DESCRIPTION
## Why this is the 7th attempt and why the previous 6 didn't work

Six prior PRs (#273, #319, #322, #341, #484, #486) all kept calling `docker login` and tried to coerce the credential storage via increasingly elaborate config tricks:

| PR | Approach |
|----|---|
| #273 | DOCKER_CONFIG to temp dir, `auths: {}` only |
| #319/#322 | + `credsStore: ""` |
| #341 | + `credHelpers: {}` |
| #484 | YAML cleanup of #341 |
| #486 (open) | + `--config` flag on `docker login` |

**None of these address the actual problem.** Verified locally on the runner host (2026-04-16) — `docker login` on macOS unconditionally writes credentials to osxkeychain after any successful login, regardless of the config presented:

```
# What I wrote into DOCKER_CONFIG/config.json:
{ "auths": {}, "credsStore": "", "credHelpers": {} }

# What Docker rewrote it to after `docker login --config <dir> ghcr.io ...` succeeded:
{
  "auths": { "ghcr.io": {} },        # empty — the auth is in the Keychain
  "credsStore": "osxkeychain"        # Docker silently rewrote this
}
```

So `--config` flag, DOCKER_CONFIG env var, `credsStore: ""`, `credHelpers: {}` — all share the same fate: Docker re-enables osxkeychain after every successful login. The Mac mini runner is a launchd user agent with a locked Keychain, so storage then fails:

```
error storing credentials - err: exit status 1,
out: `User interaction is not allowed. (-25308)`
```

PR #464 was an earlier attempt at the right fix, closed with the comment _"superseded by #341 + the Dockerfile restructure"_. But #341's approach is what was just proven not to work — every publish-* run since the close has failed with the same -25308. Re-opening the fix here.

## The fix

Skip `docker login` entirely. Write `base64(user:pat)` directly into `DOCKER_CONFIG/config.json`'s `auths` map. `docker/build-push-action@v5` and the Docker daemon both honor the auths map for image push without ever calling `docker login`, so the Keychain is never invoked.

```yaml
- name: Configure GHCR auth (write auths map; do NOT call docker login)
  shell: bash
  env:
    GHCR_USER: ${{ github.actor }}
    GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    set -eu
    mkdir -p "${RUNNER_TEMP}/docker-config"
    AUTH=$(printf '%s:%s' "${GHCR_USER}" "${GHCR_TOKEN}" | base64)
    umask 077
    cat > "${RUNNER_TEMP}/docker-config/config.json" <<JSON
    { "auths": { "ghcr.io": { "auth": "${AUTH}" } } }
    JSON
    echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
```

## Same shape in both workflows

| Workflow | Registries handled |
|---|---|
| `publish-canvas-image.yml` | `ghcr.io` |
| `publish-platform-image.yml` | `ghcr.io` + `registry.fly.io` |

Fly username remains literal `x` per the prior inline comment (verified 2026-04-15 — any other value returns 401).

## Security

- Token env vars are **never echoed**. The `AUTH=$(printf ...)` line evaluates the secret in-process; `cat <<JSON` writes the result via heredoc with `umask 077` (file mode 600). The temp config lives under `RUNNER_TEMP` and is reaped at job end.
- Diagnostics preserved (docker version + binary `ls` + registry keys only — no auth values) so future runner permission regressions remain visible without leaking secrets.
- Live diagnostic: `grep -o '"[a-zA-Z0-9.-]*\.io"'` echoes only the registry hostnames.

## Closes / supersedes

- Supersedes #486 (the `--config` flag attempt — proven not to work in the description above)
- Re-applies #464 (closed prematurely; main is still broken)

## Test plan

- [ ] Merge, then watch the next push of `canvas/**` — `publish-canvas-image` should go green
- [ ] Manually trigger `publish-platform-image` via `workflow_dispatch` — should go green
- [ ] Confirm pushed images present in `ghcr.io/molecule-ai/{canvas,platform}` and `registry.fly.io/molecule-tenant`
- [ ] Rerun the most recent failed runs (24506138960, 24504948138 from earlier reports) — should go green