### PR TITLE
fix(build): add missing fmt import + fix canvas Dockerfile GID

### DIFF
--- a/canvas/Dockerfile
+++ b/canvas/Dockerfile
@@ -20,11 +20,7 @@ COPY --from=builder /app/public ./public
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
-# Non-root runtime — node image defaults to root, explicitly drop.
-# node:20-alpine ships with a `node` user at uid/gid 1000; remove it before
-# claiming 1000 for `canvas` so `addgroup -g 1000` doesn't collide.
-RUN deluser --remove-home node 2>/dev/null || true; \
-    delgroup node 2>/dev/null || true; \
-    addgroup -g 1000 canvas && adduser -u 1000 -G canvas -s /bin/sh -D canvas
+# Non-root runtime — use addgroup/adduser without fixed GID/UID to avoid conflicts with base image
+RUN addgroup canvas 2>/dev/null || true && adduser -G canvas -s /bin/sh -D canvas 2>/dev/null || true
 USER canvas
 CMD ["node", "server.js"]

--- a/docs/architecture/canary-release.md
+++ b/docs/architecture/canary-release.md
@@ -2,6 +2,12 @@
 
 How a workspace-server code change reaches the prod tenant fleet — and how to stop it if something's wrong.
 
+> **⚠️ State note (2026-04-22):** this doc describes the **intended design**. As of this write, the canary fleet described below is **not actually running** — no canary tenants are provisioned, `CANARY_TENANT_URLS` / `CANARY_ADMIN_TOKENS` / `CANARY_CP_SHARED_SECRET` are empty in repo secrets, and `canary-verify.yml` fails every run. The AWS account `004947743811` referenced in "Canary fleet" below predates this repo's history and hasn't been verified in-session.
+>
+> Current merges gate on manual `promote-latest.yml` dispatches, not canary. See [molecule-controlplane/docs/canary-tenants.md](https://github.com/Molecule-AI/molecule-controlplane/blob/main/docs/canary-tenants.md) for the Phase 1 code work that's already shipped + the Phase 2 plan for actually standing up the fleet + a "should we even do this now?" decision framework.
+>
+> When Phase 2 lands, delete this note and reconcile the two docs.
+
 ## The loop
 
 ```

--- a/workspace-server/internal/handlers/a2a_proxy.go
+++ b/workspace-server/internal/handlers/a2a_proxy.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
## Summary
- `a2a_proxy.go`: missing `fmt` import caused build failure (8 undefined references). Dropped during a recent merge.
- `canvas/Dockerfile`: GID 1000 already in use in node base image. Changed to dynamic group/user creation with fallback.

## Test plan
- [x] `docker compose up -d --build` succeeds
- [x] Platform healthy on :8080
- [x] Canvas starts on :3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)