### PR TITLE
ci(retarget): handle 422 'duplicate PR' by closing redundant main-PR (closes #1884)

### DIFF
--- a/.github/workflows/retarget-main-to-staging.yml
+++ b/.github/workflows/retarget-main-to-staging.yml
@@ -33,18 +33,49 @@ jobs:
       || github.event.pull_request.user.login == 'molecule-ai[bot]'
     steps:
       - name: Retarget PR base to staging
+        id: retarget
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        # Issue #1884: when the bot opens a PR against main and there's
+        # already another PR on the same head branch targeting staging,
+        # GitHub's PATCH /pulls returns 422 with
+        # "A pull request already exists for base branch 'staging' …".
+        # The retarget can't proceed — but the right response is to
+        # close the now-redundant main-PR, not to fail the workflow
+        # noisily. Detect that specific 422 and close instead.
         run: |
+          set +e
           echo "Retargeting PR #${PR_NUMBER} (author: ${PR_AUTHOR}) from main → staging"
-          gh api -X PATCH \
+          PATCH_OUTPUT=$(gh api -X PATCH \
             "repos/${{ github.repository }}/pulls/${PR_NUMBER}" \
             -f base=staging \
-            --jq '.base.ref'
+            --jq '.base.ref' 2>&1)
+          PATCH_EXIT=$?
+          set -e
+          if [ "$PATCH_EXIT" -eq 0 ]; then
+            echo "::notice::Retargeted PR #${PR_NUMBER} → staging"
+            echo "outcome=retargeted" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Specifically match the 422 duplicate-base/head error so
+          # any OTHER PATCH failure (auth, deleted PR, etc.) still
+          # surfaces as a real workflow failure.
+          if echo "$PATCH_OUTPUT" | grep -q "pull request already exists for base branch 'staging'"; then
+            echo "::notice::PR #${PR_NUMBER}: duplicate target-staging PR exists on same head — closing this main-PR as redundant."
+            gh pr close "$PR_NUMBER" \
+              --repo "${{ github.repository }}" \
+              --comment "[retarget-bot] Closing — another PR on the same head branch already targets \`staging\`. This PR is redundant. See issue #1884 for the rationale."
+            echo "outcome=closed-as-duplicate" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "::error::Retarget PATCH failed and was NOT a duplicate-base error:"
+          echo "$PATCH_OUTPUT" >&2
+          exit 1
 
       - name: Post explainer comment
+        if: steps.retarget.outputs.outcome == 'retargeted'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Closes #1884 — the auto-retarget Action used to fail noisily when a bot opened a PR against \`main\` whose head branch already had a sibling PR targeting \`staging\`. Now it detects the specific 422 \"duplicate base/head\" error and closes the main-PR as redundant.

## Why

PR #1881 was the most recent example: opened against \`main\`, but #1820 already targeted \`staging\` from the same head. The retarget Action's \`gh api PATCH\` returned 422, the workflow exited 1, and the duplicate sat there until someone manually closed it.

## Behaviour matrix

| Case | Old | New |
|---|---|---|
| PATCH succeeds | retargeted + explainer comment | retargeted + explainer comment (unchanged) |
| PATCH 422 \"already exists for staging\" | workflow fails 1 | close main-PR as redundant |
| PATCH any other failure | workflow fails 1 | workflow fails 1 (unchanged) |

## Why not blanket-catch all 422s

\`gh api\` returns non-zero for many failures — auth, deleted PR, etc. Blanket-catching loses signal on real bugs. The grep matches the specific \"pull request already exists for base branch 'staging'\" text from GitHub's error response, so unrelated 422s still surface as workflow failures.

## Risk: brittle on GitHub error-message text changes

If GitHub rephrases their 422 error, the grep stops matching and we'd regress to the old behaviour. Acceptable trade-off — alternative (parsing the JSON error body) is more plumbing for the same precision. If it does drift we'll see noisy failures and can update the grep.

## Tests

GitHub Actions don't have an inline unit-test framework. Verification:
- YAML parses locally (\`yaml.safe_load\` clean)
- Bash logic uses idiomatic \`set +e\` / save-\$? / restore-\`set -e\`
- The next duplicate-PR scenario in production will exercise the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)