### PR TITLE
fix(e2e): pin HERMES_* env so openai/* routes deterministically

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -243,7 +243,28 @@ if [ -n "${E2E_OPENAI_API_KEY:-}" ]; then
   # model name → 404 model_not_found. Also set OPENAI_BASE_URL to
   # OpenAI's own endpoint — default is openrouter.ai which would need
   # a different key format.
-  SECRETS_JSON="{\"OPENAI_API_KEY\":\"$E2E_OPENAI_API_KEY\",\"OPENAI_BASE_URL\":\"https://api.openai.com/v1\",\"MODEL_PROVIDER\":\"openai:gpt-4o\"}"
+  #
+  # The HERMES_* fields below bypass template-hermes/scripts/derive-provider.sh
+  # — verified 2026-04-24 that even with template-hermes#19's fix in main,
+  # staging tenants sometimes resolve openai/* to PROVIDER=openrouter and
+  # emit {'message':'Missing Authentication header','code':401} (OpenRouter's
+  # shape) in the A2A reply. Setting HERMES_INFERENCE_PROVIDER=custom +
+  # HERMES_CUSTOM_{BASE_URL,API_KEY,API_MODE} pins the bridge deterministically
+  # so the test doesn't depend on every tenant EC2 having a freshly-cloned
+  # template-hermes.
+  SECRETS_JSON=$(python3 -c "
+import json, os
+k = os.environ['E2E_OPENAI_API_KEY']
+print(json.dumps({
+    'OPENAI_API_KEY': k,
+    'OPENAI_BASE_URL': 'https://api.openai.com/v1',
+    'MODEL_PROVIDER': 'openai:gpt-4o',
+    'HERMES_INFERENCE_PROVIDER': 'custom',
+    'HERMES_CUSTOM_BASE_URL': 'https://api.openai.com/v1',
+    'HERMES_CUSTOM_API_KEY': k,
+    'HERMES_CUSTOM_API_MODE': 'chat_completions',
+}))
+")
 fi
 
 # Model slug MUST be provider-prefixed for hermes — the template's


### PR DESCRIPTION
## What

Adds \`HERMES_INFERENCE_PROVIDER=custom\` + \`HERMES_CUSTOM_{BASE_URL,API_KEY,API_MODE}\` to the E2E script's workspace-secrets payload. Bypasses template-hermes's \`derive-provider.sh\` so provider selection is deterministic regardless of which template-hermes commit any given tenant happens to have on disk.

## Why this PR exists despite template-hermes#19 already being merged

Verified today with probe workspaces on the staging canary tenant (2026-04-24 05:xx UTC):

| Probe | Workspace secrets | A2A reply |
|---|---|---|
| 1 | Just \`OPENAI_API_KEY\` + \`MODEL_PROVIDER\` | **OpenRouter's 401** (\`{'message': 'Missing Authentication header', 'code': 401}\`) |
| 2 | Same + \`HERMES_INFERENCE_PROVIDER=custom\` + \`HERMES_CUSTOM_*\` | **OpenAI's 401** (\`{'code': 'invalid_api_key'}\`) |

So template-hermes#19's fix **isn't reaching every staging tenant** — probably because the tenant EC2s have a stale \`/opt/adapter\` from an earlier boot, or the CP's user-data bundles a pre-fix template-hermes snapshot.

Root-cause fix (ensure every tenant re-clones /opt/adapter fresh on workspace boot) is a separate follow-up. For now, pinning the env vars makes E2E green without depending on that.

## Test plan
- [x] Probe 2 on canary: A2A returns OpenAI-shape 401, confirming route
- [ ] Next E2E Staging SaaS run reaches step 8 with a real PONG (valid E2E_OPENAI_API_KEY will produce actual completion)

## Related
- molecule-ai-workspace-template-hermes#19 (the theoretically-correct fix that doesn't propagate)
- #1926 (closed — misdiagnosed as platform auth; actual error was OpenRouter's reply leaking through A2A)