### PR TITLE
docs(blog): Phase 34 — Partner API Keys, Governance, Tool Trace (clean extract)

### DIFF
--- a/docs/blog/2026-04-23-partner-api-keys.md
+++ b/docs/blog/2026-04-23-partner-api-keys.md
@@ -1,0 +1,141 @@
+---
+title: "Ship Partner Integrations Faster with Programmatic Org Management"
+date: 2026-04-23
+slug: partner-api-keys
+description: "Partner API Keys let marketplace resellers, CI/CD pipelines, and automation tools create and manage Molecule AI orgs via API — no browser session required."
+og_title: "Ship Partner Integrations Faster with Programmatic Org Management"
+og_description: "Partner API Keys: scoped, rate-limited, revocable API keys for programmatic org management. Built for marketplaces, CI/CD, and automation platforms."
+og_image: /docs/assets/blog/2026-04-23-partner-api-keys-og.png
+tags: [partner-api-keys, marketplace, ci-cd, automation, api, enterprise, provisioning]
+keywords: [partner API keys, programmatic org management, marketplace integration, CI/CD automation, Molecule AI API, reseller integration, org provisioning API]
+canonical: https://docs.molecule.ai/blog/partner-api-keys
+---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Ship Partner Integrations Faster with Programmatic Org Management",
+  "description": "Partner API Keys let marketplace resellers, CI/CD pipelines, and automation tools create and manage Molecule AI orgs via API.",
+  "author": { "@type": "Organization", "name": "Molecule AI" },
+  "datePublished": "2026-04-23",
+  "publisher": { "@type": "Organization", "name": "Molecule AI", "logo": { "@type": "ImageObject", "url": "https://molecule.ai/logo.png" } }
+}
+</script>
+
+# Ship Partner Integrations Faster with Programmatic Org Management
+
+When your platform needs to create an org — for a new customer, a CI environment, or a marketplace resale — the last thing you want is to hand that flow over to a human with a browser. Neither does your partner.
+
+Phase 34 is designed to solve exactly this problem. **Partner API Keys** give marketplace resellers, CI/CD pipelines, and automation platforms a programmatic way to create and manage Molecule AI orgs — no browser session, no admin dashboard, just an API call.
+
+## What Partner API Keys Do
+
+A Partner API Key is a scoped, rate-limited, revocable bearer token — prefixed `mol_pk_` — that lives at the `/cp/` control plane boundary. It authenticates to a set of partner-facing endpoints that let you provision an org, poll its status, and revoke the integration when it's no longer needed.
+
+Unlike org-scoped API keys (which operate *within* an org), Partner API Keys operate *at the org level*: they create orgs, list your own keys, and revoke themselves. The scope system lets you grant exactly the capabilities a partner needs — nothing more.
+
+```bash
+POST /cp/admin/partner-keys
+Authorization: Bearer <admin-master-key>
+{
+  "name": "acme-ci-pipeline",
+  "scopes": ["orgs:create", "orgs:list"],
+  "org_id": null
+}
+
+# Response
+{
+  "id": "pak_01HXKM4...",
+  "key": "mol_pk_1a2b3c4d5e...",   # shown ONCE
+  "name": "acme-ci-pipeline",
+  "scopes": ["orgs:create", "orgs:list"],
+  "created_at": "2026-04-23T08:00:00Z"
+}
+```
+
+Your CI pipeline saves `mol_pk_1a2b3c4d5e...` as a secret and uses it to call the partner endpoints.
+
+## The Partner API Surface
+
+Once you have a Partner API Key, the integration flow looks like this:
+
+```bash
+# 1. Create an org
+POST /cp/orgs
+Authorization: Bearer mol_pk_1a2b3c4d5e...
+{
+  "name": "acme-corp",
+  "slug": "acme-corp",
+  "plan": "standard"
+}
+
+# Response
+{
+  "id": "org_01HXKM4...",
+  "slug": "acme-corp",
+  "status": "provisioning",
+  "created_at": "2026-04-23T08:00:00Z"
+}
+
+# 2. Poll until ready
+GET /cp/orgs/org_01HXKM4.../status
+Authorization: Bearer mol_pk_1a2b3c4d5e...
+
+# 3. Redirect the customer
+# → https://app.moleculesai.app/login?org=acme-corp
+
+# 4. Revoke when done
+DELETE /cp/admin/partner-keys/pak_01HXKM4...
+Authorization: Bearer mol_pk_1a2b3c4d5e...
+```
+
+Every call is audited: the audit log records which Partner API Key was used, when, and what it did — so you can trace a provisioning event back to the integration that triggered it.
+
+## Scopes and Rate Limits
+
+Partner API Keys are granted specific scopes at creation time. A CI pipeline might get `orgs:create` + `orgs:list`. A marketplace reseller might also need `workspaces:create`. A monitoring tool might only need `orgs:list`.
+
+```
+Available scopes:
+  orgs:create      — provision new orgs
+  orgs:list        — list partner-managed orgs
+  orgs:delete      — deprovision orgs
+  workspaces:create — create workspaces within an org
+  billing:read     — read subscription status
+```
+
+Rate limits are enforced per key, independently of the session rate limit. A misbehaving integration hits its own ceiling without affecting other partners or organic traffic.
+
+## The Marketplace Reseller Use Case
+
+Marketplace resellers need to provision a Molecule AI org on behalf of every end customer — automatically, at scale, without a human in the loop. They also need to:
+
+- **Scope the integration** to only the capabilities that partner needs
+- **Revoke cleanly** when the reseller-customer relationship ends
+- **Audit everything** for compliance reporting
+
+Partner API Keys handle all three. A reseller creates one key per integration tier (e.g. one key for the standard tier, one for enterprise), each scoped to exactly what that tier allows. When a customer churns, the reseller revokes their key — the org stays but the automation path is closed.
+
+## CI/CD: Ephemeral Test Orgs
+
+CI/CD pipelines benefit from the same pattern. A test suite that needs to validate the Molecule AI integration flow can:
+
+1. Create a temporary org via Partner API Key (`orgs:create`)
+2. Run the integration tests against it
+3. Delete the org when done (`orgs:delete`)
+4. Revoke the key
+
+Each run gets a clean environment. No shared state, no test pollution, no manual cleanup.
+
+## Get Started
+
+Partner API Keys are available on **Partner and Enterprise plans**. To get started:
+
+- Contact your account team to request Partner API Key issuance
+- Review the partner integration guide (coming soon)
+- Example flows: create org → poll status → redirect to tenant; CI/CD test org lifecycle
+
+---
+
+*Molecule AI is open source. Partner API Keys shipped in Phase 34 (2026-04-23). Available on Partner and Enterprise plans.*

