### PR TITLE
docs(canary-release): flag as aspirational; link to current state

### DIFF
--- a/docs/architecture/canary-release.md
+++ b/docs/architecture/canary-release.md
@@ -2,6 +2,12 @@
 
 How a workspace-server code change reaches the prod tenant fleet — and how to stop it if something's wrong.
 
+> **⚠️ State note (2026-04-22):** this doc describes the **intended design**. As of this write, the canary fleet described below is **not actually running** — no canary tenants are provisioned, `CANARY_TENANT_URLS` / `CANARY_ADMIN_TOKENS` / `CANARY_CP_SHARED_SECRET` are empty in repo secrets, and `canary-verify.yml` fails every run. The AWS account `004947743811` referenced in "Canary fleet" below predates this repo's history and hasn't been verified in-session.
+>
+> Current merges gate on manual `promote-latest.yml` dispatches, not canary. See [molecule-controlplane/docs/canary-tenants.md](https://github.com/Molecule-AI/molecule-controlplane/blob/main/docs/canary-tenants.md) for the Phase 1 code work that's already shipped + the Phase 2 plan for actually standing up the fleet + a "should we even do this now?" decision framework.
+>
+> When Phase 2 lands, delete this note and reconcile the two docs.
+
 ## The loop
 
 ```


### PR DESCRIPTION
## Why

\`docs/architecture/canary-release.md\` describes the canary pipeline as if the fleet is running — referencing AWS account \`004947743811\` and role \`MoleculeStagingProvisioner\` as existing infrastructure. Reality as of 2026-04-22: no canary tenants are provisioned, the 3 GH Actions secrets are empty, and \`canary-verify.yml\` has failed **7/7 times** in the past 24h for that reason.

Aspirational docs that read as reality confuse future readers and lead to wasted investigation. This PR adds a top-of-doc state note to close the loop.

## What changes

- Added a ⚠️ note at the top of \`canary-release.md\`:
  - Clarifies this is intended design, not deployed reality.
  - Notes the AWS account ID is historical / unverified.
  - Points to current gate: manual \`promote-latest.yml\` dispatches.
  - Cross-links to [\`molecule-controlplane/docs/canary-tenants.md\`](https://github.com/Molecule-AI/molecule-controlplane/blob/main/docs/canary-tenants.md) for Phase 1 (shipped), Phase 2 plan, and the \"should we even do this now?\" decision framework.
  - Asks whoever lands Phase 2 to delete the note + reconcile.

No behaviour change. Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)