### PR TITLE
fix: railway.toml buildContext for workspace-server rename

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -29,7 +29,7 @@ name = "platform"
 [services.build]
 builder = "DOCKERFILE"
 dockerfilePath = "workspace-server/Dockerfile"
-buildContext = "workspace-server"
+buildContext = "."
 
 [services.deploy]
 startCommand = "./server"


### PR DESCRIPTION
Fixes Railway build after platform/ → workspace-server/ rename.
The Dockerfile COPYs from repo root paths (workspace-server/go.mod), so buildContext must be "." not "workspace-server".

🤖 Generated with [Claude Code](https://claude.com/claude-code)