### PR TITLE
promote: staging → main — unblock publish workflow (private-repo plugin clone)

### DIFF
--- a/.github/workflows/publish-workspace-server-image.yml
+++ b/.github/workflows/publish-workspace-server-image.yml
@@ -29,6 +29,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Checkout sibling plugin repo
+        # workspace-server/Dockerfile expects
+        # ./molecule-ai-plugin-github-app-auth at build-context root because
+        # the Go module has a `replace` directive pointing at /plugin inside
+        # the image. Pre-repo-split the plugin lived in the monorepo; the
+        # 2026-04-18 restructure moved it out but didn't add this clone step
+        # — which is why publish has been failing since then.
+        #
+        # Uses a fine-grained PAT (PLUGIN_REPO_PAT) because the plugin repo
+        # is private and the default GITHUB_TOKEN is scoped to THIS repo.
+        # The PAT needs Contents:Read on Molecule-AI/molecule-ai-plugin-
+        # github-app-auth. Falls back to the default token for the (rare)
+        # case where an operator made the plugin repo public.
+        uses: actions/checkout@v4
+        with:
+          repository: Molecule-AI/molecule-ai-plugin-github-app-auth
+          path: molecule-ai-plugin-github-app-auth
+          token: ${{ secrets.PLUGIN_REPO_PAT || secrets.GITHUB_TOKEN }}
+
       - name: Configure GHCR auth
         shell: bash
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ backups/
 /org-templates/
 /plugins/
 /workspace-configs-templates/
+# Cloned by publish-workspace-server-image.yml so the Dockerfile's
+# replace-directive path resolves. Lives in its own repo.
+/molecule-ai-plugin-github-app-auth/


### PR DESCRIPTION
## Summary

Single-commit promotion to unblock the publish workflow that's been failing since 2026-04-18. #996 adds the \`actions/checkout\` step that fetches the sibling \`molecule-ai-plugin-github-app-auth\` repo into the build context, using \`PLUGIN_REPO_PAT\` (the fine-grained PAT you just provisioned).

## Expected on merge

1. Main receives this commit.
2. \`publish-workspace-server-image\` workflow triggers.
3. It runs the new checkout step with \`PLUGIN_REPO_PAT\`, pulls the plugin repo → build succeeds.
4. GHCR receives \`ghcr.io/molecule-ai/platform:staging-<sha>\` (and tenant image).
5. I'll then run \`scripts/rollback-latest.sh <sha>\` to retag the new image to \`:latest\`, so fresh prod provisions pick it up — canary-verify isn't populated yet, so the automatic promote doesn't fire.

## Test plan

- [x] Everything already merged + green on staging
- [ ] Post-merge: verify publish workflow succeeds, then retag to \`:latest\` manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)