### PR TITLE
fix(migrations): TEXT→UUID FK type mismatch blocking all E2E runs

### DIFF
--- a/platform/migrations/025_workspace_token_usage.up.sql
+++ b/platform/migrations/025_workspace_token_usage.up.sql
@@ -4,7 +4,7 @@
 -- (default: Claude Sonnet input $3/1M, output $15/1M).
 CREATE TABLE IF NOT EXISTS workspace_token_usage (
   id                 UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
-  workspace_id       TEXT         NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  workspace_id       UUID         NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   period_start       TIMESTAMPTZ  NOT NULL,
   input_tokens       BIGINT       NOT NULL DEFAULT 0,
   output_tokens      BIGINT       NOT NULL DEFAULT 0,

--- a/platform/migrations/026_org_plugin_allowlist.up.sql
+++ b/platform/migrations/026_org_plugin_allowlist.up.sql
@@ -7,7 +7,7 @@
 -- enabled_by records the workspace ID of the admin who added the entry.
 CREATE TABLE IF NOT EXISTS org_plugin_allowlist (
   id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
-  org_id      TEXT        NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  org_id      UUID        NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
   plugin_name TEXT        NOT NULL,
   enabled_by  TEXT        NOT NULL,
   enabled_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()


### PR DESCRIPTION
## CRITICAL — unblocks all E2E CI

Migrations 025 (workspace_token_usage) and 026 (org_plugin_allowlist) declared FK columns as TEXT but workspaces.id is UUID. Postgres rejects the constraint, crashing the platform on boot. Every E2E run on main fails since these were merged.

Fix: TEXT → UUID on both FK columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)