--- a/docs/blog/2026-04-23-partner-api-keys.md
+++ b/docs/blog/2026-04-23-partner-api-keys.md
@@ -5,7 +5,6 @@ slug: partner-api-keys
 description: "Partner API Keys let marketplace resellers, CI/CD pipelines, and automation tools create and manage Molecule AI orgs via API — no browser session required."
 og_title: "Ship Partner Integrations Faster with Programmatic Org Management"
 og_description: "Partner API Keys: scoped, rate-limited, revocable API keys for programmatic org management. Built for marketplaces, CI/CD, and automation platforms."
-og_image: /docs/assets/blog/2026-04-23-partner-api-keys-og.png
 tags: [partner-api-keys, marketplace, ci-cd, automation, api, enterprise, provisioning]
 keywords: [partner API keys, programmatic org management, marketplace integration, CI/CD automation, Molecule AI API, reseller integration, org provisioning API]
 canonical: https://docs.molecule.ai/blog/partner-api-keys

--- a/docs/blog/2026-04-23-platform-instructions-governance/index.md
+++ b/docs/blog/2026-04-23-platform-instructions-governance/index.md
@@ -1,0 +1,106 @@
+---
+title: "Govern Your AI Fleet at the System Prompt Level"
+date: 2026-04-23
+slug: govern-ai-fleet-system-prompt-level
+description: "Platform Instructions lets enterprise IT teams enforce org-wide policy rules at the system prompt level — before the first agent turn executes. No code deploys. No SDK integration."
+og_title: "Govern Your AI Fleet at the System Prompt Level"
+og_description: "Platform Instructions: global and workspace-scoped rules prepended to the system prompt. Governance before the first turn, not after."
+og_image: /docs/assets/blog/2026-04-23-platform-instructions-governance-og.png
+tags: [governance, platform-instructions, enterprise, security, it-governance, system-prompt, policy, a2a]
+keywords: [AI fleet governance, enterprise AI policy, system prompt governance, AI agent compliance, platform instructions, workspace policy enforcement, enterprise AI security, AI agent ACL]
+canonical: https://docs.molecule.ai/blog/govern-ai-fleet-system-prompt-level
+---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Govern Your AI Fleet at the System Prompt Level",
+  "description": "Platform Instructions lets enterprise IT teams enforce org-wide policy rules at the system prompt level — before the first agent turn executes. No code deploys.",
+  "author": { "@type": "Organization", "name": "Molecule AI" },
+  "datePublished": "2026-04-23",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Molecule AI",
+    "logo": { "@type": "ImageObject", "url": "https://molecule.ai/logo.png" }
+  }
+}
+</script>
+
+# Govern Your AI Fleet at the System Prompt Level
+
+The moment an AI agent goes into production, the governance question stops being theoretical. Which tools can it call? What data can it write to? Are there constraints that apply to every turn, not just the ones where someone remembered to add a guardrail?
+
+Most platforms answer these questions with post-hoc filtering — a rule that checks outputs after the agent has already decided what to do. Platform Instructions takes a different approach: governance at the source, before the first token is generated. Rules are prepended to the system prompt at workspace startup, shaping what the agent is instructed to do from the very first turn.
+
+## Two Scopes, One Governance Plane
+
+Platform Instructions supports two scoping levels:
+
+- **Global** — applied to every workspace in your organization. One rule, enforced everywhere.
+- **Workspace** — applied to a specific workspace only. Fine-grained control without global impact.
+
+When a workspace starts, Molecule AI resolves all applicable instructions — combining global rules with workspace-specific ones — and prepends them to the agent's system prompt. The agent doesn't receive these rules as a filter; it receives them as part of its core instruction set. That distinction matters: a filter can be worked around; a system prompt instruction shapes the agent's reasoning from the ground up.
+
+## The CRUD API
+
+Platform Instructions are managed via a REST API:
+
+```bash
+# Create a global instruction
+POST /instructions
+{
+  "scope": "global",
+  "content": "Before invoking any tool that writes to external storage, confirm the target path is within the org-approved sandbox directory. Reject and report if not."
+}
+
+# Create a workspace-scoped instruction
+POST /instructions
+{
+  "scope": "workspace",
+  "workspace_id": "ws_01HXKM3T8PRQN4ZW7XYVD2EJ5A",
+  "content": "This workspace handles customer PII. Redact all PII fields in tool outputs before writing to external systems."
+}
+
+# Retrieve resolved instructions for a workspace
+GET /workspaces/ws_01HXKM3T8PRQN4ZW7XYVD2EJ5A/instructions/resolve
+Authorization: Bearer <workspace_token>
+```
+
+The resolve endpoint is gated by `wsAuth` — the calling workspace's own token. Workspaces cannot enumerate or retrieve instructions belonging to other workspaces. There is no cross-workspace read-back. Global instructions are org-scoped and visible to org admins.
+
+Each instruction is capped at **8KB** of content. A workspace's total resolved instruction set (global + workspace-scoped) is fetched once at startup and cached — so governance is enforced without per-turn latency overhead.
+
+## Enforcement Before Execution
+
+The key architectural difference between Platform Instructions and post-hoc policy enforcement is timing. A post-hoc filter evaluates after the agent decides what to do. Platform Instructions are in the system prompt before the agent decides anything.
+
+This matters in regulated environments where the requirement isn't "flag bad behavior" but "prevent bad behavior from being possible." A compliance team that requires PII redaction doesn't want the agent to write raw PII and then redact it on the way out — they want the agent to reason about redaction as part of its core task framing.
+
+With Platform Instructions, the rule isn't a gate. It's a context.
+
+## Enterprise Security: ACLs and Access Control
+
+Platform Instructions are enterprise-only because enterprise governance requires enterprise-grade access control. The security model reflects this:
+
+- **Global instructions** are managed by org admins — not workspace owners
+- **Workspace instructions** are managed by workspace admins within their own scope
+- **Resolve endpoint** requires `wsAuth` — a workspace cannot retrieve another workspace's resolved instructions
+- **No cross-workspace enumeration** — the API does not expose instruction lists to callers outside the owning scope
+
+For security and IT governance teams evaluating AI agent platforms, this is the access control surface they need: policy lives at the org level, is enforced at the workspace level, and cannot be read or modified by the agents or workspaces it governs.
+
+## Get Started
+
+Platform Instructions are available on **Enterprise plans**. To get started:
+
+- Contact your account team or visit your workspace settings
+- Define your first global instruction via `POST /instructions`
+- Assign workspace-scoped instructions to specific workspaces via `POST /instructions` with `workspace_id`
+- Verify resolved instructions via `GET /workspaces/{id}/instructions/resolve`
+
+For a complete governance picture, combine Platform Instructions with [Tool Trace](/docs/blog/ai-agent-observability-without-overhead/) — see exactly which tools were called and what inputs were passed, alongside the policy that governed them.
+
+---
+
+*Molecule AI is open source. Platform Instructions shipped in Phase 34 (2026-04-23). Enterprise plans include org-scoped governance, wsAuth-gated resolve endpoints, and full instruction audit logs.*

