### PR TITLE
fix(e2e): stop asserting current_task on public workspace GET

### DIFF
--- a/tests/e2e/test_api.sh
+++ b/tests/e2e/test_api.sh
@@ -259,21 +259,26 @@ R=$(curl -s -X POST "$BASE/registry/heartbeat" -H "Content-Type: application/jso
   -d "{\"workspace_id\":\"$ECHO_ID\",\"error_rate\":0.0,\"sample_error\":\"\",\"active_tasks\":1,\"uptime_seconds\":400,\"current_task\":\"Analyzing document\"}")
 check "Heartbeat with current_task" '"status":"ok"' "$R"
 
-# Test: Verify current_task in GET /workspaces/:id
+# Test: Verify state updates are observable in GET /workspaces/:id.
+# current_task itself is stripped from this endpoint as of #966 to avoid
+# leaking task bodies via the public-facing GET; active_tasks is still
+# the canonical "is it busy" signal here. The list endpoint below covers
+# the admin-only current_task visibility path.
 R=$(acurl "$BASE/workspaces/$ECHO_ID")
-check "current_task visible in workspace" '"current_task":"Analyzing document"' "$R"
 check "active_tasks updated" '"active_tasks":1' "$R"
 
-# Test: Clear current_task
+# Test: Clear current_task via heartbeat
 R=$(curl -s -X POST "$BASE/registry/heartbeat" -H "Content-Type: application/json" -H "Authorization: Bearer $ECHO_TOKEN" \
   -d "{\"workspace_id\":\"$ECHO_ID\",\"error_rate\":0.0,\"sample_error\":\"\",\"active_tasks\":0,\"uptime_seconds\":500,\"current_task\":\"\"}")
 check "Heartbeat clear current_task" '"status":"ok"' "$R"
 
 R=$(acurl "$BASE/workspaces/$ECHO_ID")
-check "current_task cleared" '"current_task":""' "$R"
+check "active_tasks cleared" '"active_tasks":0' "$R"
 
-# Test: current_task in workspace list — now admin-auth gated (C1 fix), so a
-# workspace bearer token is required once tokens exist anywhere on the platform.
+# Test: current_task IS visible in the admin workspace list — the list
+# endpoint is admin-auth gated and keeps the full record, so operators
+# can still see task progress from the dashboard without exposing it
+# over the public per-workspace GET.
 R=$(curl -s "$BASE/workspaces" -H "Authorization: Bearer $ECHO_TOKEN")
 check "current_task in list response" '"current_task"' "$R"
 


### PR DESCRIPTION
## Summary

PR #966 stripped \`current_task\`, \`last_sample_error\`, and \`workspace_dir\` from the public \`GET /workspaces/:id\` response (security fix — those fields leak task bodies / agent errors / host paths to any workspace-bearer holder). The E2E smoke test kept asserting \`"current_task":"Analyzing document"\` on the single-workspace GET, so every post-#966 CI run has failed with \`60 passed, 2 failed\`.

Swap the per-workspace asserts to \`active_tasks\` (still exposed, canonical busy signal) and keep the list-endpoint check that proves admin-auth'd callers still see \`current_task\` end-to-end.

## Blocks

Staging → main promotion (#983 — this test drift is the only red on the promotion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)