### PR TITLE
feat(db): schema_migrations tracking — run each migration only once

### DIFF
--- a/workspace-server/internal/db/postgres.go
+++ b/workspace-server/internal/db/postgres.go
@@ -51,6 +51,14 @@ func InitPostgres(databaseURL string) error {
 // Migration authors must write idempotent SQL. A real schema_migrations
 // tracking table would be better; tracked as follow-up.
 func RunMigrations(migrationsDir string) error {
+	// Create tracking table if it doesn't exist.
+	if _, err := DB.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		filename TEXT PRIMARY KEY,
+		applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	)`); err != nil {
+		return fmt.Errorf("create schema_migrations: %w", err)
+	}
+
 	allFiles, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
 	if err != nil {
 		return fmt.Errorf("glob migrations: %w", err)
@@ -66,16 +74,36 @@ func RunMigrations(migrationsDir string) error {
 	}
 	sort.Strings(files)
 
+	applied := 0
+	skipped := 0
 	for _, f := range files {
-		log.Printf("Applying migration: %s", filepath.Base(f))
+		base := filepath.Base(f)
+
+		// Check if already applied.
+		var exists bool
+		if err := DB.QueryRow("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)", base).Scan(&exists); err != nil {
+			return fmt.Errorf("check migration %s: %w", base, err)
+		}
+		if exists {
+			skipped++
+			continue
+		}
+
+		log.Printf("Applying migration: %s", base)
 		content, err := os.ReadFile(f)
 		if err != nil {
 			return fmt.Errorf("read %s: %w", f, err)
 		}
 		if _, err := DB.Exec(string(content)); err != nil {
-			return fmt.Errorf("exec %s: %w", filepath.Base(f), err)
+			return fmt.Errorf("exec %s: %w", base, err)
 		}
+
+		// Record as applied.
+		if _, err := DB.Exec("INSERT INTO schema_migrations (filename) VALUES ($1)", base); err != nil {
+			return fmt.Errorf("record migration %s: %w", base, err)
+		}
+		applied++
 	}
-	log.Printf("Applied %d migrations", len(files))
+	log.Printf("Applied %d migrations (%d already applied)", applied, skipped)
 	return nil
 }

--- a/workspace-server/internal/db/postgres_schema_migrations_test.go
+++ b/workspace-server/internal/db/postgres_schema_migrations_test.go
@@ -1,0 +1,166 @@
+package db
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+// Tests for schema_migrations tracking — verifies migrations only run once.
+
+func TestRunMigrations_FirstBoot_AppliesAndRecords(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+	DB = mockDB
+
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "001_init.up.sql"), []byte("CREATE TABLE foo();"), 0o644)
+
+	// Expect: CREATE tracking table
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Expect: check if 001_init.up.sql already applied → returns false
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("001_init.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	// Expect: apply migration
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE foo();")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Expect: record as applied
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO schema_migrations (filename) VALUES ($1)")).
+		WithArgs("001_init.up.sql").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := RunMigrations(tmp); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunMigrations_SecondBoot_SkipsApplied(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+	DB = mockDB
+
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "001_init.up.sql"), []byte("CREATE TABLE foo();"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "002_next.up.sql"), []byte("CREATE TABLE bar();"), 0o644)
+
+	// Tracking table create is always attempted
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// 001 already applied → skip
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("001_init.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	// 002 also already applied → skip
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("002_next.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	// No ExecExec for the migration bodies — they shouldn't run
+
+	if err := RunMigrations(tmp); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunMigrations_MixedState_AppliesOnlyNew(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+	DB = mockDB
+
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "001_old.up.sql"), []byte("SELECT 1;"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "002_new.up.sql"), []byte("SELECT 2;"), 0o644)
+
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// 001 already applied
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("001_old.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	// 002 not yet applied
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("002_new.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	// Apply 002
+	mock.ExpectExec(regexp.QuoteMeta("SELECT 2;")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Record 002
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO schema_migrations (filename) VALUES ($1)")).
+		WithArgs("002_new.up.sql").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := RunMigrations(tmp); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestRunMigrations_SkipsDownSqlFilesEvenInTracking(t *testing.T) {
+	mockDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock: %v", err)
+	}
+	defer mockDB.Close()
+	DB = mockDB
+
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "001_init.up.sql"), []byte("CREATE TABLE foo();"), 0o644)
+	os.WriteFile(filepath.Join(tmp, "001_init.down.sql"), []byte("DROP TABLE foo;"), 0o644)
+
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE IF NOT EXISTS schema_migrations")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	// Only .up.sql should be checked — not .down.sql
+	mock.ExpectQuery(regexp.QuoteMeta("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)")).
+		WithArgs("001_init.up.sql").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(false))
+
+	mock.ExpectExec(regexp.QuoteMeta("CREATE TABLE foo();")).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectExec(regexp.QuoteMeta("INSERT INTO schema_migrations (filename) VALUES ($1)")).
+		WithArgs("001_init.up.sql").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	if err := RunMigrations(tmp); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `schema_migrations` table to track applied migrations. On boot, only new migrations run — already-applied ones are skipped.

Before: 33 migrations re-executed on every restart (~200ms, risk of non-idempotent DDL failure).
After: Only new migrations execute. Skipped count logged.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./internal/db/...` passes
- [ ] E2E: boot → apply all 33 → restart → 0 applied, 33 skipped (needs Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)