### PR TITLE
feat(org): log loud when org-template dir is a half-clone

### DIFF
--- a/workspace-server/internal/handlers/org.go
+++ b/workspace-server/internal/handlers/org.go
@@ -321,6 +321,18 @@ func (h *OrgHandler) ListTemplates(c *gin.Context) {
 			orgFile = filepath.Join(templateDir, "org.yml")
 			data, err = os.ReadFile(orgFile)
 			if err != nil {
+				// Half-clone detection: a directory that contains a `.git/`
+				// but no `org.yaml`/`org.yml` is almost always a manifest
+				// clone that got truncated mid-checkout. Surfacing this as
+				// a warning instead of a silent skip prevents the
+				// "template missing from registry" failure mode (audit
+				// 2026-04-24: org-templates/molecule-dev/ had only `.git/`
+				// and silently dropped from the Canvas palette for hours
+				// before anyone noticed).
+				gitDir := filepath.Join(templateDir, ".git")
+				if _, gitErr := os.Stat(gitDir); gitErr == nil {
+					log.Printf("ListTemplates: WARNING %q has .git but no org.yaml/.yml — likely a half-checkout. Try 'cd %s && git checkout main -- .' to restore the working tree.", e.Name(), templateDir)
+				}
 				continue
 			}
 		}


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Post-incident retro item #6.

## Audit case 2026-04-24

`org-templates/molecule-dev/` contained only `.git/` (working tree wiped). `ListTemplates` silently skipped the directory; the molecule-dev template silently disappeared from the Canvas palette. CEO discovered hours later when looking for the registry listing.

## Fix

When a subdir of `orgDir` has a `.git/` but no `org.yaml`/`.yml`, log a warning naming the directory + the recovery command (`git checkout main -- .`).

Doesn't change response behavior — keeps ListTemplates fail-soft. Just makes the failure visible in `docker logs platform`.