### PR TITLE
chore: sync staging to main — 2026-04-24 04h (71 commits)

### DIFF
--- a/.github/workflows/e2e-staging-saas.yml
+++ b/.github/workflows/e2e-staging-saas.yml
@@ -5,7 +5,7 @@ name: E2E Staging SaaS (full lifecycle)
 # HMA memory → activity → peers), then tears down and asserts leak-free.
 #
 # Why a separate workflow (not folded into ci.yml):
-#   - The run takes ~20 min (EC2 boot + cloudflared DNS + provision sweeps +
+#   - The run takes ~25-35 min (EC2 boot + cloudflared DNS + provision sweeps +
 #     agent bootstrap), way too slow for every PR.
 #   - Needs its own concurrency group so two pushes don't fight over the
 #     same staging org slug prefix.
@@ -68,7 +68,7 @@ jobs:
   e2e-staging-saas:
     name: E2E Staging SaaS
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
 

--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -308,8 +308,8 @@ fi
 #     polling, only hard-fail at the deadline. Pre-bootstrap-watcher-fix
 #     (controlplane#245) this was a flake generator: workspace went
 #     failed→online inside our window but we bailed at the failed read.
-log "7/11 Waiting for workspace(s) to reach status=online (up to 20 min — hermes cold boot)..."
-WS_DEADLINE=$(( $(date +%s) + 1200 ))
+log "7/11 Waiting for workspace(s) to reach status=online (up to 30 min — hermes cold boot)..."
+WS_DEADLINE=$(( $(date +%s) + 1800 ))
 WS_TO_CHECK="$PARENT_ID"
 [ -n "$CHILD_ID" ] && WS_TO_CHECK="$WS_TO_CHECK $CHILD_ID"
 for wid in $WS_TO_CHECK; do


### PR DESCRIPTION
## Summary
Promotes 71 merged staging commits to main. Replaces #1962 which went stale at 38 commits.

### Notable in this batch
- **#1970** — quickstart restore + canvas drag-nest UX fixes
- **#1961** — canvas a11y + MissingKeysModal tests
- **#1921** — token-rotation race fix (P0 #1877)
- **#1902** — regression guards for 2026-04-23 bug wave
- **#1939** — github-app-auth plugin go.mod bump (#1933 step 1)
- **#1930** — hermes E2E cold-boot tolerance (20min deadline)
- **#1931** — internal content removal + CI gate (CEO directive 2026-04-23)
- **#1897** — quickstart hotfixes (API_SERVER_KEY, hermes bridge, 5 live-testing fixes)

### Test plan
- [x] All 71 individual PRs passed staging CI
- [ ] Main-side CI re-validates merged state