### PR TITLE
fix(ci): clone sibling plugin repo so publish-workspace-server-image builds

### DIFF
--- a/.github/workflows/publish-workspace-server-image.yml
+++ b/.github/workflows/publish-workspace-server-image.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout sibling plugin repo
+        # workspace-server/Dockerfile expects
+        # ./molecule-ai-plugin-github-app-auth at build-context root because
+        # the Go module has a `replace` directive pointing at /plugin inside
+        # the image. Pre-repo-split the plugin lived in the monorepo; the
+        # 2026-04-18 restructure moved it out but didn't add this clone step
+        # — which is why publish has been failing since then.
+        #
+        # Uses a fine-grained PAT (PLUGIN_REPO_PAT) because the plugin repo
+        # is private and the default GITHUB_TOKEN is scoped to THIS repo.
+        # The PAT needs Contents:Read on Molecule-AI/molecule-ai-plugin-
+        # github-app-auth. Falls back to the default token for the (rare)
+        # case where an operator made the plugin repo public.
+        uses: actions/checkout@v4
+        with:
+          repository: Molecule-AI/molecule-ai-plugin-github-app-auth
+          path: molecule-ai-plugin-github-app-auth
+          token: ${{ secrets.PLUGIN_REPO_PAT || secrets.GITHUB_TOKEN }}
+
       - name: Configure GHCR auth
         shell: bash
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ backups/
 /org-templates/
 /plugins/
 /workspace-configs-templates/
+# Cloned by publish-workspace-server-image.yml so the Dockerfile's
+# replace-directive path resolves. Lives in its own repo.
+/molecule-ai-plugin-github-app-auth/


### PR DESCRIPTION
## Summary

**Publish has been broken since the 2026-04-18 open-source restructure.** \`workspace-server/Dockerfile\` still \`COPY\`s \`./molecule-ai-plugin-github-app-auth/\` but the restructure moved that plugin to its own repo. Every main merge since has failed at "failed to compute cache key: \`/molecule-ai-plugin-github-app-auth\`: not found" — meaning **prod tenant images haven't been rebuilt for days**. This is why the Phase 1.5 / canary / billing-gate merges didn't reach the tenant image fleet yet.

## Fix

Add an \`actions/checkout\` step that fetches the plugin repo into the build context before \`docker build\` runs.

## Ops action required before next main merge

The plugin repo is private. Add a fine-grained PAT as a repo secret:

1. GitHub → Settings → Developer settings → Personal access tokens → Fine-grained
2. Repository access: \`Molecule-AI/molecule-ai-plugin-github-app-auth\` only
3. Permissions: **Contents: Read**
4. Copy token → \`Molecule-AI/molecule-core\` → Settings → Secrets → Actions → new secret \`PLUGIN_REPO_PAT\`

The workflow falls back to the default \`GITHUB_TOKEN\` if the secret is missing — so if the plugin repo is ever made public, it keeps working without the PAT.

## Test plan

- [x] Workflow YAML is valid
- [ ] After merging + setting \`PLUGIN_REPO_PAT\`: confirm next main merge publishes \`:staging-<sha>\`
- [ ] Manually retag \`:staging-<sha>\` → \`:latest\` via \`scripts/rollback-latest.sh <sha>\` (canary isn't live yet, so the automatic gate doesn't promote)

🤖 Generated with [Claude Code](https://claude.com/claude-code)