### PR TITLE
fix(security): pinned plugin refs + SHA256 integrity (#815)

### DIFF
--- a/platform/internal/plugins/github.go
+++ b/platform/internal/plugins/github.go
@@ -55,6 +55,16 @@ var repoRE = regexp.MustCompile(
 	`^([a-zA-Z0-9][a-zA-Z0-9_.\-]{0,99})/([a-zA-Z0-9][a-zA-Z0-9_.\-]{0,99})(?:#([a-zA-Z0-9_.][a-zA-Z0-9_./\-]{0,254}))?$`,
 )
 
+// pinnedRefRE matches refs that are reproducible:
+//   - Full or abbreviated git SHAs: 7–40 lowercase hex chars
+//   - Semver-style version tags: v<major>[.<minor>[.<patch>]][-prerelease]
+//
+// Branch names ("main", "dev", "feature/foo") are NOT matched — they move
+// between installs and break supply-chain reproducibility (VULN-004 / #815).
+var pinnedRefRE = regexp.MustCompile(
+	`^([0-9a-f]{7,40}|v\d+(\.\d+)*(-[a-zA-Z0-9.]+)?)$`,
+)
+
 // Fetch clones the repository and copies its contents (minus .git) into dst.
 // Returns the repository name (second path segment) as the plugin name.
 func (r *GithubResolver) Fetch(ctx context.Context, spec string, dst string) (string, error) {
@@ -64,6 +74,24 @@ func (r *GithubResolver) Fetch(ctx context.Context, spec string, dst string) (st
 		return "", fmt.Errorf("github resolver: spec %q must be <owner>/<repo>[#<ref>]", spec)
 	}
 	owner, repo, ref := m[1], m[2], m[3]
+
+	// VULN-004 / SAFE-T1102 (#815): reject bare org/repo or branch-only refs.
+	// A pinned ref is either a git SHA (7–40 hex chars) or a semver tag (v1.2.3).
+	// Bare refs ("main", "dev") or missing refs change between installs —
+	// an attacker who compromises the upstream repo gets arbitrary code execution.
+	//
+	// Escape hatch: PLUGIN_ALLOW_UNPINNED=true for local development only.
+	// This env var MUST NOT be set in production.
+	allowUnpinned := os.Getenv("PLUGIN_ALLOW_UNPINNED") == "true"
+	if !allowUnpinned && !pinnedRefRE.MatchString(ref) {
+		return "", fmt.Errorf(
+			"github resolver: spec %q has an unpinned ref %q — "+
+				"plugin installs must use a pinned ref (commit SHA or version tag, e.g. #abc1234 or #v1.2.0) "+
+				"to prevent supply-chain drift (VULN-004). "+
+				"Set PLUGIN_ALLOW_UNPINNED=true to bypass during local development only",
+			spec, ref,
+		)
+	}
 
 	runner := r.GitRunner
 	if runner == nil {

--- a/platform/internal/plugins/github_test.go
+++ b/platform/internal/plugins/github_test.go
@@ -51,6 +51,9 @@ func stubGit(repoContents map[string]string) func(ctx context.Context, dir strin
 }
 
 func TestGithubResolver_ClonesAndStripsGitDir(t *testing.T) {
+	// Bypass the pinned-ref gate — this test covers clone+copy behaviour, not
+	// supply-chain enforcement (see supply_chain_test.go for that).
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true")
 	r := &GithubResolver{
 		GitRunner: stubGit(map[string]string{
 			"plugin.yaml":             "name: demo\n",
@@ -98,6 +101,7 @@ func TestGithubResolver_PassesRefAsBranch(t *testing.T) {
 }
 
 func TestGithubResolver_OmitsBranchFlagWhenNoRef(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing git-arg behaviour
 	var seenArgs []string
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
@@ -136,6 +140,7 @@ func TestGithubResolver_RejectsInvalidSpec(t *testing.T) {
 }
 
 func TestGithubResolver_BubblesUpGitError(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing git-error propagation
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
 			return errors.New("simulated auth failure")
@@ -154,6 +159,7 @@ func TestGithubResolver_UsesDefaultsWhenNilFields(t *testing.T) {
 	// A zero-value GithubResolver should still have defaults filled in
 	// at Fetch time. Verified indirectly: we pass a stub that records
 	// the URL passed to `git clone`.
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing default-field behaviour
 	var seenArgs []string
 	r := &GithubResolver{}
 	r.GitRunner = func(ctx context.Context, dir string, args ...string) error {
@@ -212,6 +218,7 @@ func TestGithubResolver_NilGitRunnerUsesDefault(t *testing.T) {
 	// Passing nil GitRunner should fall back to defaultGitRunner. With no
 	// git on PATH, that fallback errors — we don't need real git here.
 	t.Setenv("PATH", "/nonexistent")
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing nil-runner fallback
 	r := &GithubResolver{GitRunner: nil, BaseURL: "https://example.com"}
 	_, err := r.Fetch(context.Background(), "org/repo", t.TempDir())
 	if err == nil {
@@ -220,6 +227,7 @@ func TestGithubResolver_NilGitRunnerUsesDefault(t *testing.T) {
 }
 
 func TestGithubResolver_CopyToDstFailure(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing copy-failure handling
 	r := &GithubResolver{
 		GitRunner: stubGit(map[string]string{"plugin.yaml": "name: x\n"}),
 	}
@@ -236,6 +244,7 @@ func TestGithubResolver_CopyToDstFailure(t *testing.T) {
 }
 
 func TestGithubResolver_AlwaysPassesDepth1(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing --depth=1 in git args
 	var seenArgs []string
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
@@ -254,7 +263,8 @@ func TestGithubResolver_AlwaysPassesDepth1(t *testing.T) {
 
 func TestGithubResolver_PassesDoubleDashBeforeURL(t *testing.T) {
 	// When a ref is specified, we pass `--` after --branch <ref> as
-	// defense-in-depth against ref-as-flag injection.
+	// defense-in-depth against ref-as-flag injection. Uses a pinned tag
+	// ref so the supply-chain gate passes without an env-var bypass.
 	var seenArgs []string
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
@@ -263,7 +273,7 @@ func TestGithubResolver_PassesDoubleDashBeforeURL(t *testing.T) {
 			return os.MkdirAll(target, 0o755)
 		},
 	}
-	if _, err := r.Fetch(context.Background(), "org/repo#main", t.TempDir()); err != nil {
+	if _, err := r.Fetch(context.Background(), "org/repo#v1.0.0", t.TempDir()); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 	if !containsArg(seenArgs, "--") {
@@ -280,6 +290,7 @@ func TestGithubResolver_RejectsRefStartingWithHyphen(t *testing.T) {
 }
 
 func TestGithubResolver_MapsRepositoryNotFoundToSentinel(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing ErrPluginNotFound mapping
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
 			return errors.New("remote: Repository not found.\nfatal: repository 'https://github.com/x/y.git' not found")
@@ -292,18 +303,22 @@ func TestGithubResolver_MapsRepositoryNotFoundToSentinel(t *testing.T) {
 }
 
 func TestGithubResolver_MapsMissingBranchToSentinel(t *testing.T) {
+	// Use a pinned tag ref so the supply-chain gate passes. The git error
+	// itself is what we're testing — the tag just happens to be absent from
+	// the (stubbed) remote.
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
 			return errors.New("fatal: Remote branch bogus not found in upstream origin")
 		},
 	}
-	_, err := r.Fetch(context.Background(), "org/repo#bogus", t.TempDir())
+	_, err := r.Fetch(context.Background(), "org/repo#v0.0.1", t.TempDir())
 	if !errors.Is(err, ErrPluginNotFound) {
 		t.Errorf("expected ErrPluginNotFound for missing ref, got %v", err)
 	}
 }
 
 func TestGithubResolver_AuthFailureIsNotErrPluginNotFound(t *testing.T) {
+	t.Setenv("PLUGIN_ALLOW_UNPINNED", "true") // gate bypassed; testing auth-failure mapping
 	r := &GithubResolver{
 		GitRunner: func(ctx context.Context, dir string, args ...string) error {
 			return errors.New("fatal: Authentication failed for 'https://github.com/private/repo.git/'")

--- a/platform/internal/plugins/supply_chain.go
+++ b/platform/internal/plugins/supply_chain.go
@@ -1,0 +1,128 @@
+package plugins
+
+// supply_chain.go — plugin supply-chain integrity controls (issue #768 / #815).
+//
+// Two controls:
+//
+//  1. VerifyManifestIntegrity — SHA256 content-integrity check.  If a
+//     staged plugin directory contains a manifest.json with a "sha256"
+//     field, the field is compared against the canonical digest of the
+//     staged tree.  A mismatch aborts the install before any files reach
+//     a workspace volume.
+//
+//  2. Pinned-ref gate — enforced in GithubResolver.Fetch (github.go).
+//     A bare "org/repo" spec with no "#tag" or "#sha" fragment is rejected
+//     unless PLUGIN_ALLOW_UNPINNED=true (local-dev escape hatch).
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// VerifyManifestIntegrity checks the SHA256 content hash declared in
+// manifest.json against the actual contents of stagedDir.
+//
+// Behaviour:
+//   - manifest.json absent           → nil (backward compat with pre-#768 plugins)
+//   - manifest.json present, no sha256 field → nil (same backward compat)
+//   - sha256 field matches computed digest  → nil (integrity verified)
+//   - sha256 field doesn't match           → non-nil error (tamper detected)
+//
+// The canonical digest algorithm walks all regular files in stagedDir
+// (excluding manifest.json itself), sorts by relative path, and SHA256-hashes
+// the concatenation of "<rel-path>\x00<file-content>" strings. This matches
+// the reference implementation in supply_chain_test.go:stagedDirDigest.
+func VerifyManifestIntegrity(stagedDir string) error {
+	manifestPath := filepath.Join(stagedDir, "manifest.json")
+
+	data, err := os.ReadFile(manifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil // no manifest — backward compat, skip check
+	}
+	if err != nil {
+		return fmt.Errorf("supply chain: read manifest.json: %w", err)
+	}
+
+	// Parse only the sha256 field; ignore other metadata keys.
+	var manifest struct {
+		SHA256 string `json:"sha256"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("supply chain: parse manifest.json: %w", err)
+	}
+	if manifest.SHA256 == "" {
+		return nil // no sha256 field — backward compat, skip check
+	}
+
+	computed, err := stagedTreeDigest(stagedDir)
+	if err != nil {
+		return fmt.Errorf("supply chain: compute tree digest: %w", err)
+	}
+
+	if computed != manifest.SHA256 {
+		return fmt.Errorf("supply chain: sha256 mismatch — manifest claims %s, computed %s; plugin may have been tampered with",
+			manifest.SHA256, computed)
+	}
+	return nil
+}
+
+// stagedTreeDigest computes the canonical SHA256 of all regular files in
+// stagedDir, excluding manifest.json. Algorithm:
+//
+//  1. Walk all regular files, skipping manifest.json.
+//  2. For each file, build the string "<rel-path>\x00<file-content>".
+//  3. Sort lexicographically by relative path.
+//  4. Concatenate and SHA256-hash the result.
+//  5. Return the lower-case hex digest.
+//
+// Deterministic across OS/filesystem orderings because of the sort step.
+func stagedTreeDigest(dir string) (string, error) {
+	var entries []string
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "manifest.json" {
+			return nil // exclude manifest from the digest
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("stagedTreeDigest: open %s: %w", rel, err)
+		}
+		defer f.Close()
+
+		content, err := io.ReadAll(f)
+		if err != nil {
+			return fmt.Errorf("stagedTreeDigest: read %s: %w", rel, err)
+		}
+		entries = append(entries, rel+"\x00"+string(content))
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	sort.Strings(entries)
+	var combined string
+	for _, e := range entries {
+		combined += e
+	}
+	sum := sha256.Sum256([]byte(combined))
+	return hex.EncodeToString(sum[:]), nil
+}


### PR DESCRIPTION
## Summary
- Implements VULN-004 / SAFE-T1102 — pins plugin references with SHA256 integrity checks
- Adds supply_chain.go for plugin integrity verification
- Extends GitHub plugin handler with pinning support
- New tests for integrity validation

## Test plan
- [ ] Verify plugin manifests are pinned to specific SHA refs
- [ ] Test SHA256 integrity check against tampered manifests
- [ ] Run plugin handler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Molecule-Platform-Evolvement-Manager] PR opened on behalf of Backend Engineer (Security) agent.