### PR TITLE
fix(security): scrub workspace-server token + upstream error logs

### DIFF
--- a/workspace-server/internal/handlers/workspace_provision.go
+++ b/workspace-server/internal/handlers/workspace_provision.go
@@ -545,6 +545,9 @@ func (h *WorkspaceHandler) provisionWorkspaceCP(workspaceID, templatePath string
 	if tokenErr != nil {
 		log.Printf("CPProvisioner: failed to issue token for %s: %v", workspaceID, tokenErr)
 	} else {
-		log.Printf("CPProvisioner: issued auth token for workspace %s (prefix: %s...)", workspaceID, token[:8])
+		// Don't log any prefix of the token. Earlier H1 regression showed
+		// this slice pattern (token[:8]) panics when a helper returns a
+		// short value. Length alone is enough to confirm a token issued.
+		log.Printf("CPProvisioner: issued auth token for workspace %s (len=%d)", workspaceID, len(token))
 	}
 }

--- a/workspace-server/internal/provisioner/cp_provisioner.go
+++ b/workspace-server/internal/provisioner/cp_provisioner.go
@@ -91,14 +91,21 @@ func (p *CPProvisioner) Start(ctx context.Context, cfg WorkspaceConfig) (string,
 	}
 	defer resp.Body.Close()
 
-	respBody, _ := io.ReadAll(resp.Body)
+	// Cap body read at 64 KiB — the CP only ever returns small JSON
+	// responses; an unbounded read could be weaponized into log-flood
+	// DoS by a compromised upstream.
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 	var result cpProvisionResponse
 	json.Unmarshal(respBody, &result)
 
 	if resp.StatusCode != http.StatusCreated {
+		// Prefer the structured {"error":"..."} field. Do NOT fall back
+		// to string(respBody) — our logs ingest errors, and an upstream
+		// misconfiguration that echoed the Authorization header or
+		// request body into the response would leak bearer tokens.
 		errMsg := result.Error
 		if errMsg == "" {
-			errMsg = string(respBody)
+			errMsg = fmt.Sprintf("<unstructured body, %d bytes>", len(respBody))
 		}
 		return "", fmt.Errorf("cp provisioner: provision failed (%d): %s", resp.StatusCode, errMsg)
 	}


### PR DESCRIPTION
## Summary

Two findings from the pre-launch log-scrub audit.

- **\`handlers/workspace_provision.go:548\`** logged \`token[:8]\` — same slice pattern as the H1 panic we already fixed on CP \`main.go:118\`. Panics on short tokens AND leaks 8 chars of an auth token to centralized logs, shrinking the search space for anyone with log-read access. Now logs \`len(token)\` only.
- **\`provisioner/cp_provisioner.go:101\`** fell back to logging the raw control-plane response body when the structured \`{\"error\":\"…\"}\` field was absent. If the CP ever echoed request headers (Authorization) or user-data into an error path, the bearer token would land in tenant-instance logs. Now logs byte count only and caps the body read at 64 KiB via \`io.LimitReader\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/provisioner/... ./internal/handlers/...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)