### PR TITLE
ci: update GitHub Actions to current stable versions (closes #780)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
       # CLI (molecli) moved to standalone repo: github.com/Molecule-AI/molecule-cli
       - run: go vet ./...
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           working-directory: workspace-server

--- a/.github/workflows/publish-canvas-image.yml
+++ b/.github/workflows/publish-canvas-image.yml
@@ -58,7 +58,7 @@ jobs:
         # Six prior PRs (#273, #319, #322, #341, #484, #486) all kept calling
         # `docker login` and tried to coerce credsStore — none worked.
         # The only reliable fix is to skip `docker login` entirely and write
-        # the auth string directly. `docker/build-push-action@v5` and the
+        # the auth string directly. `docker/build-push-action@v6` and the
         # daemon honor the `auths` map for push without needing login.
         shell: bash
         env:
@@ -83,12 +83,12 @@ jobs:
 
       - name: Set up QEMU
         # Apple-silicon runner building linux/amd64 images for x86 hosts.
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Compute tags
         id: tags
@@ -121,7 +121,7 @@ jobs:
           echo "ws_url=${WS_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push canvas image to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./canvas
           file: ./canvas/Dockerfile

--- a/.github/workflows/publish-workspace-server-image.yml
+++ b/.github/workflows/publish-workspace-server-image.yml
@@ -43,12 +43,12 @@ jobs:
           echo "DOCKER_CONFIG=${RUNNER_TEMP}/docker-config" >> "${GITHUB_ENV}"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: linux/amd64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Compute tags
         id: tags
@@ -56,7 +56,7 @@ jobs:
           echo "sha=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
 
       - name: Build & push platform image to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./workspace-server/Dockerfile
@@ -73,7 +73,7 @@ jobs:
             org.opencontainers.image.description=Molecule AI platform (Go API server)
 
       - name: Build & push tenant image to GHCR
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./workspace-server/Dockerfile.tenant


### PR DESCRIPTION
Routine CI action version bumps per issue #780. 🤖