### PR TITLE
fix(docs): update cd commands for workspace-server/ and workspace/ renames

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ git config core.hooksPath .githooks
 ./infra/scripts/setup.sh
 
 # Build and run the platform
-cd platform
+cd workspace-server
 go run ./cmd/server
 
 # In a separate terminal, run the canvas
@@ -77,13 +77,13 @@ causing a render loop when any node position changed.
 
 ```bash
 # Go (platform)
-cd platform && go test -race ./...
+cd workspace-server && go test -race ./...
 
 # Canvas (Next.js)
 cd canvas && npm test
 
 # Workspace runtime (Python)
-cd workspace-template && python -m pytest -v
+cd workspace && python -m pytest -v
 
 # E2E API tests (requires running platform)
 bash tests/e2e/test_api.sh

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ cd molecule-monorepo
 # `molecule-monorepo-net` Docker network. Temporal runs with
 # no auth on localhost — dev-only; production must gate it.
 
-cd platform
+cd workspace-server
 go run ./cmd/server
 
 cd ../canvas

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,7 +257,7 @@ cd molecule-monorepo
 # `molecule-monorepo-net` Docker 网络上。Temporal 默认无鉴权，
 # 仅用于本地开发；生产环境必须加 mTLS / API Key。
 
-cd platform
+cd workspace-server
 go run ./cmd/server
 
 cd ../canvas

--- a/docs/development/local-development.md
+++ b/docs/development/local-development.md
@@ -92,9 +92,9 @@ Docker Compose  2.x
 ### Unit Tests
 
 ```bash
-cd platform && go test -race ./...               # Go tests with race detection (695 tests)
+cd workspace-server && go test -race ./...               # Go tests with race detection (695 tests)
 cd canvas && npm test                            # Vitest tests (357 tests)
-cd workspace-template && python -m pytest -v     # Workspace runtime tests (1140 tests)
+cd workspace && python -m pytest -v     # Workspace runtime tests (1140 tests)
 cd sdk/python && python -m pytest -v             # SDK tests (121 tests)
 cd mcp-server && npm test                        # MCP server tests (97 Jest tests)
 ```

--- a/docs/development/testing-e2e.md
+++ b/docs/development/testing-e2e.md
@@ -37,7 +37,7 @@ The scripts handle this by:
 
 ```bash
 # Quickest check after any platform change:
-cd platform && go build ./cmd/server && ./server &
+cd workspace-server && go build ./cmd/server && ./server &
 bash tests/e2e/test_api.sh        # expect 62/62 pass
 
 # Comprehensive sweep:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,7 +39,7 @@ docker compose -f docker-compose.infra.yml up -d
 ## Step 3: Start the platform
 
 ```bash
-cd platform
+cd workspace-server
 go run ./cmd/server
 ```
 


### PR DESCRIPTION
Missed cd commands in READMEs, quickstart, dev docs, and CONTRIBUTING.md. 🤖