### PR TITLE
ci(gh-wrapper): translate --assignee @me → --label team:<role> (fixes #1957)

### DIFF
--- a/workspace/scripts/gh-wrapper.sh
+++ b/workspace/scripts/gh-wrapper.sh
@@ -122,6 +122,50 @@ _Opened by: Molecule AI ${role}_")
             i=$((i + 1))
             continue
             ;;
+        # Identity translation (#1957). All agents share one PAT, so
+        # `gh ... --assignee @me` resolves to the CEO and lands every
+        # agent-filed issue/PR on the human's plate. Translate to a
+        # role-tagged label instead — labels are the right abstraction
+        # for "this team owns it" in a multi-agent fleet.
+        #
+        # Reviewer requests are dropped: the review-bot scans by label,
+        # not by direct request, so --reviewer @me is just noise.
+        --assignee)
+            next_i=$((i + 1))
+            val="${!next_i:-}"
+            if [[ "$val" == "@me" ]]; then
+                # Translate: drop --assignee, add --label team:<role-slug>
+                slug=$(echo "$role" | tr '[:upper:] ' '[:lower:]-')
+                new_args+=(--label "team:${slug}")
+            else
+                new_args+=("$arg" "$val")
+            fi
+            i=$((i + 2))
+            continue
+            ;;
+        --assignee=@me)
+            slug=$(echo "$role" | tr '[:upper:] ' '[:lower:]-')
+            new_args+=(--label "team:${slug}")
+            i=$((i + 1))
+            continue
+            ;;
+        --reviewer)
+            next_i=$((i + 1))
+            val="${!next_i:-}"
+            if [[ "$val" == "@me" ]]; then
+                # Drop entirely — review-bot picks up via label scan
+                : # no-op
+            else
+                new_args+=("$arg" "$val")
+            fi
+            i=$((i + 2))
+            continue
+            ;;
+        --reviewer=@me)
+            # Drop entirely
+            i=$((i + 1))
+            continue
+            ;;
         *)
             new_args+=("$arg")
             i=$((i + 1))


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Fixes #1957. Post #1933 retro item #5.

## Why

All agents share one PAT, so `gh issue create --assignee @me` resolves to the CEO. Today's "6 issues @me for 7 cycles" defect signal turned out to be CEO-load misclassified as team-stagnation.

## What it does

Two new cases in the existing arg-walk loop:

- `--assignee @me` → `--label team:<role-slug>` (role from `GIT_AUTHOR_NAME`, lowercased + dashed)
- `--reviewer @me` → dropped (review-bot scans labels, not requests)
- Real user names pass through unchanged

## Acceptance

After this lands and templates pull the updated wrapper:

- `gh issue create --title foo --assignee @me` from Core-BE → opens with label `team:core-be` and no assignee
- `gh issue list --label team:core-be` becomes the discovery query for backend work
- The maintenance "issues @me" metric becomes meaningful again (CEO actually has CEO work)

Agent prompts don't need updates — the wrapper is transparent.