### PR TITLE
fix(e2e): 9 follow-ups to make staging E2E actually green end-to-end

### DIFF
--- a/.github/workflows/e2e-staging-saas.yml
+++ b/.github/workflows/e2e-staging-saas.yml
@@ -78,6 +78,10 @@ jobs:
       # retrieval + teardown. Configure in
       # Settings → Secrets and variables → Actions → Repository secrets.
       MOLECULE_ADMIN_TOKEN: ${{ secrets.MOLECULE_STAGING_ADMIN_TOKEN }}
+      # OpenAI key for workspace LLM calls (section 8 A2A). Without it,
+      # Hermes runtime crashes at boot with "No provider API key found".
+      # Configure at Settings → Secrets → Actions → MOLECULE_STAGING_OPENAI_KEY.
+      E2E_OPENAI_API_KEY: ${{ secrets.MOLECULE_STAGING_OPENAI_KEY }}
       E2E_RUNTIME: ${{ github.event.inputs.runtime || 'hermes' }}
       E2E_RUN_ID: "${{ github.run_id }}-${{ github.run_attempt }}"
       E2E_KEEP_ORG: ${{ github.event.inputs.keep_org && '1' || '0' }}
@@ -92,6 +96,14 @@ jobs:
             exit 2
           fi
           echo "Admin token present ✓"
+
+      - name: Verify OpenAI key present
+        run: |
+          if [ -z "$E2E_OPENAI_API_KEY" ]; then
+            echo "::error::MOLECULE_STAGING_OPENAI_KEY secret not set — workspaces will fail at boot with 'No provider API key found'"
+            exit 2
+          fi
+          echo "OpenAI key present ✓ (len=${#E2E_OPENAI_API_KEY})"
 
       - name: CP staging health preflight
         run: |

--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -376,8 +376,13 @@ print(json.dumps({
 }))
 ")
   set +e
+  # Raw curl (not tenant_call) because this call carries an extra
+  # X-Source-Workspace-Id header. Must still send X-Molecule-Org-Id
+  # or TenantGuard 404s — previously missing, caused section 10 to
+  # fail rc=22 despite everything upstream being correct (2026-04-21).
   DELEG_RESP=$(curl "${CURL_COMMON[@]}" -X POST "$TENANT_URL/workspaces/$CHILD_ID/a2a" \
     -H "Authorization: Bearer $EFFECTIVE_TENANT_TOKEN" \
+    -H "X-Molecule-Org-Id: $ORG_ID" \
     -H "X-Source-Workspace-Id: $PARENT_ID" \
     -H "Content-Type: application/json" \
     -d "$DELEG_PAYLOAD")

--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -229,10 +229,22 @@ tenant_call() {
 }
 
 # ─── 5. Provision parent workspace ─────────────────────────────────────
+# Runtimes like hermes crash at boot with "No provider API key found"
+# if nothing in the standard env-var list is set. Inject the API key
+# from E2E_OPENAI_API_KEY so the runtime can actually start — it's
+# per-workspace secret, so it's persisted as a workspace_secret and
+# materialized into the container env. Missing key falls through to
+# an empty secrets map; workspace will still fail but the error is
+# expected and actionable.
+SECRETS_JSON='{}'
+if [ -n "${E2E_OPENAI_API_KEY:-}" ]; then
+  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\"}"
+fi
+
 log "5/11 Provisioning parent workspace (runtime=$RUNTIME)..."
 PARENT_RESP=$(tenant_call POST /workspaces \
   -H "Content-Type: application/json" \
-  -d "{\"name\":\"E2E Parent\",\"runtime\":\"$RUNTIME\",\"tier\":2,\"model\":\"gpt-4o\"}")
+  -d "{\"name\":\"E2E Parent\",\"runtime\":\"$RUNTIME\",\"tier\":2,\"model\":\"gpt-4o\",\"secrets\":$SECRETS_JSON}")
 PARENT_ID=$(echo "$PARENT_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
 log "    PARENT_ID=$PARENT_ID"
 
@@ -242,7 +254,7 @@ if [ "$MODE" = "full" ]; then
   log "6/11 Provisioning child workspace..."
   CHILD_RESP=$(tenant_call POST /workspaces \
     -H "Content-Type: application/json" \
-    -d "{\"name\":\"E2E Child\",\"runtime\":\"$RUNTIME\",\"tier\":2,\"model\":\"gpt-4o\",\"parent_id\":\"$PARENT_ID\"}")
+    -d "{\"name\":\"E2E Child\",\"runtime\":\"$RUNTIME\",\"tier\":2,\"model\":\"gpt-4o\",\"parent_id\":\"$PARENT_ID\",\"secrets\":$SECRETS_JSON}")
   CHILD_ID=$(echo "$CHILD_RESP" | python3 -c "import json,sys; print(json.load(sys.stdin)['id'])")
   log "    CHILD_ID=$CHILD_ID"
 else

