### PR TITLE
test(ci): runtime + a2a-sdk pin compatibility gate (controlplane#253)

### DIFF
--- a/.github/workflows/runtime-pin-compat.yml
+++ b/.github/workflows/runtime-pin-compat.yml
@@ -1,0 +1,59 @@
+name: Runtime Pin Compatibility
+
+# CI gate that prevents the 5-hour staging outage from 2026-04-24 from
+# recurring (controlplane#253). The original failure mode:
+#   1. molecule-ai-workspace-runtime 0.1.13 declared `a2a-sdk<1.0` in its
+#      requires_dist metadata (incorrect — it actually imports
+#      a2a.server.routes which only exists in a2a-sdk 1.0+)
+#   2. `pip install molecule-ai-workspace-runtime` resolved cleanly
+#   3. `from molecule_runtime.main import main_sync` raised ImportError
+#   4. Every tenant workspace crashed; the canary tenant caught it but
+#      only after 5 hours of degraded staging
+#
+# This workflow installs the runtime in a fresh Python venv from PyPI
+# and tries the same import the EC2 user-data does. If pip resolution
+# silently produces a broken combo, this gate fails before the tenant
+# image gets published.
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - 'workspace/requirements.txt'
+      - '.github/workflows/runtime-pin-compat.yml'
+  pull_request:
+    branches: [main, staging]
+    paths:
+      - 'workspace/requirements.txt'
+      - '.github/workflows/runtime-pin-compat.yml'
+  # Daily catch for upstream PyPI publishes that break the pin combo
+  # without any change in our repo (e.g. someone re-yanks an a2a-sdk
+  # release or molecule-ai-workspace-runtime publishes a bad bump).
+  schedule:
+    - cron: '0 13 * * *'  # 06:00 PT
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  default-install:
+    name: Default install + import smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install runtime + workspace requirements
+        run: |
+          python -m venv /tmp/venv
+          /tmp/venv/bin/pip install --upgrade pip
+          /tmp/venv/bin/pip install molecule-ai-workspace-runtime
+          /tmp/venv/bin/pip install -r workspace/requirements.txt
+          /tmp/venv/bin/pip show molecule-ai-workspace-runtime a2a-sdk \
+            | grep -E '^(Name|Version):'
+      - name: Smoke import — fail if metadata declares deps that don't satisfy real imports
+        run: |
+          /tmp/venv/bin/python -c "from molecule_runtime.main import main_sync; print('runtime imports OK')"

--- a/.github/workflows/runtime-pin-compat.yml
+++ b/.github/workflows/runtime-pin-compat.yml
@@ -68,5 +68,10 @@ jobs:
           /tmp/venv/bin/pip show molecule-ai-workspace-runtime a2a-sdk \
             | grep -E '^(Name|Version):'
       - name: Smoke import — fail if metadata declares deps that don't satisfy real imports
+        # WORKSPACE_ID is validated at import time by platform_auth.py — EC2
+        # user-data sets it from the cloud-init template; set a placeholder
+        # here so the import smoke doesn't trip on the env-var guard.
+        env:
+          WORKSPACE_ID: 00000000-0000-0000-0000-000000000001
         run: |
           /tmp/venv/bin/python -c "from molecule_runtime.main import main_sync; print('runtime imports OK')"

--- a/.github/workflows/runtime-pin-compat.yml
+++ b/.github/workflows/runtime-pin-compat.yml
@@ -32,6 +32,10 @@ on:
   schedule:
     - cron: '0 13 * * *'  # 06:00 PT
   workflow_dispatch:
+  # Required-check support: when this becomes a branch-protection gate,
+  # merge_group runs let the queue green-check this in addition to PRs.
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -46,7 +50,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: pip
+          cache-dependency-path: workspace/requirements.txt
       - name: Install runtime + workspace requirements
+        # Install order is load-bearing: install the runtime FIRST so pip
+        # honors whatever a2a-sdk constraint the runtime metadata declares
+        # (this is the surface that broke in 2026-04-24 — runtime declared
+        # `a2a-sdk<1.0` but actually needed >=1.0). The follow-up install
+        # of workspace/requirements.txt then upgrades a2a-sdk to the
+        # constraint our runtime image actually pins. The import smoke
+        # below verifies the upgraded combination is consistent.
         run: |
           python -m venv /tmp/venv
           /tmp/venv/bin/pip install --upgrade pip


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes Molecule-AI/molecule-controlplane#253.

## Why

2026-04-24 staging outage. \`molecule-ai-workspace-runtime 0.1.13\` declared \`a2a-sdk<1.0\` in its requires_dist metadata but actually imported \`a2a.server.routes\` (1.0+ only). \`pip install\` resolved cleanly; every tenant workspace crashed at import. Canary tenant caught it but only after **5 hours of degraded staging**. PR #249 fixed the version pin manually; nothing automated catches the same class of bug for the next release.

## Fix

New workflow \`.github/workflows/runtime-pin-compat.yml\`:

- Installs \`molecule-ai-workspace-runtime\` fresh from PyPI in a Python 3.11 venv (mirrors EC2 user-data install pattern)
- Layers in \`workspace/requirements.txt\` (the runtime image's actual dep set, including the \`a2a-sdk[http-server]>=1.0,<2.0\` pin)
- Runs \`from molecule_runtime.main import main_sync\` — same import the runtime entrypoint does
- **Fails CI if pip resolution silently produced a combo that the runtime can't actually import**

## Triggers

| Event | Why |
|---|---|
| PR / push to main+staging touching \`workspace/requirements.txt\` or this workflow | Catches local pin changes |
| Daily 13:00 UTC schedule (06:00 PT) | Catches upstream PyPI publishes that break the pin combo without any change in our repo |
| \`workflow_dispatch\` | Manual re-run for ops |

\`concurrency\` cancels in-progress runs on the same ref.

## Test plan

- [ ] First run on this PR exercises the gate against current pins — should pass (we know molecule-runtime 0.1.15 + a2a-sdk 1.x is the working combo)
- [ ] Manually verify catch by temporarily pinning \`a2a-sdk<1.0\` in workspace/requirements.txt — gate should fail with ImportError on \`a2a.server.routes\` (don't merge that test pin)
- [ ] Daily schedule fires at 13:00 UTC

## Acceptance (per controlplane#253)

- [x] Workflow step added (chose standalone workflow over inline step in publish-workspace-server-image.yml — gives PR coverage + scheduled coverage, neither of which a publish-only step provides)
- [ ] Verified it would fail on the pre-#249 broken combo (manual test above)
- [ ] Verified passes on current pins (this PR's CI)
- [x] Comment in workflow header explaining why it exists + reproduces the original failure mode

## Why standalone vs inline in publish-workspace-server-image.yml

Issue suggested wedging into publish-workspace-server-image.yml. Standalone is better:

1. **PR coverage**: publish-workspace-server-image.yml only fires on \`push: main\`, so it would miss the \`workspace/requirements.txt\` change in a PR that introduces the bad pin.
2. **Scheduled coverage**: a future bad PyPI publish (no repo change) only gets caught with a periodic re-install. Wedging in a publish-only workflow misses this.
3. **Path filter**: standalone workflow only runs when relevant files change — doesn't waste a runner on every monorepo push.