### PR TITLE
fix(scheduler): strip CRLF from cron prompts (closes #958)

### DIFF
--- a/workspace-server/internal/handlers/schedules.go
+++ b/workspace-server/internal/handlers/schedules.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -96,6 +97,10 @@ func (h *ScheduleHandler) Create(c *gin.Context) {
 		return
 	}
 
+	// Strip CRLF from prompts — org-template files committed on Windows
+	// inject \r\n, causing empty agent responses (issue #958).
+	body.Prompt = strings.ReplaceAll(body.Prompt, "\r", "")
+
 	if body.Timezone == "" {
 		body.Timezone = "UTC"
 	}
@@ -159,6 +164,12 @@ func (h *ScheduleHandler) Update(c *gin.Context) {
 	if err := c.ShouldBindJSON(&body); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid JSON"})
 		return
+	}
+
+	// Strip CRLF from prompt if provided (issue #958).
+	if body.Prompt != nil {
+		clean := strings.ReplaceAll(*body.Prompt, "\r", "")
+		body.Prompt = &clean
 	}
 
 	// If cron_expr or timezone changed, revalidate and recompute next_run

--- a/workspace-server/migrations/033_strip_crlf_cron_prompts.up.sql
+++ b/workspace-server/migrations/033_strip_crlf_cron_prompts.up.sql
@@ -1,0 +1,3 @@
+-- Issue #958: Strip CRLF from cron prompts inserted from Windows org-template files.
+-- Carriage returns cause empty agent responses and phantom-producing detection.
+UPDATE workspace_schedules SET prompt = REPLACE(prompt, E'\r', '') WHERE prompt LIKE E'%\r%';


### PR DESCRIPTION
## Summary
Strips `\r` from cron prompts on both Create and Update paths. Adds migration to clean existing contaminated rows.

**Root cause:** Org-template files committed on Windows inject CRLF into prompt text stored in `workspace_schedules.prompt`.

## Test plan
- [x] `go build` + `go vet` pass
- [x] `go test -race ./internal/handlers/...` passes
- [x] Migration is idempotent (no-op if no CRLF rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)