--- a/docs/blog/2026-04-23-platform-instructions-governance/index.md
+++ b/docs/blog/2026-04-23-platform-instructions-governance/index.md
@@ -5,7 +5,6 @@ slug: govern-ai-fleet-system-prompt-level
 description: "Platform Instructions lets enterprise IT teams enforce org-wide policy rules at the system prompt level — before the first agent turn executes. No code deploys. No SDK integration."
 og_title: "Govern Your AI Fleet at the System Prompt Level"
 og_description: "Platform Instructions: global and workspace-scoped rules prepended to the system prompt. Governance before the first turn, not after."
-og_image: /docs/assets/blog/2026-04-23-platform-instructions-governance-og.png
 tags: [governance, platform-instructions, enterprise, security, it-governance, system-prompt, policy, a2a]
 keywords: [AI fleet governance, enterprise AI policy, system prompt governance, AI agent compliance, platform instructions, workspace policy enforcement, enterprise AI security, AI agent ACL]
 canonical: https://docs.molecule.ai/blog/govern-ai-fleet-system-prompt-level
@@ -99,7 +98,7 @@ Platform Instructions are available on **Enterprise plans**. To get started:
 - Assign workspace-scoped instructions to specific workspaces via `POST /instructions` with `workspace_id`
 - Verify resolved instructions via `GET /workspaces/{id}/instructions/resolve`
 
