### PR TITLE
fix(auth): WorkspaceAuth same-origin canvas on tenant

### DIFF
--- a/platform/internal/middleware/wsauth_middleware.go
+++ b/platform/internal/middleware/wsauth_middleware.go
@@ -43,15 +43,21 @@ func WorkspaceAuth(database *sql.DB) gin.HandlerFunc {
 		ctx := c.Request.Context()
 
 		tok := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization"))
-		if tok == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing workspace auth token"})
+		if tok != "" {
+			if err := wsauth.ValidateToken(ctx, database, workspaceID, tok); err != nil {
+				c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid workspace auth token"})
+				return
+			}
+			c.Next()
 			return
 		}
-		if err := wsauth.ValidateToken(ctx, database, workspaceID, tok); err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid workspace auth token"})
+		// Same-origin canvas on tenant image — Referer matches Host.
+		if isSameOriginCanvas(c) {
+			c.Next()
 			return
 		}
-		c.Next()
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing workspace auth token"})
+		return
 	}
 }
 


### PR DESCRIPTION
## Summary
WorkspaceAuth only accepted bearer tokens, blocking the canvas from calling per-workspace routes on the tenant image (restart, config, secrets, chat, activity, etc.).

Added `isSameOriginCanvas()` fallback — same check already used by AdminAuth. Only active when `CANVAS_PROXY_URL` is set (tenant image).

## Why
On the tenant, clicking "Restart" on a failed workspace returned 401 "missing workspace auth token" because the canvas makes same-origin requests without a bearer token.

## Test plan
- [x] `go build` + `go vet` clean
- [ ] After deploy, verify canvas can restart/configure workspaces on tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)