--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -238,11 +238,12 @@ tenant_call() {
 # expected and actionable.
 SECRETS_JSON='{}'
 if [ -n "${E2E_OPENAI_API_KEY:-}" ]; then
-  # MODEL_PROVIDER=openai forces Hermes's resolver to pick the OpenAI
-  # path. Without it Hermes defaults to Claude (resolution order puts
-  # anthropic before openai) and you get 404 model_not_found because
-  # the OpenAI endpoint doesn't serve claude-sonnet-* models.
-  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\",\"MODEL_PROVIDER\":\"openai\"}"
+  # MODEL_PROVIDER is a full model slug in 'provider:model' format per
+  # workspace/config.py:258. Using just "openai" gets parsed as the
+  # model name → 404 model_not_found. Also set OPENAI_BASE_URL to
+  # OpenAI's own endpoint — default is openrouter.ai which would need
+  # a different key format.
+  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\",\"OPENAI_BASE_URL\":\"https://api.openai.com/v1\",\"MODEL_PROVIDER\":\"openai:gpt-4o\"}"
 fi
 
 log "5/11 Provisioning parent workspace (runtime=$RUNTIME)..."

--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -238,7 +238,11 @@ tenant_call() {
 # expected and actionable.
 SECRETS_JSON='{}'
 if [ -n "${E2E_OPENAI_API_KEY:-}" ]; then
-  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\"}"
+  # MODEL_PROVIDER=openai forces Hermes's resolver to pick the OpenAI
+  # path. Without it Hermes defaults to Claude (resolution order puts
+  # anthropic before openai) and you get 404 model_not_found because
+  # the OpenAI endpoint doesn't serve claude-sonnet-* models.
+  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\",\"MODEL_PROVIDER\":\"openai\"}"
 fi
 
 log "5/11 Provisioning parent workspace (runtime=$RUNTIME)..."


### PR DESCRIPTION
PR #1395 was merged with the scaffolding but the harness still had several gaps that only surfaced when exercised against real staging. This PR bundles the 9 fix commits pushed after #1395 merged — all validated by manual run 18 (2026-04-21T17:47Z) which hit **all 11/11 sections green** (tenant provision → workspace online → A2A PONG → HMA memory → peer discovery → delegation CHILD_PONG → clean teardown).

## Fixes

1. `a510573` — poll `instance_status` (the actual field name) not `status`
2. `37a02d6` — derive tenant domain from CP URL so staging (`staging-api.moleculesai.app` → `*.staging.moleculesai.app`) works without overriding env
3. `e9d111d` — send `X-Molecule-Org-Id` on all tenant calls (TenantGuard 404s without it — returns 404 by design, not 403)
4. `81c4c02` — scope safety-net teardown to `GITHUB_RUN_ID`, not all today's `e2e-*` orgs (incident: this workflow deleted an unrelated manual run's tenant 1s after it hit running)
5. `5be20ac` — inject `OPENAI_API_KEY` via workspace `secrets` field so runtime can actually boot
6. `392282c` — set `MODEL_PROVIDER=openai` (later superseded)
7. `b8b3d5c` — `MODEL_PROVIDER` is `provider:model` slug, not just provider; use `openai:gpt-4o` + `OPENAI_BASE_URL=api.openai.com`
8. `5e130b7` — delegation raw-curl was missing `X-Molecule-Org-Id` header (caught because section 10 was the only raw curl; everything using `tenant_call` helper already got the fix from commit 3)
9. `bd020d8` — wire `MOLECULE_STAGING_OPENAI_KEY` repo secret into workflow env + preflight verify

## Manual verification
Run 18 (2026-04-21T17:41Z → 17:47Z, 5:52 total):
- 2/11 Tenant provisioning (2:20)
- 5-7/11 Workspace provision + online (3:25)
- 8/11 A2A PONG
- 9/11 HMA memory write/read
- 9b Peer discovery
- 10/11 Delegation CHILD_PONG
- 11/11 Clean teardown, zero leaks

## Required repo secrets
- `MOLECULE_STAGING_ADMIN_TOKEN` (already set) — CP admin bearer
- `MOLECULE_STAGING_OPENAI_KEY` (already set as of this PR) — OpenAI key for workspace runtimes