### PR TITLE
fix(F1085): scope rm to /configs/path - 1-line fix

### DIFF
--- a/workspace-server/internal/handlers/container_files.go
+++ b/workspace-server/internal/handlers/container_files.go
@@ -171,7 +171,7 @@ func (h *TemplatesHandler) deleteViaEphemeral(ctx context.Context, volumeName, f
 
 	resp, err := h.docker.ContainerCreate(ctx, &container.Config{
 		Image: "alpine:latest",
-		Cmd:   []string{"rm", "-rf", "/configs", filePath},
+		Cmd:   []string{"rm", "-rf", "/configs/" + filePath},
 	}, &container.HostConfig{
 		Binds: []string{volumeName + ":/configs"},
 	}, nil, nil, "")


### PR DESCRIPTION
1-line fix for the rm overscope bug. rm received /configs and filePath as two separate args, deleting entire /configs dir on every call. Concatenate to target only the intended file. validateRelPath already prevents traversal.