### PR TITLE
fix(ci): unblock main CI on ubuntu-latest (2 latent bugs)

### DIFF
--- a/workspace-server/internal/handlers/terminal.go
+++ b/workspace-server/internal/handlers/terminal.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -439,7 +440,9 @@ func pickFreePort() (int, error) {
 // its local port before we dial ssh at it.
 func waitForPort(ctx context.Context, host string, port int, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
-	addr := fmt.Sprintf("%s:%d", host, port)
+	// JoinHostPort handles IPv6 bracketing; `%s:%d` does not. Caught by
+	// `go vet` on ubuntu-latest (newer Go toolchain than the Mac mini).
+	addr := net.JoinHostPort(host, strconv.Itoa(port))
 	for time.Now().Before(deadline) {
 		if ctx.Err() != nil {
 			return ctx.Err()

--- a/workspace/tests/test_a2a_executor.py
+++ b/workspace/tests/test_a2a_executor.py
@@ -408,7 +408,13 @@ def test_extract_history_non_list():
 @pytest.mark.asyncio
 async def test_set_current_task_updates_heartbeat():
     """set_current_task updates heartbeat fields."""
+    # Seed active_tasks as an int — without this, MagicMock auto-creates
+    # the attribute on first access, getattr() returns a MagicMock, and
+    # `MagicMock + 1` stays a MagicMock instead of becoming 1. The real
+    # HeartbeatLoop class initialises active_tasks=0 so this matches
+    # production behaviour.
     heartbeat = MagicMock()
+    heartbeat.active_tasks = 0
     await set_current_task(heartbeat, "Doing work")
     assert heartbeat.current_task == "Doing work"
     assert heartbeat.active_tasks == 1


### PR DESCRIPTION
## Why

PR #1626 moved CI to ubuntu-latest → newer Go/Python toolchains caught two latent bugs that the Mac mini had been hiding. Fix both together so main CI goes green.

## Fix 1 — \`go vet\` on \`workspace-server/internal/handlers/terminal.go:442\`

\`\`\`
internal/handlers/terminal.go:442:22: address format \"%s:%d\" does not work with IPv6 (passed to net.Dial at L447)
\`\`\`

- **Before:** \`addr := fmt.Sprintf(\"%s:%d\", host, port)\` — drops the \`[::]\` brackets IPv6 addresses need.
- **After:** \`addr := net.JoinHostPort(host, strconv.Itoa(port))\` — handles both families.
- **Runtime impact:** zero. The only caller passes \`\"127.0.0.1\"\`, so the bug never triggered. But vet is right to flag it as a latent correctness issue.

## Fix 2 — \`test_set_current_task_updates_heartbeat\` MagicMock seeding

\`\`\`
AssertionError: assert <MagicMock name='mock.active_tasks.__add__()' id='...'> == 1
\`\`\`

- **Cause:** \`MagicMock()\` auto-creates attributes on first access, so \`getattr(heartbeat, \"active_tasks\", 0)\` in \`shared_runtime.py:165\` returns a MagicMock rather than the default 0. Adding 1 to a MagicMock returns another MagicMock, so the assertion never held.
- **Fix:** Seed \`heartbeat.active_tasks = 0\` before the first call. Matches how the real \`HeartbeatLoop\` class initialises itself.
- **Verified locally:** \`pytest tests/test_a2a_executor.py::test_set_current_task_updates_heartbeat\` passes in a clean venv.

## Notes

Both bugs pre-existed on main. PR #1626 just exposed them by moving to a more strict toolchain — which is exactly the value that migration added.

## Test plan

- [x] \`go vet ./...\` clean on workspace-server locally
- [x] \`go build ./...\` clean on workspace-server locally
- [x] \`pytest test_set_current_task_updates_heartbeat\` passes in isolated venv
- [ ] CI on this PR goes green (self-validating on ubuntu-latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)