### PR TITLE
fix(canvas): add hermes + gemini-cli to deploy preflight required keys

### DIFF
--- a/canvas/src/lib/deploy-preflight.ts
+++ b/canvas/src/lib/deploy-preflight.ts
@@ -17,6 +17,8 @@ export const RUNTIME_REQUIRED_KEYS: Record<string, string[]> = {
   deepagents: ["OPENAI_API_KEY"],
   crewai: ["OPENAI_API_KEY"],
   autogen: ["OPENAI_API_KEY"],
+  hermes: ["OPENROUTER_API_KEY"],
+  "gemini-cli": ["GOOGLE_API_KEY"],
 };
 
 /** Human-readable labels for common secret keys */
@@ -26,6 +28,8 @@ export const KEY_LABELS: Record<string, string> = {
   GOOGLE_API_KEY: "Google AI API Key",
   SERP_API_KEY: "SERP API Key",
   OPENROUTER_API_KEY: "OpenRouter API Key",
+  HERMES_API_KEY: "Nous Research API Key",
+  DEEPSEEK_API_KEY: "DeepSeek API Key",
 };
 
 /* ---------- Types ---------- */


### PR DESCRIPTION
## Summary
Hermes and gemini-cli runtimes were missing from `RUNTIME_REQUIRED_KEYS`, so
the MissingKeysModal never fired when deploying these agents — they'd start
without API keys and crash-loop.

- hermes: requires OPENROUTER_API_KEY
- gemini-cli: requires GOOGLE_API_KEY
- Added HERMES_API_KEY + DEEPSEEK_API_KEY to key labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)