### PR TITLE
fix(canvas): unblock publish-canvas-image — drop default node user before uid 1000

### DIFF
--- a/canvas/Dockerfile
+++ b/canvas/Dockerfile
@@ -21,6 +21,10 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 # Non-root runtime — node image defaults to root, explicitly drop.
-RUN addgroup -g 1000 canvas && adduser -u 1000 -G canvas -s /bin/sh -D canvas
+# node:20-alpine ships with a `node` user at uid/gid 1000; remove it before
+# claiming 1000 for `canvas` so `addgroup -g 1000` doesn't collide.
+RUN deluser --remove-home node 2>/dev/null || true; \
+    delgroup node 2>/dev/null || true; \
+    addgroup -g 1000 canvas && adduser -u 1000 -G canvas -s /bin/sh -D canvas
 USER canvas
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary

- \`publish-canvas-image\` workflow has been red on every main push since 2026-04-21 — screenshot in chat shows it failing at \`addgroup -g 1000 canvas\` inside \`canvas/Dockerfile\` stage 2.
- Root cause: \`node:20-alpine\` ships with a \`node\` user/group at uid/gid 1000, so claiming 1000 for \`canvas\` collides. Same bug \`workspace-server/Dockerfile.tenant:61-63\` already fixes with \`deluser --remove-home node\` before \`addgroup\`.
- This PR copies that exact pattern into \`canvas/Dockerfile\` so the publish workflow goes green again and the standalone canvas image resumes flowing to ghcr.

## Why the minimal diff

No behaviour change: canvas still runs as non-root uid 1000. Only the pre-step (\`deluser\`/\`delgroup\` on the shipped \`node\` account) is added. Both \`|| true\` clauses tolerate the case where a future base image drops the \`node\` account entirely.

## Test plan

- [x] Confirmed collision by reading current Dockerfile + matching CI failure log (\`exit code: 1\` at the \`addgroup\` step)
- [x] Pattern already validated in tenant Dockerfile that builds + runs daily
- [ ] \`publish-canvas-image / Build & push canvas image (push)\` passes on this PR's push
- [ ] After merge, next main push shows the workflow green and a new \`latest\` tag published

## Not in scope

- \`E2E Staging Canvas (Playwright)\` is also red on main — separate root cause (missing \`MOLECULE_STAGING_ADMIN_TOKEN\` secret + tenant provision timeout). Will file a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)