### PR TITLE
fix(scripts): make sweep-cf-orphans MAX_DELETE_PCT env override actually work

### DIFF
--- a/scripts/ops/sweep-cf-orphans.sh
+++ b/scripts/ops/sweep-cf-orphans.sh
@@ -32,7 +32,7 @@
 set -euo pipefail
 
 DRY_RUN=1
-MAX_DELETE_PCT=50   # refuse to delete more than half the records in one run
+MAX_DELETE_PCT="${MAX_DELETE_PCT:-50}"   # refuse to delete more than this pct of records in one run; caller can override via env
 REGION="${AWS_DEFAULT_REGION:-us-east-2}"
 
 for arg in "$@"; do


### PR DESCRIPTION
The script's own help text documents \`MAX_DELETE_PCT=62 ./sweep-cf-orphans.sh\` as the way to relax the 50% safety gate, but the in-script assignment on line 35 was unconditional and clobbered any env value — so the override never worked and the script would always refuse above 50%.

Hit this today while clearing CF zone buildup that was wedging staging tenant provisions. With the env honored, swept 64 orphans (36 e2e-tenant + 28 ws), zone went 111 → 47 of 200 cap.

One-char fix: \`MAX_DELETE_PCT=50\` → \`MAX_DELETE_PCT=\${MAX_DELETE_PCT:-50}\`.

Related: CP #255 (cache-collision recovery), CP #239 (zone quota).