### PR TITLE
fix(canvas/e2e): swap workspace-scoped 401s for empty 200s in staging-tabs spec

### DIFF
--- a/canvas/e2e/staging-tabs.spec.ts
+++ b/canvas/e2e/staging-tabs.spec.ts
@@ -87,6 +87,53 @@ test.describe("staging canvas tabs", () => {
       }),
     );
 
+    // Workspace-scoped 401 → 200 fallback.
+    //
+    // Several side-panel tabs (Peers/Skills/Channels/Memory/Audit and
+    // anything else workspace-scoped) hit endpoints under
+    // `/workspaces/<id>/*` that require a workspace-scoped token, NOT
+    // the tenant admin bearer this test uses. Those endpoints respond
+    // 401 in SaaS mode. canvas/src/lib/api.ts:62-74 reacts to ANY 401
+    // by setting `window.location.href` to the AuthKit login URL —
+    // which yanks the page off the tenant origin mid-test and breaks
+    // every locator assertion that runs after.
+    //
+    // For tab-render tests we don't need real data — the gate is
+    // "panel mounts without crashing, no Failed-to-load toast".
+    // Intercept the 401 and swap it for 200 + empty body. Body shape
+    // is best-effort by URL: list endpoints (collection paths that
+    // don't end in a UUID) get `[]`; single-resource endpoints get
+    // `{}`. Both are valid JSON, neither matches the real schema
+    // exactly, but well-written panels render an empty state for
+    // either rather than throwing.
+    //
+    // The two route patterns don't overlap (`/workspaces/...` vs
+    // `/cp/auth/me`) so handler order doesn't matter — the
+    // `/cp/auth/me` mock above is matched on its own path.
+    await context.route(/\/workspaces\//, async (route, request) => {
+      if (request.resourceType() !== "fetch") {
+        return route.fallback();
+      }
+      let resp;
+      try {
+        resp = await route.fetch();
+      } catch {
+        return route.fallback();
+      }
+      if (resp.status() !== 401) {
+        return route.fulfill({ response: resp });
+      }
+      // 401: swap for empty 200 keyed by URL shape.
+      const lastSeg =
+        new URL(request.url()).pathname.split("/").filter(Boolean).pop() || "";
+      const looksLikeList = !/^[0-9a-f-]{8,}$/.test(lastSeg);
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: looksLikeList ? "[]" : "{}",
+      });
+    });
+
     const consoleErrors: string[] = [];
     page.on("console", (msg) => {
       if (msg.type() === "error") {


### PR DESCRIPTION
## Summary

Adds a Playwright \`context.route\` handler that intercepts \`/workspaces/<id>/*\` 401 responses and replaces them with empty 200s, so the canvas's \`lib/api.ts\` redirect-on-401 logic doesn't yank the page off the tenant origin mid-test.

## Why

The staging-tabs spec has been failing for 6+ hours on the same locator-timeout signature, blocking #2061's promotion path:

\`\`\`
e2e/staging-tabs.spec.ts:45:7 › tab: skills
TimeoutError: locator.scrollIntoViewIfNeeded: Timeout 5000ms exceeded
- navigated to \"https://scenic-pumpkin-83.authkit.app/?...\"
\`\`\`

Diagnosis (already in the codebase comments):

- Test mocks \`/cp/auth/me\` — AuthGate's session probe ✓
- Bearer-token Authorization on all requests via \`setExtraHTTPHeaders\` ✓
- BUT several workspace-scoped endpoints (Peers, Skills, Channels, Memory, Audit) require a workspace-scoped token, not the tenant admin bearer. They 401 in SaaS mode.
- \`canvas/src/lib/api.ts:62-74\` calls \`redirectToLogin\` on any 401 → sets \`window.location.href\` → browser navigates to AuthKit → Playwright sees the navigation start mid-test → next locator action waits and times out

The existing test comment at line 18 (\"Peers tab: 401 without workspace-scoped token\") assumed those 401s would surface as errored content. That was true before the api.ts redirect path was added; it isn't now.

## What this PR changes

One route handler scoped to \`/workspaces/<id>/*\` paths:

\`\`\`ts
await context.route(/\\/workspaces\\//, async (route, request) => {
  if (request.resourceType() !== \"fetch\") return route.fallback();
  let resp;
  try { resp = await route.fetch(); } catch { return route.fallback(); }
  if (resp.status() !== 401) return route.fulfill({ response: resp });
  // 401 → empty 200 keyed by URL shape
  await route.fulfill({
    status: 200,
    contentType: \"application/json\",
    body: lastSegLooksLikeID ? \"{}\" : \"[]\",
  });
});
\`\`\`

- Real responses (200/4xx-non-401/5xx) pass through unchanged
- 401s are converted to empty bodies — \`[]\` for collection paths, \`{}\` for single-resource paths
- The route is scoped to \`/workspaces/...\` so non-workspace paths (canvas viewport, events, cp routes) are untouched

## Test plan

- [x] tsc passes locally on the spec
- [ ] Staging E2E runs to completion and all 13 tabs assert green
- [ ] Console-error budget at end of test still 0 (the route doesn't introduce console errors)

## What this preserves

- The \"Failed to load\" toast assertion still gates real crashes — it only triggers on hard render failures, not on empty data
- The aggregate console-error check at the end still gates unexpected runtime errors
- Real 200 responses for workspace endpoints (when available) pass through, so panels render real data when the bearer DOES authenticate

## Out of scope

- The deeper question of why workspace-scoped tokens differ from tenant admin bearers (and whether \`api.ts\` should be smarter about which 401s warrant logout) is a separate discussion. This PR just unblocks the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)