### PR TITLE
fix(a2a-queue): use partial-index ON CONFLICT syntax (not constraint name)

### DIFF
--- a/workspace-server/internal/handlers/a2a_queue.go
+++ b/workspace-server/internal/handlers/a2a_queue.go
@@ -82,13 +82,18 @@ func EnqueueA2A(
 		methodArg = method
 	}
 
-	// INSERT ... ON CONFLICT DO NOTHING RETURNING id. On conflict we then
-	// look up the existing row's id so the caller always receives a valid
-	// queue entry reference.
+	// INSERT ... ON CONFLICT DO NOTHING RETURNING id. The conflict target
+	// must reference the partial unique INDEX columns + WHERE clause directly
+	// (Postgres can't reference partial unique indexes by name in
+	// ON CONFLICT — only true CONSTRAINTs work for that). On conflict we
+	// then look up the existing row's id so the caller always receives a
+	// valid queue entry reference.
 	err = db.DB.QueryRowContext(ctx, `
 		INSERT INTO a2a_queue (workspace_id, caller_id, priority, body, method, idempotency_key)
 		VALUES ($1, $2, $3, $4::jsonb, $5, $6)
-		ON CONFLICT ON CONSTRAINT idx_a2a_queue_idempotency DO NOTHING
+		ON CONFLICT (workspace_id, idempotency_key)
+			WHERE idempotency_key IS NOT NULL AND status IN ('queued','dispatched')
+			DO NOTHING
 		RETURNING id
 	`, workspaceID, callerArg, priority, string(body), methodArg, keyArg).Scan(&id)
 


### PR DESCRIPTION
[molecule-platform-evolvement-manager-agent]

Hot-fix for #1892. The EnqueueA2A INSERT silently errored on every call because Postgres rejects `ON CONFLICT ON CONSTRAINT <name>` for partial unique INDEXES — that form only works for true CONSTRAINTs.

```
ERROR: constraint "idx_a2a_queue_idempotency" for table "a2a_queue" does not exist
```

The busy-error fallback in `a2a_proxy_helpers.go` masked this — when EnqueueA2A returned err, the code logged + fell through to the legacy 503. So Phase 1 deployed silently broken: 0 queue rows in 15min vs 46 busy errors.

Fix: switch to the partial-index form

```sql
ON CONFLICT (workspace_id, idempotency_key)
  WHERE idempotency_key IS NOT NULL AND status IN ('queued','dispatched')
  DO NOTHING
```

Verified locally on the live staging `a2a_queue` table — INSERT returns the new id, conflict is properly handled.

Already deployed to local staging via direct platform rebuild, this PR is just to land the source-of-truth fix on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)