### PR TITLE
fix(canvas/e2e): raise deadline 15→20 min — matches SaaS E2E tolerance

### DIFF
--- a/canvas/e2e/staging-setup.ts
+++ b/canvas/e2e/staging-setup.ts
@@ -26,8 +26,13 @@ const CP_URL = process.env.MOLECULE_CP_URL || "https://staging-api.moleculesai.a
 const ADMIN_TOKEN = process.env.MOLECULE_ADMIN_TOKEN;
 const STAGING = process.env.CANVAS_E2E_STAGING === "1";
 
-const PROVISION_TIMEOUT_MS = 15 * 60 * 1000;
-const WORKSPACE_ONLINE_TIMEOUT_MS = 10 * 60 * 1000;
+// Tenant cold boot on staging regularly takes 12-15 min when the
+// workspace-server Docker image isn't already cached on the AMI. Raised
+// to 20 min to match tests/e2e/test_staging_full_saas.sh (PR #1930)
+// after repeated "tenant provision: timed out after 900s" flakes
+// were blocking staging→main syncs on 2026-04-24.
+const PROVISION_TIMEOUT_MS = 20 * 60 * 1000;
+const WORKSPACE_ONLINE_TIMEOUT_MS = 20 * 60 * 1000;
 const TLS_TIMEOUT_MS = 3 * 60 * 1000;
 
 async function jsonFetch(


### PR DESCRIPTION
Matches the 20-min budget shipped in #1930 for \`tests/e2e/test_staging_full_saas.sh\`. Canvas E2E was stuck at 15 min which regularly flakes on tenant cold boots in the 12-15 min range.

Concrete blocker: sync PR #1981 kept failing on \`tenant provision: timed out after 900s\` even after the actual SaaS E2E went green.

Also bumps WORKSPACE_ONLINE_TIMEOUT_MS 10→20 min to cover hermes cold-install tail (apt + uv + hermes-agent clone + gateway boot can take 13-15 min on slow apt days).

No behavior change when things are fast.

## Test plan
- [x] Local type-check passes
- [ ] Next Canvas E2E run reaches tenant-running without timeout