### PR TITLE
fix(canvas): skip /registry/:id/peers 401 noise on non-online workspaces

### DIFF
--- a/canvas/src/components/tabs/DetailsTab.tsx
+++ b/canvas/src/components/tabs/DetailsTab.tsx
@@ -58,8 +58,19 @@ export function DetailsTab({ workspaceId, data }: Props) {
   }, [workspaceId]);
 
   useEffect(() => {
+    // The /registry/:id/peers endpoint requires a workspace-scoped
+    // bearer token (validateDiscoveryCaller) which the canvas session
+    // doesn't hold. For a still-provisioning or failed workspace there
+    // are no peers to show anyway — skip the fetch so the Details tab
+    // doesn't flood devtools with 401 noise and so the empty Peers
+    // section renders cleanly.
+    if (data.status !== "online" && data.status !== "degraded") {
+      setPeers([]);
+      setPeersError(null);
+      return;
+    }
     loadPeers();
-  }, [loadPeers]);
+  }, [loadPeers, data.status]);
 
   const handleSave = async () => {
     setSaving(true);


### PR DESCRIPTION
Minor: DetailsTab fired a 401 fetch to `/registry/:id/peers` for every provisioning/failed workspace because that endpoint requires a workspace-scoped bearer the canvas session doesn't hold. Skip the fetch when status ∉ {online, degraded}. Peers section renders empty instead of showing an error banner.