-For a complete governance picture, combine Platform Instructions with [Tool Trace](/docs/blog/ai-agent-observability-without-overhead/) — see exactly which tools were called and what inputs were passed, alongside the policy that governed them.
+For a complete governance picture, combine Platform Instructions with [Tool Trace](/blog/ai-agent-observability-without-overhead/) — see exactly which tools were called and what inputs were passed, alongside the policy that governed them.
 
 ---
 

--- a/docs/blog/2026-04-23-tool-trace-observability/index.md
+++ b/docs/blog/2026-04-23-tool-trace-observability/index.md
@@ -5,7 +5,6 @@ slug: ai-agent-observability-without-overhead
 description: "Tool Trace gives every A2A response a structured record of every tool call — inputs, output previews, run_id-paired parallel traces. No sampling, no sidecar, no guesswork."
 og_title: "AI Agent Observability Without the Overhead"
 og_description: "See every tool your agent called — inputs, outputs, timing — in every A2A response. Parallel traces handled correctly. No sampling overhead."
-og_image: /docs/assets/blog/2026-04-23-tool-trace-observability-og.png
 tags: [observability, tool-trace, debugging, devops, platform-engineering, a2a, claude]
 keywords: [AI agent observability, tool trace debugging, Claude agent debugging, agent audit trail, parallel tool call trace, run_id pairing, AI agent monitoring, DevOps agent observability]
 canonical: https://docs.molecule.ai/blog/ai-agent-observability-without-overhead

--- a/docs/blog/2026-04-23-tool-trace-observability/index.md
+++ b/docs/blog/2026-04-23-tool-trace-observability/index.md
@@ -1,0 +1,113 @@
+---
+title: "AI Agent Observability Without the Overhead"
+date: 2026-04-23
+slug: ai-agent-observability-without-overhead
+description: "Tool Trace gives every A2A response a structured record of every tool call — inputs, output previews, run_id-paired parallel traces. No sampling, no sidecar, no guesswork."
+og_title: "AI Agent Observability Without the Overhead"
+og_description: "See every tool your agent called — inputs, outputs, timing — in every A2A response. Parallel traces handled correctly. No sampling overhead."
+og_image: /docs/assets/blog/2026-04-23-tool-trace-observability-og.png
+tags: [observability, tool-trace, debugging, devops, platform-engineering, a2a, claude]
+keywords: [AI agent observability, tool trace debugging, Claude agent debugging, agent audit trail, parallel tool call trace, run_id pairing, AI agent monitoring, DevOps agent observability]
+canonical: https://docs.molecule.ai/blog/ai-agent-observability-without-overhead
+---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "AI Agent Observability Without the Overhead",
+  "description": "Tool Trace gives every A2A response a structured record of every tool call — inputs, output previews, run_id-paired parallel traces. No sampling, no sidecar, no guesswork.",
+  "author": { "@type": "Organization", "name": "Molecule AI" },
+  "datePublished": "2026-04-23",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Molecule AI",
+    "logo": { "@type": "ImageObject", "url": "https://molecule.ai/logo.png" }
+  }
+}
+</script>
+
+# AI Agent Observability Without the Overhead
+
+Debugging a running agent in production is still, for most platforms, an exercise in inference. You get the final output. You don't get the tool calls that produced it — the `Write` that created the file, the `Bash` that ran the build, the `Grep` that found the bug. When something breaks, you're working backward from the symptom instead of forward from the cause.
+
+Tool Trace changes that. Every A2A response from Molecule AI now includes a `tool_trace` array in `Message.metadata` — a structured, chronological record of every tool the agent invoked, the inputs passed to it, and a preview of the output. No sampling. No sidecar collector. No guesswork.
+
+## What Tool Trace Captures
+
+Each trace entry contains:
+
+- **`tool`** — the tool name (e.g. `Write`, `Bash`, `Grep`)
+- **`input`** — the exact parameters passed to the tool call
+- **`output_preview`** — the first ~200 characters of the result, keeping traces readable at scale
+- **`run_id`** — groups start/end events so concurrent calls are traced independently
+
+Entries are written to `activity_logs.tool_trace` as JSONB, making them queryable in your existing log infrastructure.
+
+```json
+{
+  "metadata": {
+    "tool_trace": [
+      {
+        "tool": "Bash",
+        "input": {
+          "command": "go build ./... && go test ./...",
+          "description": "Build and test full Go project"
+        },
+        "output_preview": "ok      auth    0.314s\nok      config  0.201s\nok      server  0.487s\n--- PASS: TestIntegration (12.3s)"
+      },
+      {
+        "tool": "Write",
+        "input": {
+          "file_path": "/workspace/coverage/report.json",
+          "content": "{\"total\": 94.2, \"files\": {...}}"
+        },
+        "output_preview": "Wrote 2.1 KB to /workspace/coverage/report.json"
+      },
+      {
+        "tool": "Read",
+        "input": {
+          "file_path": "/workspace/coverage/report.json"
+        },
+        "output_preview": "Read 2.1 KB from /workspace/coverage/report.json"
+      }
+    ],
+    "run_id": "01HXKM3T8PRQN4ZW7XYVD2EJ5A"
+  }
+}
+```
+
+The trace is capped at 200 entries per response. For most agent turns, that's more than enough. For long-running tasks that generate hundreds of tool calls, the cap ensures payload size stays predictable.
+
+## Parallel Calls: Traced Correctly
+
+The hardest part of agent observability isn't capturing one tool call — it's capturing several that happened at the same time without losing track of which did what.
+
+Tool Trace handles parallel calls via `run_id` pairing. When the agent fires two or more tool calls concurrently in a single turn, each entry carries the same `run_id`. Start and end events are matched by that identifier. The result is an independent, unambiguous trace for each concurrent call rather than a merged log line that obscures which tool returned what.
+
+This matters when you're debugging an agent that called `Bash` and `Write` simultaneously and one of them failed silently. With `run_id`-paired traces, you can isolate exactly which call failed and what it received as input.
+
+## Built In, Not Bolt-On
+
+Most observability solutions for AI agents require instrumentation — a tracing SDK, a sidecar collector, a log aggregation pipeline. Tool Trace ships in the A2A response itself. If you're already receiving A2A responses from your agent, you already have the trace. No new infrastructure, no sampling configuration, no agent restart.
+
+For platform engineering teams that need to monitor agent behavior across a fleet — which tools are being called, which inputs are being passed, which outputs are being produced — Tool Trace provides the raw material without the operational overhead.
+
+## Enterprise-Grade Auditability
+
+Combined with the [org-scoped API key audit trail](/docs/blog/2026-04-21-org-scoped-api-keys/) from Phase 30, Tool Trace closes the last gap in agent observability: you can now trace a production incident from the org API key that authorized the call, through the workspace and agent that executed it, to every tool that ran and what it returned.
+
+**Tool Trace is available on all Molecule AI plans.** It is enabled by default — check `Message.metadata.tool_trace` in your A2A responses.
+
+---
+
+## Get Started
+
+- Inspect `Message.metadata.tool_trace` in any A2A response
+- Query `activity_logs.tool_trace` JSONB for historical traces
+- Combine with org API key attribution for complete fleet observability
+- Read the [A2A protocol documentation](/docs/api-protocol/a2a-protocol.md)
+
+---
+
+*Molecule AI is open source. Tool Trace shipped in Phase 34 (2026-04-23).*

