### PR TITLE
fix(lint): unblock Platform Go CI — suppress 8 pre-existing errcheck warnings

### DIFF
--- a/workspace-server/internal/artifacts/client_test.go
+++ b/workspace-server/internal/artifacts/client_test.go
@@ -192,7 +192,7 @@ func TestForkRepo_Success(t *testing.T) {
 			return
 		}
 		var req map[string]interface{}
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req["name"] != "forked-repo" {
 			http.Error(w, "unexpected fork name", http.StatusBadRequest)
 			return
@@ -234,7 +234,7 @@ func TestImportRepo_Success(t *testing.T) {
 			return
 		}
 		var req map[string]interface{}
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req["url"] == "" {
 			http.Error(w, "url required", http.StatusBadRequest)
 			return
@@ -294,7 +294,7 @@ func TestCreateToken_Success(t *testing.T) {
 			return
 		}
 		var req map[string]interface{}
-		json.NewDecoder(r.Body).Decode(&req)
+		_ = json.NewDecoder(r.Body).Decode(&req)
 		if req["repo"] != "my-repo" {
 			http.Error(w, "unexpected repo", http.StatusBadRequest)
 			return

--- a/workspace-server/internal/channels/channels_test.go
+++ b/workspace-server/internal/channels/channels_test.go
@@ -617,7 +617,7 @@ func TestDisableChannelByChatID_WiredSetsEnabledFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sqlmock: %v", err)
 	}
-	t.Cleanup(func() { mockDB.Close() })
+	t.Cleanup(func() { _ = mockDB.Close() })
 	prevDB := db.DB
 	db.DB = mockDB
 	t.Cleanup(func() { db.DB = prevDB })
@@ -757,7 +757,7 @@ func TestDisableChannelByChatID_NoRowsAffectedSkipsReload(t *testing.T) {
 	// bot), the UPDATE returns RowsAffected=0 and we skip the reload. Verifies
 	// we don't emit a spurious log or SELECT storm on unrelated kicked events.
 	mockDB, mock, _ := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
-	t.Cleanup(func() { mockDB.Close() })
+	t.Cleanup(func() { _ = mockDB.Close() })
 	prevDB := db.DB
 	db.DB = mockDB
 	t.Cleanup(func() { db.DB = prevDB })

--- a/workspace-server/internal/channels/lark_test.go
+++ b/workspace-server/internal/channels/lark_test.go
@@ -94,7 +94,7 @@ func TestLarkAdapter_SendMessage_HappyPath(t *testing.T) {
 		gotBody = string(b)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`{"code":0,"msg":"ok"}`))
+		_, _ = w.Write([]byte(`{"code":0,"msg":"ok"}`))
 	}))
 	defer srv.Close()
 
@@ -115,7 +115,7 @@ func TestLarkAdapter_SendMessage_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if gotPath != "/open-apis/bot/v2/hook/test" {
 		t.Errorf("path: got %q", gotPath)

--- a/workspace-server/internal/channels/manager.go
+++ b/workspace-server/internal/channels/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) PausePollersForToken(workspaceID, botToken string) func() {
 	if err != nil {
 		return func() {}
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var pausedIDs []string
 	m.mu.Lock()
@@ -193,7 +193,7 @@ func (m *Manager) Reload(ctx context.Context) {
 		log.Printf("Channels: reload query error: %v", err)
 		return
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	desired := make(map[string]ChannelRow)
 	for rows.Next() {
@@ -203,8 +203,8 @@ func (m *Manager) Reload(ctx context.Context) {
 			log.Printf("Channels: reload scan error: %v", err)
 			continue
 		}
-		json.Unmarshal(configJSON, &ch.Config)
-		json.Unmarshal(allowedJSON, &ch.AllowedUsers)
+		_ = json.Unmarshal(configJSON, &ch.Config)
+		_ = json.Unmarshal(allowedJSON, &ch.AllowedUsers)
 		// #319: decrypt at the boundary between DB (ciphertext) and the
 		// in-memory config adapters consume. A decrypt failure logs and
 		// skips the channel — downstream getUpdates would fail anyway


### PR DESCRIPTION
## Context
PR #1512 merged with Platform (Go) still red. golangci-lint errcheck has been flagging 8 pre-existing `_ =`-prefix-missing call sites that have nothing to do with the restart fix. This follow-up suppresses them so the Platform (Go) check can finally go green on main.

## Changes
- `channels/lark_test.go:97` `w.Write` → `_, _ = w.Write`
- `channels/lark_test.go:118` `resp.Body.Close()` → `_ = resp.Body.Close()`
- `channels/channels_test.go:620, 760` `mockDB.Close()` in `t.Cleanup` → `_ = mockDB.Close()`
- `channels/manager.go:131, 196` `defer rows.Close()` → `defer func() { _ = rows.Close() }()` (errcheck doesn't accept `_ =` directly on `defer`)
- `channels/manager.go:206–207` `json.Unmarshal` → `_ = json.Unmarshal`
- `artifacts/client_test.go:195, 237, 297` `json.Decoder.Decode` → `_ = json.Decoder.Decode`

All ignored returns were already being ignored in practice; this just makes it explicit for the linter. No behavior change.

## Verification
- `go vet ./...` clean
- `go build ./...` green
- `go test ./internal/channels/ ./internal/artifacts/ -count=1` all pass

## Why follow-up instead of part of #1512
#1512 merged before I could push this commit. Kept separate because the lint sweep is mechanical and should land on its own audit trail.