### PR TITLE
fix(migrations): TEXT→UUID in 028_workspace_artifacts — unblocks all E2E CI

### DIFF
--- a/platform/migrations/028_workspace_artifacts.up.sql
+++ b/platform/migrations/028_workspace_artifacts.up.sql
@@ -8,8 +8,8 @@
 -- call POST /workspaces/:id/artifacts/token to obtain a fresh git credential.
 
 CREATE TABLE IF NOT EXISTS workspace_artifacts (
-    id           TEXT        NOT NULL DEFAULT gen_random_uuid()::text,
-    workspace_id TEXT        NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    id           UUID        NOT NULL DEFAULT gen_random_uuid(),
+    workspace_id UUID        NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
     cf_repo_name TEXT        NOT NULL,
     cf_namespace TEXT        NOT NULL,
     -- remote_url is the base Git remote (without embedded credentials).


### PR DESCRIPTION
## Summary
Migration 028 (`workspace_artifacts`) declares `id` and `workspace_id` as `TEXT` with a FK to `workspaces(id)` which is `UUID`. Postgres rejects the FK constraint at migration time:

```
Migrations failed: exec 028_workspace_artifacts.up.sql:
  pq: foreign key constraint "workspace_artifacts_workspace_id_fkey" cannot be implemented
```

Platform exits via `log.Fatalf` → `/health` never responds → E2E smoke test times out after 30s → **every open PR fails CI**.

Same class of bug as #646 (which fixed migration 025). Fix: `TEXT → UUID` for both `id` and `workspace_id` columns.

## Impact
This has been blocking ALL open PRs for 5+ maintenance cycles. PRs #650, #651, #659, #669 all fail on the same E2E step. Once this merges, their CI re-runs should pass.

## Test plan
- [x] Verified the FK type mismatch in the CI logs (`gh run view --log-failed`)
- [ ] CI on this PR itself should pass (it's the first run that successfully applies 028)

🤖 Generated with [Claude Code](https://claude.com/claude-code)