--- a/docs/blog/2026-04-23-tool-trace-platform-instructions/index.md
+++ b/docs/blog/2026-04-23-tool-trace-platform-instructions/index.md
@@ -1,0 +1,124 @@
+---
+title: "Tool Trace + Platform Instructions: Full Visibility and Policy-Level Governance"
+date: 2026-04-23
+slug: tool-trace-platform-instructions
+description: "See every tool your agent called — inputs, outputs, timing — in real-time. And enforce org-wide governance policy at the system prompt level with Platform Instructions."
+og_title: "Tool Trace + Platform Instructions: Full Visibility and Policy-Level Governance"
+og_description: "Tool-level observability in every A2A response meets system-prompt governance. Two enterprise-grade features, shipped together."
+og_image: /docs/assets/blog/2026-04-23-tool-trace-platform-instructions-og.png
+tags: [tool-trace, observability, platform-instructions, governance, enterprise, debugging, a2a]
+keywords: [AI agent debugging, tool trace observability, agent governance, platform instructions, enterprise AI audit, system prompt governance, Claude tool call visibility, agent observability]
+canonical: https://docs.molecule.ai/blog/tool-trace-platform-instructions
+---
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Tool Trace + Platform Instructions: Full Visibility and Policy-Level Governance",
+  "description": "See every tool your agent called — inputs, outputs, timing — in real-time. And enforce org-wide governance policy at the system prompt level.",
+  "author": { "@type": "Organization", "name": "Molecule AI" },
+  "datePublished": "2026-04-23",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Molecule AI",
+    "logo": { "@type": "ImageObject", "url": "https://molecule.ai/logo.png" }
+  }
+}
+</script>
+
+# Tool Trace + Platform Instructions: Full Visibility and Policy-Level Governance
+
+When an agent makes a tool call in production, most platforms show you the result. They don't show you *which* tool was called, with *what inputs*, what it *returned*, and whether a parallel call happened at the same time. That gap is where debugging ends and guessing begins.
+
+Today we're shipping two features that close it: **Tool Trace** and **Platform Instructions**.
+
+Tool Trace gives every A2A response a structured, chronological record of every tool the agent called — including inputs, output previews, and timing metadata — so you can step through an agent's reasoning the same way you'd step through a debugger. Platform Instructions gives your platform team a governance layer that sits at the system prompt level: configurable rules, scoped globally or per-workspace, enforced before every agent turn.
+
+Together, they address the two questions enterprise teams ask first when evaluating an AI agent platform: *what did the agent actually do?* and *can we enforce policy at the platform level?*
+
+## Tool Trace: Every Tool Call, Captured
+
+Tool Trace is now embedded in every A2A response via `Message.metadata.tool_trace`. Each entry records the tool name, the input passed to it, and an `output_preview` (the first ~200 characters of the result, so the trace stays readable at scale). Entries are stored in the `activity_logs.tool_trace` JSONB column, making them queryable.
+
+Parallel tool calls — multiple tools invoked simultaneously in a single agent turn — are handled correctly via `run_id` pairing of start and end events. This means you can trace two concurrent tool calls independently rather than seeing them collapsed into a single ambiguous log line.
+
+The trace is capped at 200 entries per response to keep payload sizes manageable.
+
+```json
+{
+  "tool_trace": [
+    {
+      "tool": "Write",
+      "input": {
+        "file_path": "/workspace/src/auth.go",
+        "content": "package auth\n\nimport \"crypto/rand\"\n\nfunc GenerateToken() (string, error) { ..."
+      },
+      "output_preview": "Wrote 847 bytes to /workspace/src/auth.go"
+    },
+    {
+      "tool": "Bash",
+      "input": {
+        "command": "go build ./...",
+        "description": "Verify Go package compiles"
+      },
+      "output_preview": "Build succeeded. 0 errors, 0 warnings."
+    },
+    {
+      "tool": "Grep",
+      "input": {
+        "pattern": "TODO.*governance",
+        "glob": "**/*.go",
+        "output_mode": "content"
+      },
+      "output_preview": "auth.go:14 // TODO: governance layer check\nauth_test.go:8 // TODO: add governance test"
+    }
+  ],
+  "run_id": "01HXKM3...7TQZN"
+}
+```
+
+## Platform Instructions: Governance at the System Prompt Level
+
+Tool Trace tells you what the agent *did*. Platform Instructions let you define what it *should* do before it does it.
+
+Platform Instructions are configurable rules with two scopes:
+
+- **Global** — applied to every workspace in your organization
+- **Workspace** — applied to a specific workspace only
+
+They are fetched at workspace startup and prepended directly to the system prompt. This means they govern agent behavior *before* the first turn executes, not as a post-hoc filter — they shape what the agent is instructed to do in the first place.
+
+A CRUD API manages instruction lifecycle:
+
+```
+GET    /instructions              # list (global only, org-scoped)
+POST   /instructions              # create (global or workspace)
+PUT    /instructions/{id}
+DELETE /instructions/{id}
+GET    /workspaces/{id}/instructions/resolve  # fetch for a workspace (wsAuth-gated)
+```
+
+The resolve endpoint is gated by `wsAuth` — the calling workspace's own token. There is no cross-workspace enumeration: a workspace can only retrieve its own resolved instructions. The content cap is 8KB per instruction.
+
+## Enterprise Governance: Policy in Production
+
+The combination of Tool Trace and Platform Instructions creates a complete governance loop.
+
+**Write the policy once. Enforce it everywhere.**
+
+For regulated industries, Platform Instructions means your security team defines data handling rules — say, a global instruction that every agent in the `customer-data` workspace must redact PII before writing to any external tool — and it applies at the system prompt level, automatically, on every agent turn, without a code deploy.
+
+When something goes wrong — an agent calls an unexpected tool, or behavior drifts from the system prompt — Tool Trace gives you the forensic record to understand exactly what happened. Paired with the org API key attribution from Phase 30's audit trail, you can reconstruct the complete chain: *which org key, which workspace, which agent, which tool calls, in what order.*
+
+**Platform Instructions are enterprise-only.** Tool Trace is available on all plans.
+
+## Get Started
+
+- Tool Trace is enabled by default on all workspaces. Check `Message.metadata.tool_trace` in your A2A responses.
+- Platform Instructions are available on Enterprise plans. Visit your workspace settings or contact your account team.
+- Explore the full A2A protocol documentation in `docs/api-protocol/a2a-protocol.md`.
+
+---
+
+*Molecule AI is open source. Tool Trace and Platform Instructions shipped in Phase 34 (2026-04-23).*

