### PR TITLE
ci(codeql): add CodeQL workflow for Go + JS analysis

### DIFF
--- a/.github/workflows/canary-verify.yml
+++ b/.github/workflows/canary-verify.yml
@@ -34,7 +34,9 @@ jobs:
   canary-smoke:
     # Skip when the upstream workflow failed — no image to test against.
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    # Self-hosted mac mini — GitHub-hosted minutes are quota-blocked on
+    # this org (same reason publish/promote-latest moved earlier).
+    runs-on: [self-hosted, macos, arm64]
     outputs:
       sha: ${{ steps.compute.outputs.sha }}
     steps:
@@ -77,12 +79,21 @@ jobs:
     # the runner) that can retag remotely with a single API call each.
     needs: canary-smoke
     if: ${{ needs.canary-smoke.result == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macos, arm64]
     steps:
-      - name: Install crane
+      - name: Ensure crane installed
+        # Matches the install pattern in promote-latest.yml — brew
+        # cleanup exits non-zero on the shared runner's /opt/homebrew
+        # symlinks, so skip it.
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_ENV_HINTS: "1"
         run: |
-          curl -fsSL https://github.com/google/go-containerregistry/releases/download/v0.20.2/go-containerregistry_Linux_x86_64.tar.gz | \
-            tar xz -C /usr/local/bin crane
+          if ! command -v crane >/dev/null 2>&1; then
+            brew install crane
+          fi
+          crane version
 
       - name: GHCR login
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,124 @@
+name: CodeQL
+
+# Controls CodeQL scan triggers for this repo.
+#
+# GitHub's "Code quality" default setup (the UI-configured one) is
+# hardcoded to only scan the default branch — on this repo that's
+# `staging`, so PRs promoting staging→main would otherwise never be
+# scanned. This workflow fills that gap by explicitly scanning both
+# branches on push and PR.
+#
+# Runs on the self-hosted mac mini (matches the org-wide Code Quality
+# runner-label config). GHAS is NOT enabled on this repo, so results
+# are not uploaded to the Security tab — the scan fails the PR check
+# on findings, and the SARIF is kept as a workflow artifact for
+# triage.
+
+on:
+  push:
+    branches: [main, staging]
+  pull_request:
+    branches: [main, staging]
+  schedule:
+    # Weekly run picks up findings in code that hasn't been touched.
+    - cron: '30 1 * * 0'
+
+permissions:
+  actions: read
+  contents: read
+  # No security-events: write — we don't call the upload API.
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: [self-hosted, macos, arm64]
+    timeout-minutes: 45
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, javascript-typescript, python]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Checkout sibling plugin repo
+        # Same reasoning as publish-workspace-server-image.yml — the Go
+        # module's replace directive needs the plugin source so
+        # CodeQL's "go build" phase can resolve.
+        if: matrix.language == 'go'
+        uses: actions/checkout@v4
+        with:
+          repository: Molecule-AI/molecule-ai-plugin-github-app-auth
+          path: molecule-ai-plugin-github-app-auth
+          token: ${{ secrets.PLUGIN_REPO_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Ensure jq installed
+        # Follows the crane-install pattern in promote-latest.yml.
+        # HOMEBREW_NO_* flags skip the cleanup that fails on the shared
+        # runner's /opt/homebrew symlinks.
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_ENV_HINTS: "1"
+        run: command -v jq >/dev/null || brew install jq
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # security-extended widens past the default to include the
+          # full security-query set for a public SaaS surface.
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        id: analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"
+          # upload: never — GHAS isn't enabled on this repo, so the
+          # upload API 403s. Write SARIF locally instead.
+          upload: never
+          output: sarif-results/${{ matrix.language }}
+
+      - name: Parse SARIF + fail on findings
+        # The analyze step writes <database>.sarif into the output
+        # directory — database name is the short CodeQL lang id, not
+        # the matrix value (e.g. "javascript-typescript" →
+        # javascript.sarif), so glob rather than hardcode.
+        # Filter to error/warning severity: security-extended emits
+        # "note" rows for informational findings we don't want to fail
+        # the build over.
+        shell: bash
+        run: |
+          set -euo pipefail
+          dir="sarif-results/${{ matrix.language }}"
+          sarif=$(ls "$dir"/*.sarif 2>/dev/null | head -1 || true)
+          if [ -z "$sarif" ] || [ ! -f "$sarif" ]; then
+            echo "::error::No SARIF file found under $dir"
+            ls -la "$dir" 2>/dev/null || true
+            exit 1
+          fi
+          echo "Parsing $sarif"
+          count=$(jq '[.runs[].results[] | select(.level == "error" or .level == "warning")] | length' "$sarif")
+          echo "CodeQL findings (error+warning) for ${{ matrix.language }}: $count"
+          if [ "$count" -gt 0 ]; then
+            echo "::error::CodeQL found $count issues. Details below; full SARIF in the artifact."
+            jq -r '.runs[].results[] | select(.level == "error" or .level == "warning") | "  - [\(.level)] \(.ruleId // "?"): \(.message.text // "(no message)") @ \(.locations[0].physicalLocation.artifactLocation.uri // "?"):\(.locations[0].physicalLocation.region.startLine // "?")"' "$sarif"
+            exit 1
+          fi
+
+      - name: Upload SARIF artifact
+        # Keep SARIF around on success + failure so triagers can diff.
+        # 14-day retention — longer than default 3, short enough not
+        # to bloat quota.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ matrix.language }}
+          path: sarif-results/${{ matrix.language }}/
+          retention-days: 14

--- a/canvas/src/app/orgs/page.tsx
+++ b/canvas/src/app/orgs/page.tsx
@@ -20,6 +20,7 @@
 import { useEffect, useState } from "react";
 import { fetchSession, redirectToLogin, type Session } from "@/lib/auth";
 import { PLATFORM_URL } from "@/lib/api";
+import { formatCredits, pillTone, bannerKind } from "@/lib/credits";
 
 type OrgStatus = "awaiting_payment" | "provisioning" | "running" | "failed" | string;
 
@@ -31,6 +32,13 @@ interface Org {
   status: OrgStatus;
   created_at: string;
   updated_at: string;
+  // Credit system fields. Present whenever the control plane's models
+  // serializer runs — tests + older snapshot JSONs may not have them,
+  // so treat as optional in TS and fall back to 0 at render time.
+  credits_balance?: number;
+  plan_monthly_credits?: number;
+  overage_used_credits?: number;
+  overage_cap_credits?: number;
 }
 
 export default function OrgsPage() {
@@ -174,10 +182,56 @@ function OrgRow({ org }: { org: Org }) {
           <div className="text-sm text-zinc-400">
             {org.slug} · <StatusLabel status={org.status} /> · {org.plan || "free"}
           </div>
+          <div className="mt-2 flex items-center gap-2">
+            <CreditsPill org={org} />
+            <LowCreditsBanner org={org} />
+          </div>
         </div>
         <OrgCTA org={org} />
       </div>
     </li>
+  );
+}
+
+// CreditsPill renders the balance with a tone that matches the banner
+// severity. Format + color logic lives in @/lib/credits so it can be
+// tested without mounting React.
+function CreditsPill({ org }: { org: Org }) {
+  const balance = org.credits_balance ?? 0;
+  return (
+    <span className={`rounded border px-2 py-0.5 text-xs ${pillTone(org)}`} title="Credit balance">
+      {formatCredits(balance)} credits
+    </span>
+  );
+}
+
+// LowCreditsBanner is a one-liner that only renders when the balance
+// is low AND the org is running. bannerKind() picks which message to
+// show; render just dispatches on it.
+function LowCreditsBanner({ org }: { org: Org }) {
+  if (org.status !== "running") return null;
+  const kind = bannerKind(org);
+  if (kind === "none") return null;
+  if (kind === "overage") {
+    const used = (org.overage_used_credits ?? 0).toLocaleString();
+    return (
+      <span className="text-xs text-amber-300">
+        overage active · {used} used
+      </span>
+    );
+  }
+  if (kind === "out-of-credits") {
+    return (
+      <a href={`/pricing?org=${encodeURIComponent(org.slug)}`} className="text-xs text-red-300 underline">
+        out of credits — upgrade to keep running
+      </a>
+    );
+  }
+  // trial-tail
+  return (
+    <a href={`/pricing?org=${encodeURIComponent(org.slug)}`} className="text-xs text-amber-300 underline">
+      trial almost out
+    </a>
   );
 }
 

--- a/canvas/src/app/orgs/page.tsx
+++ b/canvas/src/app/orgs/page.tsx
@@ -21,6 +21,7 @@ import { useEffect, useState } from "react";
 import { fetchSession, redirectToLogin, type Session } from "@/lib/auth";
 import { PLATFORM_URL } from "@/lib/api";
 import { formatCredits, pillTone, bannerKind } from "@/lib/credits";
+import { TermsGate } from "@/components/TermsGate";
 
 type OrgStatus = "awaiting_payment" | "provisioning" | "running" | "failed" | string;
 
@@ -162,14 +163,35 @@ function CheckoutBanner() {
 function Shell({ children }: { children: React.ReactNode }) {
   return (
     <main className="min-h-screen bg-zinc-950 text-zinc-100">
-      <div className="mx-auto max-w-2xl px-6 pt-20 pb-12">
-        <h1 className="text-3xl font-bold text-white">Your organizations</h1>
-        <p className="mt-2 text-zinc-400">
-          Each org is an isolated Molecule workspace.
-        </p>
-        <div className="mt-8">{children}</div>
-      </div>
+      <TermsGate>
+        <div className="mx-auto max-w-2xl px-6 pt-20 pb-12">
+          <h1 className="text-3xl font-bold text-white">Your organizations</h1>
+          <p className="mt-2 text-zinc-400">
+            Each org is an isolated Molecule workspace.
+          </p>
+          <DataResidencyNotice />
+          <div className="mt-8">{children}</div>
+        </div>
+      </TermsGate>
     </main>
+  );
+}
+
+// DataResidencyNotice surfaces where workspace data lives so EU-based
+// signups can make an informed choice (GDPR Art. 13 disclosure
+// requirement). Plain text, no icon — the goal is clarity, not
+// decoration. A future EU region selector can replace this with a
+// region dropdown.
+function DataResidencyNotice() {
+  return (
+    <p className="mt-3 rounded border border-zinc-800 bg-zinc-900/60 px-3 py-2 text-xs text-zinc-400">
+      Workspaces run in AWS us-east-2 (Ohio, United States). EU region support is on the roadmap — reach out to
+      {" "}
+      <a href="mailto:support@moleculesai.app" className="underline">
+        support@moleculesai.app
+      </a>
+      {" "}if you need data residency in another region today.
+    </p>
   );
 }
 

--- a/canvas/src/components/TermsGate.tsx
+++ b/canvas/src/components/TermsGate.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PLATFORM_URL } from "@/lib/api";
+
+// TermsGate blocks the page it wraps until the user has accepted the
+// current terms version. Fetches /cp/auth/terms-status on mount; if
+// the server says accepted=false it renders a modal over the children
+// instead of hiding them entirely — that way the /orgs list is still
+// visible behind the gate so the user understands what they're
+// agreeing to touch.
+//
+// The server is the source of truth; this component is a UX
+// convenience. Org-mutating endpoints should (and do) also enforce
+// ToS via their own DB check so a power-user calling curl can't
+// bypass the gate.
+export function TermsGate({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = useState<"loading" | "accepted" | "pending" | "error">("loading");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${PLATFORM_URL}/cp/auth/terms-status`, {
+          credentials: "include",
+          signal: AbortSignal.timeout(10_000),
+        });
+        if (cancelled) return;
+        if (res.status === 401) {
+          // Not signed in — the page this wraps handles redirect to login.
+          // Fall through to "accepted" so we don't double-gate anonymous.
+          setStatus("accepted");
+          return;
+        }
+        if (!res.ok) {
+          setStatus("error");
+          setError(`terms-status: ${res.status}`);
+          return;
+        }
+        const body = (await res.json()) as { accepted?: boolean };
+        setStatus(body.accepted ? "accepted" : "pending");
+      } catch (err) {
+        if (!cancelled) {
+          setStatus("error");
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const accept = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`${PLATFORM_URL}/cp/auth/accept-terms`, {
+        method: "POST",
+        credentials: "include",
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`${res.status}: ${text}`);
+      }
+      setStatus("accepted");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {children}
+      {status === "pending" && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/80 backdrop-blur-sm">
+          <div className="mx-4 max-w-lg rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl">
+            <h2 className="text-lg font-semibold text-white">Terms &amp; conditions</h2>
+            <p className="mt-3 text-sm text-zinc-300">
+              Before you create an organization, please review our{" "}
+              <a href="/legal/terms" className="text-sky-400 underline" target="_blank" rel="noreferrer">
+                Terms of Service
+              </a>{" "}
+              and{" "}
+              <a href="/legal/privacy" className="text-sky-400 underline" target="_blank" rel="noreferrer">
+                Privacy Policy
+              </a>
+              . Click agree to continue.
+            </p>
+            <p className="mt-3 text-xs text-zinc-500">
+              By agreeing you acknowledge that workspace data is stored in AWS us-east-2 (Ohio, United States).
+            </p>
+            {error && <p className="mt-3 text-sm text-red-400">{error}</p>}
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                onClick={accept}
+                disabled={submitting}
+                className="rounded bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:opacity-50"
+              >
+                {submitting ? "Saving…" : "I agree"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {status === "error" && (
+        <div className="fixed bottom-4 left-4 right-4 mx-auto max-w-md rounded border border-red-800 bg-red-950 p-3 text-sm text-red-200">
+          Couldn&apos;t check terms status: {error ?? "unknown error"}
+        </div>
+      )}
+    </>
+  );
+}

--- a/canvas/src/lib/__tests__/credits.test.ts
+++ b/canvas/src/lib/__tests__/credits.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { formatCredits, pillTone, bannerKind } from "@/lib/credits";
+
+describe("formatCredits", () => {
+  it("renders raw numbers under 10k", () => {
+    expect(formatCredits(0)).toBe("0");
+    expect(formatCredits(42)).toBe("42");
+    expect(formatCredits(9999)).toBe("9999");
+  });
+  it("compacts 10k+ with one decimal", () => {
+    expect(formatCredits(12345)).toBe("12.3k");
+    expect(formatCredits(30000)).toBe("30.0k");
+  });
+});
+
+describe("pillTone", () => {
+  it("zinc for healthy balance", () => {
+    expect(pillTone({ credits_balance: 5000, plan_monthly_credits: 9000 })).toContain("zinc");
+  });
+  it("amber when under 10% of monthly", () => {
+    expect(pillTone({ credits_balance: 500, plan_monthly_credits: 9000 })).toContain("amber");
+  });
+  it("red at zero or negative", () => {
+    expect(pillTone({ credits_balance: 0, plan_monthly_credits: 9000 })).toContain("red");
+    expect(pillTone({ credits_balance: -1, plan_monthly_credits: 9000 })).toContain("red");
+  });
+  it("trial (monthly=0) is healthy until balance hits zero", () => {
+    // No paid plan → no ratio reference; only "0" means empty.
+    expect(pillTone({ credits_balance: 50, plan_monthly_credits: 0 })).toContain("zinc");
+    expect(pillTone({ credits_balance: 0, plan_monthly_credits: 0 })).toContain("red");
+  });
+});
+
+describe("bannerKind", () => {
+  it("overage wins when overage_used > 0", () => {
+    // Even a healthy balance gets "overage" so the banner reminds the
+    // paying customer that extra charges are accruing.
+    expect(bannerKind({ credits_balance: 3000, plan_monthly_credits: 9000, overage_used_credits: 500 }))
+      .toBe("overage");
+  });
+  it("out-of-credits when balance <= 0 and no overage", () => {
+    expect(bannerKind({ credits_balance: 0, plan_monthly_credits: 9000 })).toBe("out-of-credits");
+  });
+  it("trial-tail when plan is free and balance is low", () => {
+    expect(bannerKind({ credits_balance: 50, plan_monthly_credits: 0 })).toBe("trial-tail");
+  });
+  it("none for healthy paid balance", () => {
+    expect(bannerKind({ credits_balance: 8000, plan_monthly_credits: 9000 })).toBe("none");
+  });
+  it("none for a trial that still has plenty of credits", () => {
+    expect(bannerKind({ credits_balance: 400, plan_monthly_credits: 0 })).toBe("none");
+  });
+});

--- a/canvas/src/lib/credits.ts
+++ b/canvas/src/lib/credits.ts
@@ -1,0 +1,53 @@
+// credits.ts — small pure helpers for rendering credit state on /orgs.
+// Kept out of page.tsx so unit tests can exercise the formatting +
+// banner-kind logic in node (no jsdom) without needing to mount React.
+
+export type CreditsBannerKind =
+  | "none"
+  | "overage"        // paid plan has started burning overage this period
+  | "out-of-credits" // balance 0, not on a paid plan (trial ran out)
+  | "trial-tail";    // balance low but not zero, no paid plan yet
+
+export interface CreditsFields {
+  credits_balance?: number;
+  plan_monthly_credits?: number;
+  overage_used_credits?: number;
+}
+
+// formatCredits renders an int as a compact string. 9999 → "9999",
+// 12345 → "12.3k". Keeps the balance pill narrow enough to fit on one
+// line next to the org slug even for the Scale plan's 30k grant.
+export function formatCredits(n: number): string {
+  if (n < 10_000) return String(n);
+  return `${(n / 1000).toFixed(1)}k`;
+}
+
+// pillTone returns the tailwind classnames that color the balance pill.
+// Empty / exhausted → red; within 10% of zero → amber; else zinc. The
+// 10% threshold matches the banner trigger — one consistent "low"
+// signal so the pill and banner agree.
+export function pillTone(fields: CreditsFields): string {
+  const balance = fields.credits_balance ?? 0;
+  const monthly = fields.plan_monthly_credits ?? 0;
+  if (balance <= 0) return "bg-red-950 text-red-200 border-red-800";
+  const ratio = monthly > 0 ? balance / monthly : 1;
+  if (ratio < 0.1) return "bg-amber-950 text-amber-200 border-amber-800";
+  return "bg-zinc-800 text-zinc-200 border-zinc-700";
+}
+
+// bannerKind picks which (if any) banner to show under the balance
+// pill. Precedence:
+//   1. overage_used > 0 → "overage" (even if balance is refreshed)
+//   2. balance <= 0      → "out-of-credits"
+//   3. trial + low tail → "trial-tail"
+//   4. otherwise         → "none"
+export function bannerKind(fields: CreditsFields): CreditsBannerKind {
+  const balance = fields.credits_balance ?? 0;
+  const monthly = fields.plan_monthly_credits ?? 0;
+  const overageUsed = fields.overage_used_credits ?? 0;
+
+  if (overageUsed > 0) return "overage";
+  if (balance <= 0) return "out-of-credits";
+  if (monthly === 0 && balance < 100) return "trial-tail";
+  return "none";
+}


### PR DESCRIPTION
## Summary
- Adds CodeQL analysis workflow covering Go and JavaScript/TypeScript
- Scans on push to main + staging and on PRs

## Note
- Branch has stale-base files (canary-verify, canvas changes) mixed in — may need cherry-pick to clean branch

## Test plan
- [ ] Verify CodeQL workflow triggers correctly
- [ ] Check Go and JS analysis completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Molecule-Platform-Evolvement-Manager] PR opened on behalf of Security/DevOps agent.