### PR TITLE
feat(provision): propagate workspace model into runtime env (MVP hermes MiniMax flow)

### DIFF
--- a/workspace-server/internal/handlers/workspace_provision.go
+++ b/workspace-server/internal/handlers/workspace_provision.go
@@ -94,6 +94,7 @@ func (h *WorkspaceHandler) provisionWorkspaceOpts(workspaceID, templatePath stri
 	// Runs after secret loads so an operator can still override via a
 	// workspace_secret named GIT_AUTHOR_NAME if they want custom identity.
 	applyAgentGitIdentity(envVars, payload.Name)
+	applyRuntimeModelEnv(envVars, payload.Runtime, payload.Model)
 
 	// Plugin extension point: run any registered EnvMutators (e.g.
 	// github-app-auth, vault-secrets) AFTER built-in identity injection so
@@ -544,6 +545,37 @@ func (h *WorkspaceHandler) ensureDefaultConfig(workspaceID string, payload model
 	return files
 }
 
+// applyRuntimeModelEnv exposes the workspace's selected model via an
+// env var the target runtime's install.sh / start.sh knows to read.
+// Each runtime owns its own env-var contract — the tenant just plumbs
+// the value through so CP can bake it into user-data.
+//
+// Why per-runtime rather than a generic MOLECULE_MODEL: each runtime
+// installer has its own config schema and naming (hermes writes to
+// ~/.hermes/config.yaml with `model.default`; langgraph reads from
+// /configs/config.yaml directly; future IoT/robotics targets may have
+// firmware manifests). Keeping the contract owned by the runtime
+// template means adding a new runtime doesn't require edits on the
+// tenant side for each one.
+//
+// For runtimes with no env-based model override (langgraph etc. read
+// model from /configs/config.yaml which CP user-data generates from
+// payload.Model at boot), this is a no-op — no harm in the switch
+// being empty for those cases.
+func applyRuntimeModelEnv(envVars map[string]string, runtime, model string) {
+	if model == "" {
+		return
+	}
+	switch runtime {
+	case "hermes":
+		// template-hermes install.sh reads this into ~/.hermes/config.yaml's
+		// model.default field; derives HERMES_INFERENCE_PROVIDER from the
+		// slug prefix (minimax/…, anthropic/…, openai/…, etc.) when the
+		// provider isn't explicitly set.
+		envVars["HERMES_DEFAULT_MODEL"] = model
+	}
+}
+
 // loadWorkspaceSecrets loads global + workspace-specific secrets into a map.
 // Returns nil map + error string on decrypt failure. Shared by both Docker
 // and control plane provisioning paths to avoid duplication.
@@ -600,6 +632,7 @@ func (h *WorkspaceHandler) provisionWorkspaceCP(workspaceID, templatePath string
 	}
 
 	applyAgentGitIdentity(envVars, payload.Name)
+	applyRuntimeModelEnv(envVars, payload.Runtime, payload.Model)
 	if err := h.envMutators.Run(ctx, workspaceID, envVars); err != nil {
 		log.Printf("CPProvisioner: env mutator failed for %s: %v", workspaceID, err)
 		// F1086 / #1206: env mutator errors (missing tokens, vault paths) must not


### PR DESCRIPTION
## Why

Customer creates a hermes workspace with \`model=minimax/MiniMax-M2.7-highspeed\` + secret \`MINIMAX_API_KEY=sk-cp-…\` in canvas → expects it to just work. Previously the model selection was dropped on the floor: \`payload.Model\` set the default in the workspace's \`/configs/config.yaml\` but didn't reach the runtime's installer, so template-hermes's \`install.sh\` (+ docker \`start.sh\`) seeded \`~/.hermes/config.yaml\` with the template default (nousresearch/hermes-4-70b) instead of MiniMax.

## Fix

One helper, two call sites, no CP changes required:

\`applyRuntimeModelEnv(envVars, runtime, model)\` — runtime-switched helper. For hermes, sets \`HERMES_DEFAULT_MODEL\`. Other runtimes use their own config mechanism; the switch is empty for them.

Called in both:
- \`provisionWorkspaceOpts\` (Docker path, local dev)
- \`provisionWorkspaceCP\` (SaaS path, production)

The existing \`envVars\` map is already POSTed to CP as \`{\"env\": ...}\` and CP already \`export\`s each entry into workspace-EC2 user-data, so this change is fully contained to the tenant.

## Pairs with

- [template-hermes#8](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/8) — install.sh for bare-host
- [template-hermes#9](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/9) — derive-provider.sh (model prefix → HERMES_INFERENCE_PROVIDER)
- [controlplane#231](https://github.com/Molecule-AI/molecule-controlplane/pull/231) — CP user-data runs \`/opt/adapter/install.sh\`

With all four merged, the end-to-end chain is:

\`\`\`
Canvas Config tab (model + secret)
  → tenant workspace create handler
  → envVars populated from secrets + applyRuntimeModelEnv
  → CPProvisioner.Start POSTs to /cp/workspaces/provision
  → CP.ProvisionWorkspace bakes env into user-data
  → workspace EC2 boots, pip-installs, git-clones template
  → install.sh reads HERMES_DEFAULT_MODEL + MINIMAX_API_KEY from env
  → scripts/derive-provider.sh sets PROVIDER=minimax
  → ~/.hermes/config.yaml + .env seeded correctly
  → hermes gateway boots with MiniMax Token Plan as provider
  → molecule-runtime comes online
  → customer chats, MiniMax answers
\`\`\`

Zero ops touch. Zero canvas-side Save-button dependency.

## Design doc

Foundation for the broader WorkspaceBackend architecture tracked in \`Molecule-AI/internal/product/designs/workspace-backends.md\`. This PR is the last step-1 piece; steps 2-4 (formal interface, declarative manifest, first-new-backend) remain as follow-ups.

## Test plan

- [x] \`go build ./...\` + \`go vet ./...\` clean in workspace-server
- [ ] After deploy to staging/hongmingwang: create a hermes workspace with MiniMax-M2.7-highspeed + sk-cp-... secret, first chat succeeds without any ops intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)