### PR TITLE
fix: enforce LF for .py hook files — fix #507 (all agents "no response generated")

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,12 @@
 *.sh text eol=lf
 workspace-template/entrypoint.sh text eol=lf
 
+# Python hook files are invoked by .sh hooks with path substitution;
+# CRLF in either the .sh OR the .py file breaks the hook dispatch.
+# See Molecule-AI/molecule-core#507 — SessionStart hook failed silently,
+# agents returned "(no response generated)" on every A2A call.
+*.py text eol=lf
+
 # Dockerfiles and compose files are parsed by tools that tolerate CRLF,
 # but keep LF for consistency across platforms.
 Dockerfile text eol=lf


### PR DESCRIPTION
## Summary
- Adds `*.py text eol=lf` to `.gitattributes` so Python hook files keep LF on Windows checkouts (core.autocrlf=true reintroduces CRLF otherwise)
- Companion fix: https://github.com/Molecule-AI/molecule-ai-plugin-molecule-session-context/commit/main — same `.gitattributes` rule added to the plugin repo that seeds `/configs/.claude/hooks/` at workspace provision time

## Root cause (details in #507)
SessionStart hook shell script had `#!/usr/bin/env bash\r\n…exec python3 "$(...)/session-start-context.py"\r\n`. The trailing `\r` bled into the filename arg, so python3 hit `ENOENT` on `session-start-context.py\r`. claude-code swallowed the hook error and terminated the query with `result=''`, `num_turns=1`, `input_tokens=0`, `output_tokens=0` — the model was never called. Manifested as `(no response generated)` across all 22 agents, 100% of A2A calls.

## Reproduction (before fix)
```
$ docker exec ws-… gosu agent python -c "import asyncio, claude_agent_sdk as sdk; asyncio.run((...).query(prompt='ping', ...))"
=== SystemMessage subtype=hook_response ===
  output: "python3: can't open file '/configs/.claude/hooks/session-start-context.py\r': [Errno 2]"
=== ResultMessage ===
  result = ''
  input_tokens = 0
  output_tokens = 0
```

## Verification (after fix)
Applied `sed -i 's/\r$//'` to `/configs/.claude/hooks/*.sh,*.py` in 2 workspace containers (PM + Frontend Engineer) → both produced proper `TextBlock(text='pong')` + `result='pong'` with real token usage. Rolled out the in-container sed across all 22 running workspaces.

The `.gitattributes` change is the durable fix — prevents future host-side checkouts from reintroducing CRLF, which means the next provisioner-triggered copy of `plugins/molecule-session-context/hooks/` into a workspace volume stays LF-clean.

## Test plan
- [x] Reproduce `(no response generated)` in a workspace with CRLF hooks
- [x] Strip CRLF in the same container → SDK returns real text
- [x] Verify `.gitattributes` rule applies via `git check-attr -a hooks/session-start-context.py`
- [x] Push companion fix to `molecule-ai-plugin-molecule-session-context` (merged to main at `b98b93f`)
- [ ] Platform rebuild + fresh workspace provisioning confirms LF in volumes (will verify next cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)