### PR TITLE
ci(publish-image): auto-tag :staging-latest so CP picks up new builds

### DIFF
--- a/.github/workflows/publish-workspace-server-image.yml
+++ b/.github/workflows/publish-workspace-server-image.yml
@@ -73,7 +73,20 @@ jobs:
       #   - canary-verify.yml runs smoke tests against them
       #   - On green → canary-verify retags :staging-<sha> → :latest
       #   - On red → :latest stays on the prior good digest, prod is safe
-      - name: Build & push platform image to GHCR (staging-<sha> only)
+      # Every push of :staging-<sha> also retags the same digest as
+      # :staging-latest so staging CP (which pins TENANT_IMAGE at
+      # :staging-latest) picks up new builds automatically — no more manual
+      # Railway env-var edits. Prod's :latest retag still happens in
+      # canary-verify.yml after the canary fleet greenlights this digest;
+      # :staging-latest is strictly the "most recent main build," not a
+      # canary-verified promotion.
+      #
+      # Before this, TENANT_IMAGE on Railway staging was pinned to a static
+      # :staging-<sha> and drifted months behind (2026-04-24 incident:
+      # canary tenant ran :staging-a14cf86, 10 days stale, which lacked
+      # applyRuntimeModelEnv and caused every E2E to route hermes+openai
+      # through openrouter → 401). See issue filed with this PR.
+      - name: Build & push platform image to GHCR (staging-<sha> + staging-latest)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -82,6 +95,7 @@ jobs:
           push: true
           tags: |
             ${{ env.IMAGE_NAME }}:staging-${{ steps.tags.outputs.sha }}
+            ${{ env.IMAGE_NAME }}:staging-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
@@ -89,7 +103,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.description=Molecule AI platform (Go API server) — pending canary verify
 
-      - name: Build & push tenant image to GHCR (staging-<sha> only)
+      - name: Build & push tenant image to GHCR (staging-<sha> + staging-latest)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -98,6 +112,7 @@ jobs:
           push: true
           tags: |
             ${{ env.TENANT_IMAGE_NAME }}:staging-${{ steps.tags.outputs.sha }}
+            ${{ env.TENANT_IMAGE_NAME }}:staging-latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Canvas uses same-origin fetches. The tenant Go platform


### PR DESCRIPTION
## Root cause

Staging CP's \`TENANT_IMAGE\` on Railway was pinned to \`:staging-a14cf86\` — a static SHA that drifted 10+ days stale. Every tenant provisioned on staging (including every E2E run's fresh tenant) used this stale image. That image predated \`applyRuntimeModelEnv\`, so \`HERMES_DEFAULT_MODEL\` never reached the workspace EC2. install.sh fell back to nousresearch/hermes-4-70b, derive-provider.sh routed to openrouter, and every A2A call got OpenRouter's 401.

All of today's upstream fixes landed in the code but couldn't take effect:
- template-hermes#19 (provider priority)
- template-hermes#20 (decouple prefix-strip)
- molecule-controlplane#247 (fresh /opt/adapter clone)
- molecule-core#1987 (E2E HERMES_CUSTOM_* pin workaround)

All shadowed by the stale tenant image.

## Fix

Publish every main build under both \`:staging-<sha>\` and \`:staging-latest\`. Then point \`TENANT_IMAGE\` at \`:staging-latest\` on Railway staging. Every future main merge auto-propagates to new tenant provisions.

## Safety

\`:staging-latest\` is "most recent main build." Not canary-verified. That distinction is preserved:
- **Prod** tenants still pull \`:latest\` — retagged by \`canary-verify.yml\` only after the canary fleet green-lights the digest
- **Staging** tenants now pull \`:staging-latest\` — every main build, pre-canary

Staging tenants become the canary. A bad \`:staging-latest\` gets caught before \`:latest\` promotion hits prod. This is what the canary design already intended; the missing \`:staging-latest\` tag was the hole.

## Changes

- 2 lines added to \`publish-workspace-server-image.yml\` (one per image: platform + tenant)
- Zero impact on image size or build time (tags reference the same digest)
- Zero new secrets or permissions

## One-time Railway update

Done via \`railway variables --service controlplane --environment staging --set "TENANT_IMAGE=ghcr.io/molecule-ai/platform-tenant:staging-d812c284"\` as the band-aid unblock. Once this PR merges, I'll flip it to \`:staging-latest\`.

## Follow-up

Filed issue to audit all CP env vars for similar drift-prone SHA pins.

## Test plan
- [x] Workflow YAML validates (no syntax changes beyond tag list)
- [ ] Next main merge produces both tags in GHCR
- [ ] Staging CP re-provisions new tenants using :staging-latest
- [ ] E2E goes green end-to-end with all upstream fixes actually taking effect