### PR TITLE
fix(ci): remove go.mod replace /plugin — unblocks all CI

### DIFF
--- a/platform/Dockerfile
+++ b/platform/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /app
 # Plugin source for replace directive in go.mod
 COPY molecule-ai-plugin-github-app-auth/ /plugin/
 COPY platform/go.mod platform/go.sum ./
+# Add replace directive for Docker builds (plugin is COPYed to /plugin above)
+RUN echo 'replace github.com/Molecule-AI/molecule-ai-plugin-github-app-auth => /plugin' >> go.mod
 RUN go mod download
 COPY platform/ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /platform ./cmd/server

--- a/platform/Dockerfile.tenant
+++ b/platform/Dockerfile.tenant
@@ -16,7 +16,9 @@
 # ── Stage 1: Go platform binary ──────────────────────────────────────
 FROM golang:1.25-alpine AS go-builder
 WORKDIR /app
+COPY molecule-ai-plugin-github-app-auth/ /plugin/
 COPY platform/go.mod platform/go.sum ./
+RUN echo 'replace github.com/Molecule-AI/molecule-ai-plugin-github-app-auth => /plugin' >> go.mod
 RUN go mod download
 COPY platform/ .
 RUN CGO_ENABLED=0 GOOS=linux go build -o /platform ./cmd/server

--- a/platform/go.mod
+++ b/platform/go.mod
@@ -90,5 +90,3 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/Molecule-AI/molecule-ai-plugin-github-app-auth => /plugin


### PR DESCRIPTION
The replace directive breaks CI. Move it to Dockerfile build time only.