### PR TITLE
fix(router): remove AdminAuth from test-token — unblocks E2E CI bootstrap

### DIFF
--- a/platform/internal/router/router.go
+++ b/platform/internal/router/router.go
@@ -328,13 +328,15 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 	}
 
 	// Admin — test token minting (issue #6). Hidden in production via TestTokensEnabled().
-	// AdminAuth is a second defence-in-depth layer: on a fresh install with no tokens yet,
-	// AdminAuth is fail-open (HasAnyLiveTokenGlobal == 0), so the bootstrap still works.
-	// Once any token exists, callers must present a valid bearer — unauthenticated workspace-
-	// UUID enumeration is blocked even on non-production instances.
+	// NOT behind AdminAuth — this is the bootstrap endpoint E2E tests and
+	// fresh installs use to obtain their first admin bearer. Adding AdminAuth
+	// (#612) broke the chicken-and-egg: after first workspace provision creates
+	// a live token in the DB, AdminAuth requires auth for ALL requests, but the
+	// client has no token yet because it needs this endpoint to get one.
+	// The handler itself rejects calls when MOLECULE_ENV=prod (TestTokensEnabled).
 	{
 		tokh := handlers.NewAdminTestTokenHandler()
-		r.GET("/admin/workspaces/:id/test-token", middleware.AdminAuth(db.DB), tokh.GetTestToken)
+		r.GET("/admin/workspaces/:id/test-token", tokh.GetTestToken)
 	}
 
 	// Admin — GitHub App installation token refresh (issue #547).


### PR DESCRIPTION
## Summary
Reverts the AdminAuth gate on `GET /admin/workspaces/:id/test-token` that #612 added. This endpoint is the bootstrap path for E2E tests and fresh installs to obtain their first admin bearer token. With AdminAuth, it's a chicken-and-egg deadlock:

```
1. POST /workspaces (fail-open, no tokens) → creates workspace → token inserted in DB
2. AdminAuth now sees a live token → requires auth on ALL routes
3. E2E calls test-token to get first bearer → 401 "admin auth required"
4. All subsequent tests fail
```

The handler's own guard (`TestTokensEnabled() == false` when `MOLECULE_ENV=prod`) is the correct production gate. AdminAuth was defence-in-depth that broke the only bootstrap path.

## Impact
This has been blocking ALL open PR CI for 6+ maintenance cycles. Combined with the migration 028 FK bug (fixed in #670), these two issues explain why the team's PRs have been stuck despite active development.

Timeline of CI blockers this session:
1. Migration 028 TEXT→UUID FK — fixed by #670 (merged ~10:17 UTC)
2. **This bug** — #612's AdminAuth on test-token (introduced ~21:15 UTC yesterday, masked by the migration failure until #670 landed)

## Test plan
- [x] Confirmed root cause via CI logs: `test-token response: {"error":"admin auth required"}`
- [ ] CI on this PR should be the first to pass E2E since the 028 fix
- [ ] After merge + rebase, #650/#651/#696/#701 should all go GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)