### PR TITLE
hardening(handlers): defensive requestContext + newTestGinContext helpers (follow-up to #1755)

### DIFF
--- a/workspace-server/internal/handlers/gin_context.go
+++ b/workspace-server/internal/handlers/gin_context.go
@@ -1,0 +1,33 @@
+package handlers
+
+// gin_context.go — shared gin.Context helpers.
+//
+// These exist because a number of code paths read c.Request.Context() and
+// pass it straight into DB / HTTP calls. When a handler is invoked with a
+// gin.Context that has no Request (usually a bare gin.CreateTestContext
+// in a unit test, rarely a misconfigured middleware chain in prod),
+// c.Request is nil and the dereference panics. The 2026-04-23 incident
+// (PR #1755) had one such panic kill the test binary mid-run and mask
+// ~25 pre-existing failures downstream.
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+)
+
+// requestContext returns c.Request.Context() when Request is set, and
+// context.Background() otherwise. Use this everywhere instead of a raw
+// c.Request.Context() so a nil Request hardens into a benign empty
+// context instead of a nil-deref panic.
+//
+// Intentionally forgiving: production Gin always sets Request, so the
+// branch is dead code at runtime. The guard exists to keep the handler
+// robust against test contexts and any future middleware that might
+// reset the Request field — a safer default than crashing the process.
+func requestContext(c *gin.Context) context.Context {
+	if c == nil || c.Request == nil {
+		return context.Background()
+	}
+	return c.Request.Context()
+}

--- a/workspace-server/internal/handlers/gin_context_test.go
+++ b/workspace-server/internal/handlers/gin_context_test.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// requestContext must return context.Background for the three degenerate
+// inputs production code can realistically hit — nil context, nil Request,
+// and a zero-value bare gin.Context from CreateTestContext — without
+// panicking. Together with the third case (real Request set), these cover
+// every path a handler can take.
+
+func TestRequestContext_NilContext(t *testing.T) {
+	// Must not panic. Returned ctx must still be usable (Deadline/Err OK to call).
+	got := requestContext(nil)
+	if got == nil {
+		t.Fatal("requestContext(nil) returned nil — must return context.Background")
+	}
+	if _, has := got.Deadline(); has {
+		t.Error("context.Background should have no deadline")
+	}
+}
+
+func TestRequestContext_NilRequest(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w) // Request is nil on fresh test context
+	if c.Request != nil {
+		t.Skip("gin changed CreateTestContext to set Request; test no longer exercises nil-Request path")
+	}
+	got := requestContext(c)
+	if got == nil {
+		t.Fatal("requestContext(c) with nil Request returned nil")
+	}
+	if got != context.Background() {
+		// OK for implementations to return a distinct empty ctx, but warn.
+		t.Logf("note: requestContext(nil-Request) returned non-Background context %#v", got)
+	}
+}
+
+func TestRequestContext_RealRequestPassesThrough(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	// Attach a request with a context-value so we can verify the same
+	// context is handed through (not replaced with Background).
+	type ctxKey string
+	reqCtx := context.WithValue(context.Background(), ctxKey("marker"), "present")
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil).WithContext(reqCtx)
+
+	got := requestContext(c)
+	if got.Value(ctxKey("marker")) != "present" {
+		t.Errorf("requestContext dropped the Request's context — expected marker=present, got %v",
+			got.Value(ctxKey("marker")))
+	}
+}

--- a/workspace-server/internal/handlers/handlers_test.go
+++ b/workspace-server/internal/handlers/handlers_test.go
@@ -69,6 +69,24 @@ func allowLoopbackForTest(t *testing.T) {
 	t.Cleanup(func() { testAllowLoopback = prev })
 }
 
