### PR TITLE
ci: add merge_group trigger to block-internal-paths workflow

### DIFF
--- a/.github/workflows/block-internal-paths.yml
+++ b/.github/workflows/block-internal-paths.yml
@@ -15,6 +15,11 @@ on:
     types: [opened, synchronize, reopened]
   push:
     branches: [main, staging]
+  # Required for GitHub merge queue: the queue's pre-merge CI run on
+  # `gh-readonly-queue/...` refs needs this check to fire so the queue
+  # gets a real result instead of stalling forever AWAITING_CHECKS.
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   check:


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Re-do of the trigger fix that was bundled into PR #1995 but never landed — the second commit on that branch got rejected by GH006 (branch locked by merge queue) after the first commit was already queued. Only the file-removal commit made it to staging.

## Why this matters

Without \`merge_group:\` trigger, adding \`Block forbidden paths\` to \`required_status_checks\` **deadlocks the queue**: every PR sits in AWAITING_CHECKS forever waiting on a check that can't fire on \`gh-readonly-queue/*\` refs.

## Sequence to land safely

1. (already done) Removed \`Block forbidden paths\` from \`required_status_checks\` so queue can drain
2. **This PR** — add \`merge_group\` trigger
3. (after merge) Re-add \`Block forbidden paths\` to \`required_status_checks\`

## Diff

5 lines added to \`.github/workflows/block-internal-paths.yml\` — same shape as PR #1982 added to ci.yml + codeql.yml.