### PR TITLE
ci: add merge_group trigger to ci + codeql

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,17 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+  # GitHub merge queue fires `merge_group` for the queue's pre-merge CI run.
+  # Required so the queue gets a real check result instead of a false-green
+  # from the absence of a triggered workflow. Safe to add unconditionally —
+  # the event simply doesn't fire until the queue is enabled on the branch.
+  merge_group:
+    types: [checks_requested]
 
 # Cancel in-progress CI runs when a new commit arrives on the same ref.
-# This prevents stale runs from queuing behind each other.
+# This prevents stale runs from queuing behind each other. The merge_group
+# refs (refs/heads/gh-readonly-queue/...) get their own concurrency group
+# automatically because github.ref differs from the PR ref.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,6 +18,12 @@ on:
     branches: [main, staging]
   pull_request:
     branches: [main, staging]
+  # GitHub merge queue fires `merge_group` for the queue's pre-merge CI run.
+  # Required so CodeQL Analyze checks get a real result on the queued
+  # commit instead of a false-green. Event only fires once merge queue is
+  # enabled on the target branch — safe to add unconditionally.
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Weekly run picks up findings in code that hasn't been touched.
     - cron: '30 1 * * 0'


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Step 1 of 3 to enable GitHub merge queue on the \`staging\` branch.

## Why

Today: 27 of 28 open staging PRs are stale (DIRTY/BEHIND/BLOCKED). \`required_status_checks.strict=true\` forces every PR to be up-to-date with staging head, so each merge invalidates every other open PR. Agents are filing PRs faster than they can rebase them. The drop-stale endpoint that would fix the queue overflow (#1950) is itself stuck BEHIND staging — circular.

GitHub merge queue is the standard answer (Rust's bors since ~2013, Kubernetes' Tide, Google/Meta internal, GitHub itself, Shopify, Stripe, Datadog). It auto-rebases each PR against fresh staging head, runs CI on the rebased commit, merges if green, picks the next one.

## What this PR changes

Adds \`merge_group: { types: [checks_requested] }\` to the two workflows that produce required-status checks on staging:

- \`ci.yml\` — Detect changes, Platform (Go), Canvas (Next.js), Python Lint & Test, Shellcheck (E2E scripts)
- \`codeql.yml\` — Analyze (go) / Analyze (javascript-typescript) / Analyze (python)

Without this, the queue's pre-merge run on the speculative \`gh-readonly-queue/...\` ref would never fire, every queued PR would show false-green, and queue would merge unverified rebases.

## Why this is safe to land in isolation

The \`merge_group\` event only fires once the queue is enabled on a branch (separate UI/API toggle). So today this PR is a **no-op** — pure plumbing for step 2.

## Sequence

1. **This PR** — workflow triggers (zero behavior change)
2. Enable merge queue on staging via UI/API: Settings → Branches → Edit \`staging\` rule → \"Require merge queue\". Merge method = MERGE (matches the no-squash/no-rebase policy on this repo). Strategy = ALLGREEN.
3. Update IC cron prompt: \`gh pr merge --auto --merge\` instead of manual merge
4. Manually queue the existing 28 staging PRs once enabled

Reversible at any step (toggle queue off in UI).

## Other workflows checked

\`e2e-staging-*\`, \`canary-*\`, \`publish-*\` are not required status checks → no \`merge_group\` needed. \`auto-promote-staging.yml\` runs on push to staging only → also unaffected.