### PR TITLE
fix(provisioner): auto-recover from empty config volume on restart (#1858)

### DIFF
--- a/workspace-server/internal/handlers/workspace_provision.go
+++ b/workspace-server/internal/handlers/workspace_provision.go
@@ -143,27 +143,61 @@ func (h *WorkspaceHandler) provisionWorkspaceOpts(workspaceID, templatePath stri
 	cfg := h.buildProvisionerConfig(workspaceID, templatePath, configFiles, payload, envVars, pluginsPath, awarenessNamespace)
 	cfg.ResetClaudeSession = resetClaudeSession // #12
 
-	// Preflight #17: refuse to start a container we already know will crash on missing config.yaml.
-	// When the caller supplies neither a template dir nor in-memory configFiles (the auto-restart
-	// path), probe the existing Docker named volume. If it's empty/missing config.yaml, mark the
-	// workspace 'failed' instead of handing it to Docker's unless-stopped restart policy, which
-	// would otherwise loop forever on FileNotFoundError.
+	// Preflight #17: detect + auto-recover the "empty config volume" crashloop.
+	//
+	// When the caller supplies neither a template dir nor in-memory configFiles
+	// (the auto-restart path), probe the existing Docker named volume. If the
+	// volume is empty / missing config.yaml, we can't just hand the container
+	// to Docker's unless-stopped restart policy — molecule-runtime will crash
+	// on FileNotFoundError and loop forever.
+	//
+	// Before #1858: bail out and mark the workspace 'failed'. Required operator
+	// intervention (manual `docker run --rm -v <vol>:/configs -v <tmpl>:/src
+	// alpine cp -r /src/. /configs/`).
+	//
+	// After #1858: attempt recovery by resolving the workspace's runtime-default
+	// template from h.configsDir (same path the Restart handler uses for
+	// apply_template=true) and wiring it in. The volume will be rewritten from
+	// the template on container start, same as first-provision. Only if the
+	// recovery template itself is missing do we bail.
 	if srcErr := provisioner.ValidateConfigSource(templatePath, configFiles); srcErr != nil {
 		hasConfig, probeErr := h.provisioner.VolumeHasFile(ctx, workspaceID, "config.yaml")
 		if probeErr != nil {
 			log.Printf("Provisioner: config.yaml preflight probe failed for %s: %v (proceeding)", workspaceID, probeErr)
 		} else if !hasConfig {
-			msg := fmt.Sprintf("cannot start workspace %s: no config.yaml source and config volume is empty — delete the workspace or provide a template", workspaceID)
-			log.Printf("Provisioner: %s", msg)
-			if _, dbErr := db.DB.ExecContext(ctx,
-				`UPDATE workspaces SET status = 'failed', last_sample_error = $2, updated_at = now() WHERE id = $1`,
-				workspaceID, msg); dbErr != nil {
-				log.Printf("Provisioner: failed to mark workspace %s as failed: %v", workspaceID, dbErr)
+			// Try to recover by applying the runtime-default template. payload.Runtime
+			// is populated by the caller (Restart handler / Create handler) from the
+			// DB row — same source of truth the apply_template=true path uses.
+			recovered := false
+			if payload.Runtime != "" {
+				runtimeTemplate := filepath.Join(h.configsDir, payload.Runtime+"-default")
+				if _, statErr := os.Stat(runtimeTemplate); statErr == nil {
+					log.Printf("Provisioner: auto-recover for %s — config volume empty, applying %s-default template (#1858)",
+						workspaceID, payload.Runtime)
+					templatePath = runtimeTemplate
+					// Rebuild cfg with the recovered template path so Start() sees it.
+					cfg = h.buildProvisionerConfig(workspaceID, templatePath, configFiles, payload, envVars, pluginsPath, awarenessNamespace)
+					cfg.ResetClaudeSession = resetClaudeSession
+					recovered = true
+				} else {
+					log.Printf("Provisioner: auto-recover for %s — runtime template %s not found: %v",
+						workspaceID, runtimeTemplate, statErr)
+				}
 			}
-			h.broadcaster.RecordAndBroadcast(ctx, "WORKSPACE_PROVISION_FAILED", workspaceID, map[string]interface{}{
-				"error": msg,
-			})
-			return
+
+			if !recovered {
+				msg := fmt.Sprintf("cannot start workspace %s: no config.yaml source and config volume is empty — delete the workspace or provide a template", workspaceID)
+				log.Printf("Provisioner: %s", msg)
+				if _, dbErr := db.DB.ExecContext(ctx,
+					`UPDATE workspaces SET status = 'failed', last_sample_error = $2, updated_at = now() WHERE id = $1`,
+					workspaceID, msg); dbErr != nil {
+					log.Printf("Provisioner: failed to mark workspace %s as failed: %v", workspaceID, dbErr)
+				}
+				h.broadcaster.RecordAndBroadcast(ctx, "WORKSPACE_PROVISION_FAILED", workspaceID, map[string]interface{}{
+					"error": msg,
+				})
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
[molecule-platform-evolvement-manager-agent]

Closes **#1858**.

## Root-cause fix for a bug that hit us twice today

| Time | Workspace | Status before manual fix |
|---|---|---|
| 16:31 UTC | Research Lead | failed — \"config volume empty\" |
| 18:55 UTC | Tech Researcher | failed — same error |

Both needed the same manual workaround:

\`\`\`bash
docker stop ws-<id>
docker run --rm -v ws-<id>-configs:/configs \
  -v workspace-configs-templates/claude-code-default:/src:ro \
  alpine sh -c 'cp -r /src/. /configs/'
docker start ws-<id>
psql -c \"UPDATE workspaces SET status='online' WHERE id='...'\"
\`\`\`

## What the fix does

At \`workspace_provision.go:151\` (Preflight #17), when the config volume probe finds no \`config.yaml\` AND the caller didn't supply a template (the auto-restart path), instead of immediately marking \`failed\`:

1. Look up the workspace's runtime from \`payload.Runtime\` (set by the Restart handler from the DB)
2. Resolve \`h.configsDir/\${runtime}-default\` — the same template path \`apply_template=true\` uses
3. If it exists, set \`templatePath\` and rebuild \`cfg\` so Provisioner.Start writes it into the volume
4. Only fall through to the original fail-path if the recovery template itself is missing

## Why this is strictly safer

- **Happy path unchanged.** Recovery code only fires in the case that previously fail-marked the workspace.
- **Runtime matched.** \`payload.Runtime\` comes from the DB's \`workspaces.runtime\` column, so we can't accidentally apply a langgraph template to a claude-code workspace.
- **State-loss bound.** If the user had custom edits in their config volume, they're gone — but they were ALREADY gone (volume was empty). This fix recovers to the template baseline, same as what \`apply_template=true\` does today.

## Verification

- \`go build ./cmd/server\` passes (verified via \`docker run golang:1.25-alpine\`)
- Replaying today's live incident: if this code had been running, Research Lead + Tech Researcher would have self-recovered without the 2-step manual intervention.

## Scope discipline — what's NOT in this PR

- **Unit test** (need \`VolumeHasFile\` mock + configsDir temp dir). Filed as follow-up on #1858.
- **\`.provisioned\` marker** (class-level fix — write a marker after first-provision template copy, probe it on restart). Makes diagnostics cleaner but this PR fixes the immediate bug without it.
- **Canvas / event surfacing** for the recovery action. Today the operator sees a log line; a future PR could broadcast a \`WORKSPACE_AUTO_RECOVERED\` event.

## Test plan for reviewer

- [ ] \`go build ./cmd/server\` passes — **already verified**
- [ ] \`go vet ./...\` passes
- [ ] CI Platform(Go) green
- [ ] Smoke test on staging: manually wipe a test workspace's config volume, trigger restart, verify it recovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)