### PR TITLE
fix(orgtoken): cast org_id to text in COALESCE (prevents /org/tokens 500)

### DIFF
--- a/workspace-server/internal/orgtoken/tokens.go
+++ b/workspace-server/internal/orgtoken/tokens.go
@@ -142,8 +142,13 @@ func Validate(ctx context.Context, db *sql.DB, plaintext string) (id, prefix, or
 // symptom of abuse or a bug — the hard cap prevents one runaway
 // minting loop from O(N) pageloads in the admin UI.
 func List(ctx context.Context, db *sql.DB) ([]Token, error) {
+	// org_id is a UUID column — COALESCE must cast to text first,
+	// otherwise Postgres rejects the empty-string literal with
+	// "pq: invalid input syntax for type uuid: ''". sqlmock doesn't
+	// exercise pq type coercion, so this bug only surfaces against
+	// a real Postgres (prod).
 	rows, err := db.QueryContext(ctx, `
-		SELECT id, prefix, COALESCE(name,''), COALESCE(org_id,''),
+		SELECT id, prefix, COALESCE(name,''), COALESCE(org_id::text,''),
 		       COALESCE(created_by,''), created_at, last_used_at
 		FROM org_api_tokens
 		WHERE revoked_at IS NULL


### PR DESCRIPTION
## Summary
- `orgtoken.List` queries `COALESCE(org_id,'')` but `org_id` is a UUID column — Postgres can't cast `''` to UUID, fails with `pq: invalid input syntax for type uuid: ""`
- Fix: `COALESCE(org_id::text,'')` — operates on matching types
- No Go-side changes: `Token.OrgID` is already `string`, scan still works

## Symptom (prod, hongmingwang)
```
2026/04/22 23:33:14 orgtoken list: orgtoken: list: pq: invalid input syntax for type uuid: ""
[GIN] 2026/04/22 - 23:33:14 | 500 | 835.234µs | 127.0.0.1 | GET "/org/tokens"
```
Tenant Settings → Org Tokens page broken.

## Why tests didn't catch it
sqlmock (used in `tokens_test.go`) doesn't model the pq driver's type coercion. It accepts any AddRow value for any declared column, so the query-level type mismatch is invisible. Real fix needs a real-Postgres integration harness; filed as follow-up.

## Test plan
- [x] `go test ./internal/orgtoken/` — existing tests still pass (regex `SELECT id, prefix.*FROM org_api_tokens.*ORDER BY created_at DESC` still matches)
- [x] Live prod Postgres verified: `SELECT COALESCE(org_id::text,'') FROM org_api_tokens LIMIT 5` executes without error
- [ ] After deploy: GET /org/tokens returns 200 on hongmingwang

## Audit
Searched for sibling `COALESCE(uuid_col, '')` patterns across workspace-server. Only one other hit: `terminal.go` uses `COALESCE(instance_id, '')` but `instance_id` is text (EC2 IDs like `i-xxx`), not UUID — safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)