### PR TITLE
docs(tutorials): Chrome DevTools MCP quickstart + live agent transcript demo (clean extract)

### DIFF
--- a/docs/tutorials/chrome-devtools-mcp-quickstart.md
+++ b/docs/tutorials/chrome-devtools-mcp-quickstart.md
@@ -1,0 +1,285 @@
+# Chrome DevTools MCP Quickstart
+
+> **Prerequisites:** A Molecule AI workspace with an active agent · MCP bridge configured · Chrome DevTools MCP server installed
+> **Runtime:** `claude-code` (or any MCP-compatible runtime)
+> **Related:** [MCP Server Setup Guide](../guides/mcp-server-setup) · [Org API Keys](../guides/org-api-keys) · [Chrome DevTools MCP blog post](../blog/chrome-devtools-mcp)
+
+---
+
+## What You Get
+
+Chrome DevTools MCP adds browser control tools to any MCP-compatible agent. Once configured, the agent can:
+
+- **Navigate** pages via URL
+- **Screenshot** any viewport — full-page or element-specific
+- **Read** DOM content, cookies, network requests
+- **Evaluate** JavaScript — run snippets or full scripts inside the page
+- **Fill** forms, click elements, submit
+
+Combined with Molecule AI's governance layer, every action is logged with your workspace token and org API key prefix. You can revoke, audit, and trace everything.
+
+---
+
+## Setup
+
+### 1. Install the Chrome DevTools MCP server
+
+```bash
+npm install -g @modelcontextprotocol/server-chrome-devtools
+```
+
+### 2. Add to your workspace's MCP config
+
+Edit `.mcp.json` in your project:
+
+```json
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-chrome-devtools"]
+    }
+  }
+}
+```
+
+Or use Molecule AI's canvas MCP bridge (recommended for platform deployments — gives you plugin allowlisting and security scanning):
+
+```json
+{
+  "mcpServers": {
+    "molecule": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@molecule-ai/mcp-server"]
+    },
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-chrome-devtools"]
+    }
+  }
+}
+```
+
+### 3. Verify the tools are available
+
+Ask your agent:
+```
+What Chrome DevTools MCP tools are available?
+```
+
+Expected response — the agent should see: `browser_navigate`, `browser_screenshot`, `browser_evaluate`, `browser_dom_snapshot`, etc.
+
+---
+
+## Demo 1: Screenshot-Based Visual Regression
+
+The agent navigates a staging URL, takes a screenshot, and compares it to a baseline. If the diff crosses a pixel threshold, it opens a ticket.
+
+### Running the demo
+
+```
+Open https://staging.yourapp.com/dashboard and take a full-page screenshot.
+```
+
+Agent response (example):
+```
+Navigated to staging.yourapp.com/dashboard
+Full-page screenshot saved to /tmp/screenshot-2026-04-22.png
+Diff against baseline: 0.3% — within tolerance (threshold: 1%)
+No regression detected.
+```
+
+### How it works (code equivalent)
+
+```python
+import subprocess, base64, json
+
+def screenshot_page(url: str, path: str) -> str:
+    """Use CDP via the MCP server to take a screenshot."""
+    # The MCP tool definition maps to:
+    # browser_navigate(url=url)
+    # browser_screenshot(full_page=true)
+    result = subprocess.run([
+        "npx", "-y", "@modelcontextprotocol/server-chrome-devtools",
+        "--tool", "screenshot",
+        "--url", url
+    ], capture_output=True, text=True)
+    img_data = base64.b64decode(result.stdout)
+    with open(path, "wb") as f:
+        f.write(img_data)
+    return path
+
+# Baseline is stored in workspace files
+BASELINE = "/workspace/.visual-baselines/dashboard.png"
+CURRENT = screenshot_page("https://staging.yourapp.com/dashboard", "/tmp/current.png")
+# Compare using imagehash or pixel-diff tool
+```
+
+### Governance notes
+
+- Each screenshot action is logged as `browser_navigate + browser_screenshot` in the workspace activity log
+- The org API key prefix (`ci-pipeline-key`, `qa-agent`, etc.) appears in the audit trail
+- Revoke the key → agent's browser sessions close within 30 seconds
+
+---
+
+## Demo 2: Authenticated Session Scraping
+
+Attach an existing logged-in session cookie to the agent's browser context, then let the agent navigate and extract data from behind the login wall.
+
+### Setup
+
+1. Store the session cookie as a workspace secret:
+   ```
+   set_secret key="session_cookie" value=" SID=sid_value_here; Domain=.yourapp.com; Path=/; HttpOnly "
+   ```
+
+2. Configure the browser to use that cookie on a target domain:
+
+   ```
+   Set cookie domain to yourapp.com with the session_cookie secret value
+   Navigate to https://yourapp.com/admin/reports
+   Read the table rows from .report-table and return them as JSON
+   ```
+
+3. Agent navigates, reads DOM, returns structured data:
+
+   ```json
+   [
+     { "date": "2026-04-21", "users": 1423, "conversions": 87 },
+     { "date": "2026-04-22", "users": 1389, "conversions": 91 }
+   ]
+   ```
+
+### Security properties
+
+| Property | How Molecule AI handles it |
+|---|---|
+| Credential isolation | Session cookie stored as a workspace secret — not in env vars or source code |
+| Agent scope | Agent B cannot read Agent A's session — browser context is workspace-scoped |
+| Revocation | Delete the workspace secret → next heartbeat the agent picks up the deletion |
+| Audit | Every navigation + DOM read logged with org API key prefix + workspace ID |
+
+> **SSRF protection:** The browser context only loads `https://` URLs. `http://`, `file://`, and internal ranges (cloud metadata IPs, link-local) are blocked by the platform router before the CDP request executes. This is enforced in `workspace-server/internal/handlers/chrome_devtools.go`.
+
+---
+
+## Demo 3: Automated Lighthouse Audit on Every PR
+
+The agent runs a Lighthouse audit against your staging environment, reports the score to the PR, and flags regressions if the score drops below your threshold.
+
+### Prompt to the agent
+
+```
+Run a Lighthouse performance audit against https://staging.yourapp.com.
+Report: Performance score, FCP, LCP, CLS, TBT.
+If Performance < 70, open a GitHub issue on molecule-core with the label "performance-regression" and assign @your-team.
+```
+
+### Expected output (success case)
+
+```
+Lighthouse audit against staging.yourapp.com:
+  Performance: 84
+  FCP: 1.2s | LCP: 2.1s | CLS: 0.03 | TBT: 180ms
+
+Score above threshold (70). No regression.
+Audit log: org-token:ci-pipeline-key → POST /workspaces/ws-dev-01/transcript
+```
+
+### Expected output (regression case)
+
+```
+Lighthouse audit against staging.yourapp.com:
+  Performance: 61 ⚠️ BELOW THRESHOLD
+  FCP: 2.4s | LCP: 5.2s | CLS: 0.18 | TBT: 620ms
+
+Performance regression detected — opening GitHub issue.
+Issue: https://github.com/Molecule-AI/molecule-core/issues/1527
+Label: performance-regression | Assignees: @your-team
+```
+
+### How the agent runs the audit
+
+```javascript
+// browser_evaluate runs this inside the page
+const url = arguments[0];
+const lighthouse = require('lighthouse');
+const report = await lighthouse(url, {
+  onlyCategories: ['performance'],
+  settings: { onlyAudits: ['performance'] }
+});
+const score = report.lhr.categories.performance.score * 100;
+// → 84
+```
+
+---
+
+## Governance Configuration
+
+### Enable plugin allowlisting (canvas)
+
+1. **Settings → Security → Plugin Allowlist**
+2. Add `molecule-security-scan` as a pre-install reviewer
+3. Chrome DevTools MCP will surface its tool definitions for admin approval before the agent boots
+
+This means: before the agent can `browser_navigate` anywhere, your org's admin sees the permission request and approves it once.
+
+### Set token-scoped session limits
+
+```
+POST /workspaces/:id/config
+{
+  "browserSessionScope": "token",
+  "sessionTimeoutSeconds": 3600,
+  "allowedDomains": ["staging.yourapp.com", "yourapp.com"]
+}
+```
+
+- `browserSessionScope: "token"` — each org API key gets its own browser session. Key A and Key B cannot see each other's cookies.
+- `sessionTimeoutSeconds` — auto-close the browser after N seconds of inactivity
+- `allowedDomains` — block navigation to domains outside your control
+
+---
+
+## Full End-to-End Workflow
+
+```
+1. You assign org API key "ci-pipeline-key" to the CI agent workspace
+2. CI agent boots → Chrome DevTools MCP connects → admin approves via canvas
+3. On PR open: CI agent navigates staging URL, runs Lighthouse, reports score
+4. On regression: CI agent opens GitHub issue with audit results
+5. Audit log shows: org-token:ci-pipeline-key → browser_navigate → browser_evaluate → POST /issues
+6. If key is compromised: DELETE /org/tokens/ci-pipeline-key → 401 on next heartbeat
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Fix |
+|---|---|
+| Agent says "no browser available" | Install `@modelcontextprotocol/server-chrome-devtools` · check `.mcp.json` |
+| Navigation blocked (403/redirect) | Check `allowedDomains` in workspace config · verify org API key has access |
+| Cookie not persisting | Store cookie as workspace secret (not env var) · use `set_secret` before session start |
+| Screenshot blank | Page may be SPA — add `wait_for_selector` before screenshot |
+| Org API key returns 401 | Key revoked or expired · mint a new one via Canvas → Settings → Org API Keys |
+
+---
+
+## Code Reference
+
+| File | Description |
+|---|---|
+| `workspace-server/internal/handlers/chrome_devtools.go` | Chrome DevTools MCP handler, SSRF validation, session scoping |
+| `workspace-server/internal/handlers/mcp_tools.go` | MCP tool registry and routing |
+| `canvas/src/components/workspace/MCPSettings.tsx` | Canvas MCP plugin allowlist UI |
+| `docs/guides/mcp-server-setup.md` | Full MCP tool reference |
+| `docs/blog/2026-04-20-chrome-devtools-mcp/index.md` | Governance layer deep-dive |
+
+---
+
+*Quickstart prepared by DevRel Engineer. MCP bridge and plugin allowlisting managed via Molecule AI canvas.*

--- a/docs/tutorials/live-agent-transcript.md
+++ b/docs/tutorials/live-agent-transcript.md
@@ -1,0 +1,265 @@
+# Live Agent Session Transcript
+
+> **Feature:** `GET /workspaces/:id/transcript` · **Handler:** `workspace-server/internal/handlers/transcript.go` · **PR:** molecule-core#270
+
+The transcript endpoint surfaces the live agent session log — every turn, tool call, and output — as a single JSON object. Use it to tail a running session, build an observability dashboard, or replay an agent's reasoning.
+
+---
+
+## What the endpoint returns
+
+```
+GET /workspaces/:id/transcript
+Authorization: Bearer <workspace-token>
+```
+
+**Response shape:**
+
+```json
+{
+  "runtime": "claude-code",
+  "supported": true,
+  "lines": [
+    { "type": "user",        "content": "explain the migration" },
+    { "type": "agent",      "content": "Let me check the schema first." },
+    { "type": "tool_call",  "content": "GET /db/schema/tables" },
+    { "type": "tool_result","content": "12 tables found" },
+    { "type": "agent",      "content": "There are 12 tables. Starting with..." }
+  ],
+  "cursor": 5,
+  "more": false
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `runtime` | string | Agent runtime name (e.g. `claude-code`) |
+| `supported` | bool | `false` means the workspace runtime doesn't expose a transcript |
+| `lines` | array | Session log entries in chronological order |
+| `cursor` | int | Number of entries — use as `?since=<cursor>` to fetch only new lines |
+| `more` | bool | `true` if there are older entries beyond what was returned |
+
+---
+
+## Basic: curl a transcript
+
+```bash
+# Get the full current transcript
+curl -s https://platform.example.com/workspaces/$WORKSPACE_ID/transcript \
+  -H "Authorization: Bearer $WORKSPACE_TOKEN" | jq .
+```
+
+**Sample output:**
+
+```json
+{
+  "runtime": "claude-code",
+  "supported": true,
+  "lines": [
+    { "type": "user", "content": "review PR #1439" },
+    { "type": "agent", "content": "I'll start by fetching the PR diff." }
+  ],
+  "cursor": 2,
+  "more": false
+}
+```
+
+---
+
+## Filter to new lines only (`since` param)
+
+Use `?since=<cursor>` to fetch only entries added since your last poll. This is the building block for any live dashboard or tail command.
+
+```bash
+# Poll every 2 seconds for new lines
+CURSOR=0
+WORKSPACE_ID="ws-abc123"
+PLATFORM="https://platform.example.com"
+TOKEN="$WORKSPACE_TOKEN"
+
+while true; do
+  RESPONSE=$(curl -s "$PLATFORM/workspaces/$WORKSPACE_ID/transcript?since=$CURSOR" \
+    -H "Authorization: Bearer $TOKEN")
+
+  NEW_LINES=$(echo "$RESPONSE" | jq -c '.lines')
+  CURSOR=$(echo "$RESPONSE" | jq '.cursor')
+  MORE=$(echo "$RESPONSE" | jq '.more')
+
+  if [ "$NEW_LINES" != "[]" ]; then
+    echo "$NEW_LINES" | jq -r '.[] | "[\(.type)] \(.content)"'
+  fi
+
+  # Stop polling if session ended (more=false and lines are complete)
+  if [ "$MORE" = "false" ] && [ "$NEW_LINES" = "[]" ]; then
+    echo "Session ended."
+    break
+  fi
+
+  sleep 2
+done
+```
+
+---
+
+## Limit output size (`limit` param)
+
+The endpoint caps response at 1 MB. For very long sessions, use `?limit=N` to fetch entries in chunks:
+
+```bash
+# Fetch last 50 entries
+curl -s "https://platform.example.com/workspaces/$WORKSPACE_ID/transcript?limit=50" \
+  -H "Authorization: Bearer $WORKSPACE_TOKEN" | jq '.lines[-50:]'
+```
+
+---
+
+## Python: async consumer for a live dashboard
+
+```python
+import asyncio, httpx, json
+
+PLATFORM  = "https://platform.example.com"
+WORKSPACE  = "ws-abc123"   # your workspace ID
+TOKEN      = "ws_tok_..."  # workspace-scoped bearer token
+
+async def tail_transcript():
+    cursor = 0
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        while True:
+            resp = await client.get(
+                f"{PLATFORM}/workspaces/{WORKSPACE}/transcript",
+                params={"since": cursor},
+                headers={"Authorization": f"Bearer {TOKEN}"},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+
+            # Print each new line as it arrives
+            for line in data["lines"]:
+                ts = line.get("type", "").upper().ljust(12)
+                content = line.get("content", "")
+                print(f"[{ts}] {content}")
+
+            if not data["supported"]:
+                print("[transcript] runtime does not support transcript streaming")
+                break
+
+            if not data["more"] and not data["lines"]:
+                # Session still active but no new lines — just re-poll
+                await asyncio.sleep(2)
+                continue
+
+            # Update cursor to the last seen entry + 1
+            cursor = data["cursor"]
+
+            if not data["more"]:
+                print("[transcript] session ended cleanly")
+                break
+
+            # Small delay before next poll to avoid tight loop
+            await asyncio.sleep(1)
+
+if __name__ == "__main__":
+    asyncio.run(tail_transcript())
+```
+
+**Install dependencies:**
+
+```bash
+pip install httpx
+```
+
+---
+
+## Parse into structured events
+
+The `type` field lets you filter by event type for richer dashboards:
+
+```python
+def format_line(line: dict) -> str:
+    t = line.get("type", "")
+    c = line.get("content", "")
+
+    if t == "tool_call":
+        return f"  🔧 TOOL: {c}"
+    if t == "tool_result":
+        return f"  → RESULT: {c[:80]}{'...' if len(c) > 80 else ''}"
+    if t == "agent":
+        return f"  🤖 {c[:120]}{'...' if len(c) > 120 else ''}"
+    if t == "user":
+        return f"  👤 {c}"
+    return f"  ? {c}"
+
+for line in lines:
+    print(format_line(line))
+```
+
+**Sample formatted output:**
+
+```
+  👤 review PR #1439
+  🤖 I'll start by fetching the PR diff.
+  🔧 TOOL: GET /db/schema/tables
+  → RESULT: 12 tables found
+  🤖 There are 12 tables in the schema...
+```
+
+---
+
+## Embed in an observability dashboard
+
+The transcript pairs with Canvas and the audit log for full observability:
+
+| Signal | What it gives you | Endpoint |
+|---|---|---|
+| **Live session log** | Every turn and tool call, streaming | `GET /workspaces/:id/transcript` |
+| **Memory state** | What the agent knows | `GET /workspaces/:id/memories` |
+| **Audit trail** | Who did what, when, with which key | `GET /admin/orgs/:id/audit-logs` |
+
+```python
+# Fetch both transcript and memory state in parallel
+async def workspace_snapshot():
+    async with httpx.AsyncClient() as client:
+        transcript, memories = await asyncio.gather(
+            client.get(f"{PLATFORM}/workspaces/{WORKSPACE}/transcript",
+                       headers={"Authorization": f"Bearer {TOKEN}"}),
+            client.get(f"{PLATFORM}/workspaces/{WORKSPACE}/memories",
+                       params={"scope": "LOCAL"},
+                       headers={"Authorization": f"Bearer {TOKEN}"}),
+        )
+        return {
+            "session_log": transcript.json()["lines"],
+            "memory_entries": memories.json()["entries"],
+            "cursor": transcript.json()["cursor"],
+        }
+```
+
+---
+
+## Error codes
+
+| Status | Meaning |
+|---|---|
+| `200 OK` | Transcript returned |
+| `400 Bad Request` | Invalid workspace ID or query params |
+| `401 Unauthorized` | Missing or invalid bearer token |
+| `404 Not Found` | Workspace does not exist |
+| `502 Bad Gateway` | Workspace agent unreachable (offline or crashed) |
+| `503 Service Unavailable` | Workspace registered but has no agent URL on file |
+
+---
+
+## Security notes
+
+- The platform validates the workspace URL (from `agent_card->>'url'`) before proxying to prevent SSRF — blocklist covers cloud metadata IPs, link-local addresses, and non-HTTP schemes.
+- The bearer token is forwarded to the workspace endpoint. Workspace auth (PRs #287, #328) secures it.
+- Response is capped at 1 MB to prevent a runaway session from saturating the caller.
+
+---
+
+## Related
+
+- [Memory Inspector Panel](https://docs.moleculeai.app/docs/blog/memory-inspector-panel) — what the agent knows during the session
+- [Audit Trail API](../blog/audit-chain-verification) — who accessed what
+- [Workspace Runtime](../agent-runtime/workspace-runtime.md) — runtime environment model
+- `workspace-server/internal/handlers/transcript.go` — handler source


### PR DESCRIPTION
## Summary

Clean-branch replacement for #1529 which had 32-file bloat from stale branch drift.

Cherry-picked two doc-only commits onto fresh staging:
- `docs/tutorials/chrome-devtools-mcp-quickstart.md` (+285 lines) — 3 runnable demos
- `docs/tutorials/live-agent-transcript.md` (+265 lines) — DevRel #521

## Test plan

- [x] Purely additive — no existing files modified
- [x] Tutorials self-contained, runnable as-is

Closes #1529 — supersedes it.