### PR TITLE
fix(workspace-crud): propagate Stop errors on delete (closes #1843)

### DIFF
--- a/workspace-server/internal/handlers/workspace_crud.go
+++ b/workspace-server/internal/handlers/workspace_crud.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -388,9 +389,24 @@ func (h *WorkspaceHandler) Delete(c *gin.Context) {
 	// Now stop containers + remove volumes for all descendants (any depth).
 	// Any concurrent heartbeat / registration / liveness-triggered restart
 	// will see status='removed' and bail out early.
+	//
+	// #1843: Stop() errors used to be silently swallowed. On the CP/EC2
+	// backend, Stop() calls the control plane's DELETE workspaces endpoint
+	// to terminate the EC2; if that errors (CP transient 5xx, network),
+	// the EC2 stays running with no DB row to track it — the
+	// "14 orphan workspace EC2s on a 0-customer account" scenario.
+	// Aggregate Stop failures and surface them as 500 so the client can
+	// retry. The retry replays Stop with the same instance_id (still
+	// readable from the row even after status='removed') — idempotent on
+	// the CP side. RemoveVolume errors stay log-and-continue: those are
+	// local cleanup of /var/data, not infra-leak class.
+	var stopErrs []error
 	for _, descID := range descendantIDs {
 		if h.provisioner != nil {
-			h.provisioner.Stop(ctx, descID)
+			if err := h.provisioner.Stop(ctx, descID); err != nil {
+				log.Printf("Delete descendant %s stop error: %v", descID, err)
+				stopErrs = append(stopErrs, fmt.Errorf("stop descendant %s: %w", descID, err))
+			}
 			if err := h.provisioner.RemoveVolume(ctx, descID); err != nil {
 				log.Printf("Delete descendant %s volume removal warning: %v", descID, err)
 			}
@@ -401,7 +417,10 @@ func (h *WorkspaceHandler) Delete(c *gin.Context) {
 
 	// Stop + remove volume for the workspace itself
 	if h.provisioner != nil {
-		h.provisioner.Stop(ctx, id)
+		if err := h.provisioner.Stop(ctx, id); err != nil {
+			log.Printf("Delete %s stop error: %v", id, err)
+			stopErrs = append(stopErrs, fmt.Errorf("stop %s: %w", id, err))
+		}
 		if err := h.provisioner.RemoveVolume(ctx, id); err != nil {
 			log.Printf("Delete %s volume removal warning: %v", id, err)
 		}
@@ -411,6 +430,21 @@ func (h *WorkspaceHandler) Delete(c *gin.Context) {
 	h.broadcaster.RecordAndBroadcast(ctx, "WORKSPACE_REMOVED", id, map[string]interface{}{
 		"cascade_deleted": len(descendantIDs),
 	})
+
+	// If any Stop call failed, surface 500 so the client retries. The DB
+	// row is already 'removed' (idempotent), and Stop's instance_id
+	// lookup tolerates that — the retry replays the terminate. This is
+	// the loud-fail-instead-of-silent-leak choice; users see a 500
+	// instead of an orphaned EC2.
+	if len(stopErrs) > 0 {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": fmt.Sprintf("workspace marked removed, but %d stop call(s) failed — please retry: %v",
+				len(stopErrs), errors.Join(stopErrs...)),
+			"removed_count": len(allIDs),
+			"stop_failures": len(stopErrs),
+		})
+		return
+	}
 
 	// Hard purge: cascade delete all FK data and remove the DB row entirely (#1087)
 	if c.Query("purge") == "true" {


### PR DESCRIPTION
## Summary

Closes #1843 — workspace delete's \`Stop()\` errors were silently swallowed; on EC2 backend that meant terminate failures left the EC2 running with no DB row to track. Surfaces failures as 500 + retry guidance, matching CP #262 + workspace-server #269 cleanup-correctness pattern.

## What changes

\`workspace-server/internal/handlers/workspace_crud.go:Delete\`:

| Path | Before | After |
|---|---|---|
| \`Stop()\` returns nil | mark removed, broadcast | mark removed, broadcast (unchanged) |
| \`Stop()\` returns err | swallow, return 200 | aggregate via errors.Join, return 500 |
| \`RemoveVolume()\` returns err | log + continue | log + continue (unchanged — local cleanup) |

Idempotency preserved:
- DB row marked 'removed' before \`Stop()\` (per #73 — anti-resurrection guarantee)
- \`resolveInstanceID\` reads instance_id without status filter → retry replays Stop
- CP's TerminateInstance is idempotent on already-terminated EC2s

## Behaviour change at the API

- Old: 200 \`{\"status\":\"removed\",\"cascade_deleted\":N}\` regardless of Stop outcome
- New: 500 \`{\"error\":\"...\",\"removed_count\":N,\"stop_failures\":K}\` on Stop failure; 200 on success

Frontend may need to handle both shapes — surfaces a retry affordance to the user instead of hiding the orphan-creation.

## Test debt (acknowledged)

The handler's \`provisioner\` field is the concrete \`*provisioner.Provisioner\` type, not an interface. Adding a regression test for the new error path requires either a refactor (introduce a Backend interface for the handler) or docker-backed integration tests. Filing the refactor as a follow-up. CP #262 + #269 ship without exhaustive new tests for the same reason — same pattern, same acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)