+// newTestGinContext returns a recorder + gin.Context with Request pre-set
+// to an empty GET "/". Use this instead of bare gin.CreateTestContext
+// anywhere a handler or helper reaches for c.Request.Context(), so the
+// DB/ HTTP path doesn't nil-deref on a missing Request. Pairs with the
+// defensive requestContext helper in gin_context.go — together they make
+// it hard to regress into the 2026-04-23 panic-chain pattern (PR #1755).
+//
+// Callers that need a specific method/path/body should still build the
+// Request explicitly — this helper is the "I don't care, just give me a
+// gin context that won't panic" shortcut.
+func newTestGinContext(t *testing.T) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+	return w, c
+}
+
 // expectBudgetCheck adds the sqlmock expectation for the budget-check
 // query that ProxyA2A runs before forwarding. checkWorkspaceBudget
 // fails-open on sql.ErrNoRows, so we return a deliberately-empty

--- a/workspace-server/internal/handlers/org_plugin_allowlist.go
+++ b/workspace-server/internal/handlers/org_plugin_allowlist.go
@@ -135,7 +135,10 @@ func requireCallerOwnsOrg(c *gin.Context) (string, error) {
 	// Look up the token's org_id (populated at mint time by orgTokenActor).
 	// org_id is NULL for tokens minted before this migration or via
 	// ADMIN_TOKEN bootstrap — those callers get callerOrg="" and are denied.
-	orgID, err := orgtoken.OrgIDByTokenID(c.Request.Context(), db.DB, tokID)
+	// Use requestContext (gin_context.go) rather than c.Request.Context()
+	// directly so a test context without a Request returns context.Background
+	// instead of panicking on a nil dereference. See 2026-04-23 incident notes.
+	orgID, err := orgtoken.OrgIDByTokenID(requestContext(c), db.DB, tokID)
 	if err != nil {
 		// DB error — deny by default rather than risk cross-org access.
 		return "", fmt.Errorf("allowlist: requireCallerOwnsOrg: %v", err)


### PR DESCRIPTION
## Summary
Follow-up to #1755. Adds two small helpers that prevent the "nil c.Request → nil deref panic → test binary killed → downstream tests masked" pattern from recurring. No behavior change — both helpers default to what production already does.

Stacked on \`fix/platform-go-ci-stabilize\` (the #1755 branch). Rebase-retarget to \`main\` after #1755 merges.

## Layer 1 — \`requestContext(c)\` helper
Drop-in replacement for \`c.Request.Context()\`. Returns \`context.Background()\` when \`c\` or \`c.Request\` is nil. Production Gin always sets Request, so the defensive branch is dead code at runtime.

Migrated the one known panic site (\`requireCallerOwnsOrg\`'s \`OrgIDByTokenID\` call) as proof-of-concept. The remaining ~140 \`c.Request.Context()\` call sites stay raw for this PR — rolling migration tracked in internal KI-010.

## Layer 2 — \`newTestGinContext(t)\` helper
Returns a recorder + gin.Context with Request pre-attached to GET \`/\`. Replaces bare \`gin.CreateTestContext(w)\` for the common "just give me a context that won't panic" case.

Not adopted across every test yet (80+ bare callers in handlers/) — a follow-up lint rule (KI-010 Layer 5) will drive the full migration.

## Why not also Layers 3–6
See \`known-issues.md#KI-010\` in the internal repo. Short version:
- **L3** (\`-shuffle=on\` in CI) — open, 1-line ci.yml tweak. Land AFTER L1+L2 so surfaced failures are real bugs not panic-chain casualties.
- **L4** (goroutine-panic fail-loud) — skip. Wrong diagnosis; the 2026-04-23 panic was synchronous.
- **L5** (lint rule) — open, needs golangci-lint config work.
- **L6** (schema-column contract check) — open, addresses the schema-drift class that made up most of #1755's 25 unmasked failures.

## Test plan
- [x] \`go test -race ./...\` — full suite green (14 packages)
- [x] Three tests for \`requestContext\` covering nil ctx, nil Request, real Request
- [x] \`go build ./...\` clean

## References
- Parent: #1755
- Internal docs: \`known-issues.md\` KI-010 (panic-chain), KI-011 (E2E hermes boot), KI-012 (Canvas mock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)