### PR TITLE
fix(canvas): add 15s fetch timeout on API calls

### DIFF
--- a/canvas/src/lib/api.ts
+++ b/canvas/src/lib/api.ts
@@ -8,6 +8,12 @@ import { getTenantSlug } from "./tenant";
 export const PLATFORM_URL =
   process.env.NEXT_PUBLIC_PLATFORM_URL ?? "http://localhost:8080";
 
+// 15s is long enough for slow CP queries but short enough that a
+// hung backend doesn't leave the UI spinning forever. The abort
+// propagates through AbortController so React components can observe
+// the error and render a retry affordance.
+const DEFAULT_TIMEOUT_MS = 15_000;
+
 async function request<T>(
   method: string,
   path: string,
@@ -28,6 +34,7 @@ async function request<T>(
     headers,
     body: body ? JSON.stringify(body) : undefined,
     credentials: "include",
+    signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
   });
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary

Pre-launch audit finding. Every fetch in \`canvas/src/lib/api.ts\` was unbounded — a slow or hung CP response would leave the UI spinning forever with no way for the user to abort. Classic client-side DoS.

15s covers the slowest observed CP call (Stripe portal redirect, ~3s) with comfortable headroom. \`AbortSignal.timeout\` propagates through React Query / SWR consumers cleanly so components can render a retry affordance.

## Test plan

- [x] Typecheck on api.ts clean (pre-existing a11y test error unrelated)
- [ ] Manual: throttle network → slow request → confirm it aborts at 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)