### PR TITLE
chore(canvas): review nits on ConsoleModal + Peers empty state

### DIFF
--- a/canvas/src/components/ConsoleModal.tsx
+++ b/canvas/src/components/ConsoleModal.tsx
@@ -45,12 +45,14 @@ export function ConsoleModal({ workspaceId, workspaceName, open, onClose }: Prop
       })
       .catch((e) => {
         if (ignore) return;
-        // 501 = deployment without a control plane (local docker-compose);
-        // we render a friendlier message than "501 Not Implemented".
+        // 501 = deployment without a control plane (local docker-compose).
+        // 404 = EC2 instance has been terminated. Match with word-boundary
+        // regex so a status code appearing inside an unrelated number
+        // ("15012") doesn't false-match.
         const msg = e instanceof Error ? e.message : "Failed to load console output";
-        if (/501/.test(msg)) {
+        if (/\b501\b/.test(msg)) {
           setError("Console output is only available on cloud (SaaS) deployments.");
-        } else if (/404/.test(msg)) {
+        } else if (/\b404\b/.test(msg)) {
           setError("No EC2 instance found for this workspace — it may have been terminated.");
         } else {
           setError(msg);

--- a/canvas/src/components/tabs/DetailsTab.tsx
+++ b/canvas/src/components/tabs/DetailsTab.tsx
@@ -268,6 +268,10 @@ export function DetailsTab({ workspaceId, data }: Props) {
       <Section title={`Peers (${peers.length})`}>
         {peersError ? (
           <p className="text-xs text-red-400">{peersError}</p>
+        ) : peers.length === 0 && data.status !== "online" && data.status !== "degraded" ? (
+          <p className="text-xs text-zinc-500">
+            Peers are only discoverable while the workspace is online.
+          </p>
         ) : peers.length === 0 ? (
           <p className="text-xs text-zinc-500">No reachable peers</p>
         ) : (


### PR DESCRIPTION
Post-review cleanup for #1178/#1189:

- ConsoleModal 501/404 detection uses `\b` anchors so "15012" doesn't false-match as "501"
- Peers section explains WHY the list is empty on provisioning/offline workspaces rather than showing the same "No reachable peers" text used for healthy workspaces with zero siblings