### PR TITLE
ci: auto-retarget bot PRs opened against main → staging

### DIFF
--- a/.github/workflows/retarget-main-to-staging.yml
+++ b/.github/workflows/retarget-main-to-staging.yml
@@ -1,0 +1,63 @@
+name: Retarget main PRs to staging
+
+# Mechanical enforcement of SHARED_RULES rule 8 ("Staging-first workflow, no
+# exceptions"). When a bot opens a PR against main, retarget it to staging
+# automatically and leave an explanatory comment. Human CEO-authored PRs (the
+# staging→main promotion PR, etc.) are left alone — they're the authorised
+# exception to the rule.
+#
+# Why an Action instead of only a prompt rule: prompt rules depend on every
+# role's system-prompt.md staying in sync. Today 5 of 8 engineer roles
+# (core-be, core-fe, app-fe, app-qa, devops-engineer) don't have the
+# staging-first section — the bot keeps opening PRs to main. An Action
+# enforces the invariant regardless of prompt drift.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  retarget:
+    name: Retarget to staging
+    runs-on: ubuntu-latest
+    # Only fire for bot-authored PRs. Human CEO PRs (staging→main promotion)
+    # are intentional and pass through.
+    if: >-
+      github.event.pull_request.user.type == 'Bot'
+      || endsWith(github.event.pull_request.user.login, '[bot]')
+      || github.event.pull_request.user.login == 'app/molecule-ai'
+      || github.event.pull_request.user.login == 'molecule-ai[bot]'
+    steps:
+      - name: Retarget PR base to staging
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          echo "Retargeting PR #${PR_NUMBER} (author: ${PR_AUTHOR}) from main → staging"
+          gh api -X PATCH \
+            "repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
+            -f base=staging \
+            --jq '.base.ref'
+
+      - name: Post explainer comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --body "$(cat <<'BODY'
+          [retarget-bot] This PR was opened against `main` and has been retargeted to `staging` automatically.
+
+          **Why:** per [SHARED_RULES rule 8](https://github.com/Molecule-AI/molecule-ai-org-template-molecule-dev/blob/main/SHARED_RULES.md), all feature work targets `staging` first; the CEO promotes `staging → main` separately.
+
+          **What changed:** just the base branch — no code change. CI will re-run against `staging`. If you get merge conflicts, rebase on `staging`.
+
+          **If this PR is the CEO's staging→main promotion:** the Action skipped you (only bot-authored PRs are retargeted). If you see this comment on your CEO PR, that's a bug — please tag @HongmingWang-Rabbit.
+          BODY
+          )"


### PR DESCRIPTION
[molecule-platform-evolvement-manager-agent]

## Problem

Bot PRs keep being opened against \`main\` despite SHARED_RULES rule 8 \"Staging-first workflow, no exceptions.\"

**Today's evidence:** I retargeted **17 bot PRs** to staging across 7 maintenance cycles. Two more appeared in the 15-minute window between cycles 39 and 40. The retarget cost is ~30 seconds per PR but the SIGNAL — that the rule isn't being followed mechanically — is what matters.

## Root cause

Audit of \`molecule-ai-org-template-molecule-dev\` engineer role prompts:

| Role | Has \`gh pr create --base staging\` rule? |
|---|---|
| backend-engineer | ✅ |
| frontend-engineer | ✅ |
| **core-be** | **❌** |
| **core-fe** | **❌** |
| **app-fe** | **❌** |
| **app-qa** | **❌** |
| **devops-engineer** | **❌** |

The newer per-team specialised roles forked from older generalists without the staging-first section. Five roles don't have the rule in their prompt and therefore default to whatever \`gh pr create\` does naturally — which is \`base=main\` if main is the default branch.

## Fix — mechanical Action

\`\`\`yaml
on:
  pull_request_target:
    types: [opened, reopened]
    branches: [main]
\`\`\`

Fires on every PR opened against \`main\`. If author is a bot, retargets to staging via \`gh api PATCH .../pulls/N -f base=staging\` and posts an explainer comment. Human-authored PRs (CEO's staging→main promotion) pass through untouched.

## Why an Action instead of just fixing prompts

Two reasons:
1. **Prompt drift is inevitable.** Today 5 of 8 roles are missing the rule; tomorrow a new role gets added and likely will too. The Action enforces the invariant regardless.
2. **\`pull_request_target\` runs with repo-level write tokens** so it can self-modify the PR — no per-bot token configuration needed. The retarget happens within seconds of the PR being opened.

## Tradeoffs

- **Author detection might miss new bot identities** — currently checks \`user.type=='Bot'\` OR ends with \`[bot]\` OR equals \`app/molecule-ai\` / \`molecule-ai[bot]\`. If we add a new GitHub App identity (e.g. \`triage-bot\`), I'll need to extend the \`if:\` clause. Alternatively switch to \"if NOT human\" detection but that's more error-prone.
- **One race condition**: between the PR being opened and the Action firing, CI may have started running against \`main\` baseline. After retarget, CI re-runs against staging. Cost: a few wasted CI minutes per PR. Cheaper than my manual time + human attention.

## Follow-up (not in this PR)

- Add the staging-first section to the 5 missing role prompts in \`molecule-ai-org-template-molecule-dev\`. Even with the Action live, documenting in the prompt helps agents learn the convention rather than learning by being corrected.
- Filing as a follow-up issue on the standalone template repo.

## Test plan

- [ ] Action fires the next time a bot opens a PR against main (~next cycle, given today's rate)
- [ ] Action does NOT fire when CEO opens the staging→main promotion PR
- [ ] Explainer comment posts cleanly
- [ ] Retargeted PR's CI re-runs against staging baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)