### PR TITLE
fix(registry): auto-recover failed/provisioning workspaces on successful heartbeat

### DIFF
--- a/workspace-server/internal/handlers/registry.go
+++ b/workspace-server/internal/handlers/registry.go
@@ -444,6 +444,22 @@ func (h *RegistryHandler) evaluateStatus(c *gin.Context, payload models.Heartbea
 		}
 		h.broadcaster.RecordAndBroadcast(ctx, "WORKSPACE_ONLINE", payload.WorkspaceID, map[string]interface{}{})
 	}
+
+	// Auto-recovery: if a workspace is marked "failed" or "provisioning" but is
+	// actively sending heartbeats, it has clearly booted successfully. Transition
+	// to "online" so the scheduler and dashboard reflect reality. This catches
+	// cases where the provisioner crashed mid-setup or an earlier error left the
+	// status stale.
+	if currentStatus == "failed" || currentStatus == "provisioning" {
+		if _, err := db.DB.ExecContext(ctx, `UPDATE workspaces SET status = 'online', updated_at = now() WHERE id = $1 AND status IN ('failed', 'provisioning')`, payload.WorkspaceID); err != nil {
+			log.Printf("Heartbeat: failed to auto-recover %s from %s to online: %v", payload.WorkspaceID, currentStatus, err)
+		} else {
+			log.Printf("Heartbeat: auto-recovered %s from %s to online (heartbeat received)", payload.WorkspaceID, currentStatus)
+		}
+		h.broadcaster.RecordAndBroadcast(ctx, "WORKSPACE_ONLINE", payload.WorkspaceID, map[string]interface{}{
+			"recovered_from": currentStatus,
+		})
+	}
 }
 
 // UpdateCard handles POST /registry/update-card


### PR DESCRIPTION
## Summary

Extracted from closed PR #1664. When a workspace is stuck in `failed` or `provisioning` state but is actively sending successful heartbeats, the heartbeat handler now transitions it to `online`. Transient boot failures or a provisioner crash mid-setup previously left workspaces marked `failed` even after they became healthy, requiring manual intervention.

## Problem

- A flaky boot or a provisioner that crashes mid-setup leaves `workspaces.status = 'failed'` (or stale `'provisioning'`) in the DB.
- The workspace subsequently comes up and begins sending heartbeats, but `evaluateStatus` only handled the `online -> degraded`, `degraded -> online`, and `offline -> online` transitions.
- Result: the scheduler and dashboard keep reporting the workspace as dead despite it being healthy. Users have to manually reset status or delete-and-recreate.

## Fix

In `workspace-server/internal/handlers/registry.go::evaluateStatus`, after the existing `offline` recovery block, add a new branch:

```go
if currentStatus == "failed" || currentStatus == "provisioning" {
    // UPDATE workspaces SET status = 'online' ... WHERE id = $1 AND status IN ('failed', 'provisioning')
    // broadcast WORKSPACE_ONLINE with recovered_from=<prev status>
}
```

- Same `WHERE status IN (...)` guarded UPDATE pattern as the existing offline-recovery block, so a concurrent delete that flips to `removed` cannot race the recovery back to `online`.
- Existing `online`, `degraded`, and `offline` transitions are untouched.
- Broadcasts `WORKSPACE_ONLINE` with a `recovered_from` payload field so the UI/event log can distinguish auto-recovery from first-time online.

## Test plan

- [x] `go build ./...` in `workspace-server/` passes cleanly.
- [x] `go test ./internal/handlers/... -count=1 -run "TestRegistry|TestHeartbeat|TestRegister"` — the only failures (`TestRegister_C18_HijackBlockedNoBearer`, `TestRegister_ProvisionerURLPreserved`) reproduce on `origin/main` without this patch, confirmed pre-existing and unrelated.
- [ ] Manual: force `status = 'failed'` on a running workspace, confirm next heartbeat flips to `'online'` and emits `WORKSPACE_ONLINE` with `recovered_from: "failed"`.
- [ ] Manual: force `status = 'provisioning'` on a running workspace, confirm same behaviour with `recovered_from: "provisioning"`.
- [ ] Verify `removed` workspaces are NOT revived (guarded by the `status IN ('failed', 'provisioning')` predicate in the UPDATE).

Scope: `workspace-server/internal/handlers/registry.go` only.