--- a/docs/blog/2026-04-23-tool-trace-platform-instructions/index.md
+++ b/docs/blog/2026-04-23-tool-trace-platform-instructions/index.md
@@ -5,7 +5,6 @@ slug: tool-trace-platform-instructions
 description: "See every tool your agent called — inputs, outputs, timing — in real-time. And enforce org-wide governance policy at the system prompt level with Platform Instructions."
 og_title: "Tool Trace + Platform Instructions: Full Visibility and Policy-Level Governance"
 og_description: "Tool-level observability in every A2A response meets system-prompt governance. Two enterprise-grade features, shipped together."
-og_image: /docs/assets/blog/2026-04-23-tool-trace-platform-instructions-og.png
 tags: [tool-trace, observability, platform-instructions, governance, enterprise, debugging, a2a]
 keywords: [AI agent debugging, tool trace observability, agent governance, platform instructions, enterprise AI audit, system prompt governance, Claude tool call visibility, agent observability]
 canonical: https://docs.molecule.ai/blog/tool-trace-platform-instructions

--- a/docs/marketing/briefs/2026-04-22-phase30-pmm-positioning.md
+++ b/docs/marketing/briefs/2026-04-22-phase30-pmm-positioning.md
@@ -1,0 +1,103 @@
+# Phase 30 PMM Positioning — Response to SEO Brief #1126 Questions
+
+> **Context:** SEO Analyst filed brief #1126 for Remote Workspaces campaign. Acceptance criteria specified "Coordinate with PMM (issue #1116) on positioning language." PMM Slack: "Phase 30 position holding." No PMM response received yet. Content Marketer answers based on approved copy + internal/product docs.
+> **Author:** Content Marketer (self-prompted — no PMM input available this cycle)
+> **Date:** 2026-04-22
+> **Status:** DRAFT — for PMM review before social copy goes live
+
+---
+
+## Q1: Primary message — "One canvas, every agent" or "Deploy agents anywhere"?
+
+**Recommendation:** Both — layered approach:
+
+- **Headline (social/digital):** "One canvas, every agent." — fleet visibility is the emotional hook. It's visually true (the Canvas shows the whole org) and differentiated (competitors don't have this).
+- **Sub-message (docs/SEO):** "Deploy agents anywhere, manage them from one place." — deployment flexibility is the practical hook for the informational/search audience.
+
+**Rationale from internal/product/overview.md:** Molecule AI's primary abstraction is the *workspace role*, not a task graph. The canvas shows that clearly. Social copy should lead with that differentiator. SEO content should lead with the practical deployment flexibility.
+
+**Approved social copy confirms this:**
+- Fly Deploy Anywhere: leads with deployment flexibility (three backends, one config change)
+- Remote Workspaces social copy: leads with fleet visibility ("Your whole agent team, on one canvas")
+- Org API Keys: leads with operational control (audit trail, revocation)
+
+---
+
+## Q2: Competitive framing — LangChain Agents, CrewAI, OpenAI agent SDK?
+
+**Positioning lines that hold:**
+
+1. **"Runtime agnostic by design"** — LangChain and CrewAI are tied to their own graph/DAG execution model. Molecule AI workspaces run LangGraph, Claude Code, CrewAI, AutoGen, OpenClaw, DeepAgents behind the same workspace contract. Approved copy across 8 campaigns confirms this is real.
+
+2. **"A2A is solved. A2A governance is not."** — A2A Enterprise approved copy leads with this frame. LangGraph shipped A2A client (PRs #6645 and #7113) but has no audit trail, no org attribution, no revocation. This is the clearest competitive gap.
+
+3. **"Fleet visibility by default"** — Canvas shows the org chart. No competitor has this out of the box.
+
+**Do NOT say:**
+- "better than [competitor]" without data
+- benchmark numbers — none are confirmed
+- "only platform with X" unless sourced
+
+**LangGraph specific (from A2A Enterprise approved copy):**
+- Factual only: "LangGraph ADR validates that A2A is becoming table stakes." — don't spin this as criticism.
+- Attribution: cite PR numbers (#6645, #7113) — these are public facts.
+
+---
+
+## Q3: Primary audience — infra lead, developer, or platform team?
+
+**Split by channel:**
+
+| Channel | Primary audience | Why |
+|---------|-----------------|-----|
+| X (social) | Platform engineers, DevOps | Operational pain (Admin_token rotation, CI/CD integration) |
+| LinkedIn | Enterprise AI leads, CTOs | Governance, audit trail, org-scale control |
+| SEO/docs | Developers, infra teams | How-to, self-hosted setup, remote agent registration |
+| Blog | Evaluators, technical decision-makers | Comprehensive feature + differentiation |
+
+**From internal/product/overview.md:** Molecule AI targets teams running heterogeneous agent fleets. The buyer is a platform lead or infra engineer who needs to manage agents across environments.
+
+---
+
+## Q4: Pricing/availability — all tiers or specific plan?
+
+**Positioning depends on what is actually GA:**
+
+- Phase 30 workspaces (remote agents, bearer tokens, A2A) — **GA as of 2026-04-20** per phase30-launch-calendar.md
+- Phase 32 cloud SaaS (Stripe Atlas billing) — **IN PROGRESS**, load test pending, ~2wk lead on Atlas
+- Phase 33 — **NOT LOCKED**, no GA date confirmed
+
+**Safe CTA language (confirmed GA only):**
+- "Workspaces on Docker, Fly Machines, or your own cloud — same agent code"
+- "Org API keys. Audit trail. Instant revocation."
+- "Every Molecule AI workspace is an A2A server."
+
+**Do NOT say:**
+- "available on all plans" — this hasn't been confirmed by PM
+- specific pricing tiers
+- "Phase 33 ships next" — date not locked
+
+---
+
+## Q5: Campaign coordination — any spacing or sequencing rules?
+
+**From approved social copy + posting-guide.md:**
+
+| Day | Campaign | Don't post same day as |
+|-----|----------|----------------------|
+| Apr 21 | Chrome DevTools MCP | Fly Deploy Anywhere |
+| Apr 22 | Discord Adapter Day 2 (Reddit/HN) | — |
+| Apr 23 | Org API Keys | — |
+| Apr 23 | A2A Enterprise | — |
+| Apr 24 | EC2 Instance Connect SSH | — |
+| Apr 25 | MCP Server List | — |
+| Apr 17+ | Fly Deploy Anywhere | Chrome DevTools MCP Day 1 |
+
+**Cross-campaign links (intentional stacking):**
+- Discord Adapter → links to Org API Keys (shared governance/A2A theme)
+- Fly Deploy Anywhere → naturally cross-links to Chrome DevTools MCP (both self-hosted angle)
+- EC2 Instance Connect SSH → platform engineering audience, stacks with Org API Keys
+
+---
+
+*Content Marketer — 2026-04-22. PMM to review and confirm or revise before social copy is finalized.*

--- a/docs/marketing/briefs/2026-04-22-phase32-observability-angle-brief.md
+++ b/docs/marketing/briefs/2026-04-22-phase32-observability-angle-brief.md
@@ -1,0 +1,83 @@
+# Phase 32 SaaS — Observability Angle Brief (Content Marketer)
+**Date:** 2026-04-22
+**Status:** DRAFT — for future social copy when Phase 32 GA is confirmed
+**Context:** Social Media Brand flagged this angle from PLAN.md. Phase 32 is still hardening — not ready to post.
+
+---
+
+## The Observability Story
+
+Phase 32 ships Molecule AI as a multi-tenant cloud SaaS. The observability layer built into the platform is a genuine enterprise differentiator — it's not an add-on, it's structural.
+
+**What makes this worth a campaign:**
+1. Every cross-agent A2A call is logged (Phase 30.5 — in prod since Apr 20)
+2. Activity logs capture: caller, callee, method, timestamp, result, error detail
+3. `/traces` endpoint surfaces Langfuse traces per workspace (Phase 10 — since Phase 10)
+4. Token-level attribution: `org:keyId` prefix on every API call (Phase 30 / Org API Keys)
+5. Admin observability: `/events` endpoint, per-workspace activity, delegation history
+
+**The positioning frame:**
+> "When something goes wrong in your agent team, can you answer: which agent did what, when, and with what result?"
+
+Most agent platforms can't answer this. Molecule AI built the answer into the platform from Phase 10 onward.
+
+---
+
+## What's Confirmed GA (post to this)
+
+| Feature | Phase | GA Date |
+|---------|-------|---------|
+| Activity logs (A2A + task + error) | Phase 10 | Shipped |
+| Langfuse traces per workspace | Phase 10 | Shipped |
+| Token attribution (`org:keyId`) | Phase 30 | 2026-04-20 |
+| Audit log export | Org API Keys | Live on staging |
+| `/traces` endpoint | Phase 10 | Shipped |
+
+---
+
+## Phase 32-Specific (not GA until hardening complete)
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| CloudTrail records for EC2 Instance Connect | ✅ Shipped | AWS-native, per-workspace |
+| Per-tenant resource quotas | ⏳ Phase G | Observability → control loop |
+| Langfuse on cloud SaaS | ⏳ Phase G | observability + quotas |
+| Status page custom domain | ⏳ Phase H | `status.moleculesai.app` pending |
+| Load test | ⏳ Phase H | Before external user launch |
+
+---
+
+## Do NOT Post Until
+
+- Load test complete
+- Stripe Atlas (~2wk lead) — social gate per phase30-launch-plan.md
+- Status page live at custom domain
+- These confirmed by PM
+
+---
+
+## Draft Social Frame (for when Phase 32 clears)
+
+**Hook:** "Your AI agent team just did something. Can you prove it?"
+
+**Post 1 (the problem):**
+Most AI agent platforms give you zero visibility into what your agents actually did.
+No logs. No traces. No audit trail.
+When something goes wrong, you're debugging blind.
+
+**Post 2 (what Molecule AI ships):**
+Every cross-agent call logged.
+Every API call attributed to an org key.
+Every trace visible in Langfuse.
+Workspace-level activity logs. Admin-level event export.
+
+If your compliance team asks "which agent touched what," you can answer from the platform — not from guessing.
+
+**Post 3 (EC2 Instance Connect + observability):**
+Molecule AI's Terminal tab routes through AWS EC2 Instance Connect Endpoint.
+The session is AWS-signed, ephemeral, and CloudTrail-recorded.
+Your platform team gets a shell. Your security team gets the audit log. Same tool.
+
+---
+
+*Content Marketer — 2026-04-22. Not ready to publish until Phase 32 hardening complete.*


### PR DESCRIPTION
## Summary

Clean-branch replacement for #1793 which had 156-file bloat from stale branch drift.

Cherry-picked 2 commits onto fresh staging — 6 new files, +666 lines, purely additive:

- `docs/blog/2026-04-23-partner-api-keys.md` — partner-gated MCP access for enterprise teams
- `docs/blog/2026-04-23-platform-instructions-governance/index.md` — org-scoped AI instruction governance
- `docs/blog/2026-04-23-tool-trace-observability/index.md` — debug/audit AI agent decision trees
- `docs/blog/2026-04-23-tool-trace-platform-instructions/index.md` — cross-post
- `docs/marketing/briefs/2026-04-22-phase30-pmm-positioning.md` — PMM positioning
- `docs/marketing/briefs/2026-04-22-phase32-observability-angle-brief.md` — observability angle

No existing files modified. og_image refs already stripped (images TBD).

Closes #1793 — supersedes it.