### PR TITLE
fix(mcp): type assertion safety + ws-url redaction

### DIFF
--- a/workspace-server/internal/handlers/mcp.go
+++ b/workspace-server/internal/handlers/mcp.go
@@ -735,16 +735,10 @@ func (h *MCPHandler) toolCommitMemory(ctx context.Context, workspaceID string, a
 	}
 
 	memoryID := uuid.New().String()
-	// SAFE-T1201 (#838): scrub known credential patterns before persistence so
-	// plain-text API keys pulled in via tool responses can't land in the
-	// memories table (and leak into shared TEAM scope). Reuses redactSecrets
-	// already shipped for the HTTP path in PR #881 — this was the MCP-bridge
-	// sibling the original fix missed. Runs on every write regardless of scope.
-	content, _ = redactSecrets(workspaceID, content)
 	_, err := h.database.ExecContext(ctx, `
 		INSERT INTO agent_memories (id, workspace_id, content, scope, namespace)
 		VALUES ($1, $2, $3, $4, $5)
-	`, memoryID, workspaceID, content, scope, workspaceID)
+	`, memoryID, workspaceID, redactSecrets(content), scope, workspaceID)
 	if err != nil {
 		log.Printf("MCPHandler.commit_memory workspace=%s: %v", workspaceID, err)
 		return "", fmt.Errorf("failed to save memory")


### PR DESCRIPTION
## PR #1036 Review — REQUEST CHANGES (Critical)

**Files:** mcp.go (+68/-13), secrets.go, terminal.go, webhooks.go, a2a_proxy.go, canvas/src/lib/ws-url.ts (+2/-2)

---

### CRITICAL: Duplicate-Line Go Syntax Error (blocks compile)

ExecContext line has two statements on one line separated by tab:

ExecContext call line is duplicated — tab-separated. This is a hard Go compile error. PR cannot be merged.

### CRITICAL: redactSecrets Signature Conflict

PR #1036 defines redactSecrets(content string) string (1-arg). PR #1017 uses redactSecrets(workspaceID, content) (2-arg). Incompatible signatures — neither can merge independently.

**Recommended merge order:** Merge #1017 first (2-arg is correct — workspaceID needed for audit logging). Then rebase #1036 to: (1) remove duplicate function definition, (2) change call to 2-arg form, (3) fix duplicate-line error.

### Positive Changes

- Type assertion safety: targetID, ok := args workspace_id .(string) with ok-check — no silent nil coercion
- ws-url.ts null coalescing: NEXT_PUBLIC_WS_URL ??
- secrets.go RowsAffected error handling with log

---

### Verdict

REQUEST CHANGES: Fix duplicate-line syntax, rebase after #1017 merges, use canonical 2-arg redactSecrets signature.

| Check | Result |
|-------|--------|
| Duplicate-line syntax | FAILS — blocks compile |
| Signature conflict | FAILS — blocks merge |
| Type assertion safety | PASS |
| RowsAffected error | PASS |
| ws-url null coalescing | PASS |
| Mergeable | NO |