### PR TITLE
chore: code-review cleanup on today's shipped PRs (dead code + better errors)

### DIFF
--- a/canvas/src/components/ContextMenu.tsx
+++ b/canvas/src/components/ContextMenu.tsx
@@ -18,7 +18,6 @@ interface MenuItem {
 export function ContextMenu() {
   const contextMenu = useCanvasStore((s) => s.contextMenu);
   const closeContextMenu = useCanvasStore((s) => s.closeContextMenu);
-  const removeNode = useCanvasStore((s) => s.removeNode);
   const updateNodeData = useCanvasStore((s) => s.updateNodeData);
   const selectNode = useCanvasStore((s) => s.selectNode);
   const setPanelTab = useCanvasStore((s) => s.setPanelTab);

--- a/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
+++ b/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
@@ -40,7 +40,6 @@ const mockStore = {
     nodeData: Record<string, unknown>;
   } | null,
   closeContextMenu,
-  removeNode: vi.fn(),
   updateNodeData: vi.fn(),
   selectNode: vi.fn(),
   setPanelTab: vi.fn(),

--- a/workspace-server/internal/handlers/workspace_preflight.go
+++ b/workspace-server/internal/handlers/workspace_preflight.go
@@ -2,6 +2,8 @@ package handlers
 
 import (
 	"fmt"
+	"log"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -39,6 +41,11 @@ func missingRequiredEnv(configFiles map[string][]byte, envVars map[string]string
 	}
 	var schema requiredEnvSchema
 	if err := yaml.Unmarshal(raw, &schema); err != nil {
+		// Safe default: the in-container preflight is the source of truth
+		// for config.yaml shape, so we don't block the provision here. But
+		// log at WARN so operators can notice a template with malformed
+		// YAML — otherwise a silently-skipped preflight is invisible.
+		log.Printf("Preflight: WARN — config.yaml unparseable, skipping required_env check: %v", err)
 		return nil
 	}
 	if len(schema.RuntimeConfig.RequiredEnv) == 0 {
@@ -64,7 +71,7 @@ func formatMissingEnvError(missing []string) string {
 		)
 	}
 	return fmt.Sprintf(
-		"missing required env vars %q — add them under Config → Env Vars (or as Global secrets) and retry",
-		missing,
+		"missing required env vars %s — add them under Config → Env Vars (or as Global secrets) and retry",
+		strings.Join(missing, ", "),
 	)
 }

--- a/workspace-server/internal/handlers/workspace_preflight_test.go
+++ b/workspace-server/internal/handlers/workspace_preflight_test.go
@@ -117,8 +117,8 @@ func TestFormatMissingEnvError_Single(t *testing.T) {
 }
 
 func TestFormatMissingEnvError_Multiple(t *testing.T) {
-	msg := formatMissingEnvError([]string{"A", "B"})
-	if !strings.Contains(msg, "A") || !strings.Contains(msg, "B") {
-		t.Errorf("message should name both vars: %q", msg)
+	msg := formatMissingEnvError([]string{"FOO", "BAR"})
+	if !strings.Contains(msg, "FOO, BAR") {
+		t.Errorf("multi-var message should join with ', ' — got %q", msg)
 	}
 }


### PR DESCRIPTION
## What

Three nits from post-merge review of #1119 / #1133:

1. **Dead code** — \`ContextMenu.tsx\` still imported \`removeNode\` from the store after #1133 moved the delete confirm to Canvas. Removed. Same for the unused \`removeNode\` mock entry in \`ContextMenu.keyboard.test.tsx\`.

2. **Silent preflight YAML parse failure** — \`missingRequiredEnv\` returned \`nil\` on parse error (safe default, the in-container preflight owns schema), but left no trace for ops. Added a WARN log so malformed templates are visible.

3. **User-facing error formatting** — \`formatMissingEnvError\` used \`%q\` on a slice → \`[\"A\" \"B\"]\`. Ugly and looks like a Go literal. Switched to \`strings.Join(missing, \", \")\`. Test updated.

## Why direct-merge to main

User authorised direct-merge on review cleanup; zero behavioural impact beyond one log line.

## Test plan

- [x] \`go build ./...\` clean
- [x] Preflight tests: \`go test ./internal/handlers/... -run TestMissingRequiredEnv|TestFormatMissingEnvError\` pass
- [x] Canvas tests: \`npx vitest run src/components/__tests__/ContextMenu.keyboard.test.tsx\` — 15/15 pass