### PR TITLE
test(config): lock ComplianceConfig default to owasp_agentic (#2059)

### DIFF
--- a/workspace/tests/test_config.py
+++ b/workspace/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import os
 
+import pytest
 import yaml
 
 from config import (
@@ -263,36 +264,28 @@ def test_compliance_dataclass_default():
     assert cfg.prompt_injection == "detect"
 
 
-def test_compliance_default_when_yaml_omits_block(tmp_path):
-    """A config.yaml with no `compliance:` key still gets owasp_agentic."""
+@pytest.mark.parametrize(
+    "yaml_payload, expected_mode",
+    [
+        # No `compliance:` key at all — full default path.
+        ({}, "owasp_agentic"),
+        # Explicit empty block — exercises load_config's
+        # `.get("mode", "owasp_agentic")` default-fill at config.py:377.
+        # Common shape during template editing.
+        ({"compliance": {}}, "owasp_agentic"),
+        # Documented opt-out: explicit `mode: ""` disables compliance.
+        ({"compliance": {"mode": ""}}, ""),
+    ],
+    ids=["yaml_omits_block", "yaml_block_empty", "yaml_explicit_optout"],
+)
+def test_compliance_default_via_load_config(tmp_path, yaml_payload, expected_mode):
+    """load_config honors the owasp_agentic default at every yaml shape and
+    still respects explicit opt-out."""
     config_yaml = tmp_path / "config.yaml"
-    config_yaml.write_text(yaml.dump({}))
+    config_yaml.write_text(yaml.dump(yaml_payload))
 
     cfg = load_config(str(tmp_path))
-    assert cfg.compliance.mode == "owasp_agentic"
+    assert cfg.compliance.mode == expected_mode
+    # prompt_injection was never overridden in any payload — must stay at
+    # the dataclass default regardless of the mode value.
     assert cfg.compliance.prompt_injection == "detect"
-
-
-def test_compliance_default_when_yaml_block_is_empty(tmp_path):
-    """An explicitly empty `compliance: {}` block still gets owasp_agentic.
-
-    This is the load_config default-fill path — `.get("mode", "owasp_agentic")`
-    must keep delivering the new default even when the operator dropped a
-    bare `compliance:` block in their yaml (a common shape during template
-    editing).
-    """
-    config_yaml = tmp_path / "config.yaml"
-    config_yaml.write_text(yaml.dump({"compliance": {}}))
-
-    cfg = load_config(str(tmp_path))
-    assert cfg.compliance.mode == "owasp_agentic"
-    assert cfg.compliance.prompt_injection == "detect"
-
-
-def test_compliance_explicit_optout_still_works(tmp_path):
-    """Explicit `mode: ""` in yaml must disable compliance — opt-out path."""
-    config_yaml = tmp_path / "config.yaml"
-    config_yaml.write_text(yaml.dump({"compliance": {"mode": ""}}))
-
-    cfg = load_config(str(tmp_path))
-    assert cfg.compliance.mode == ""

--- a/workspace/tests/test_config.py
+++ b/workspace/tests/test_config.py
@@ -6,6 +6,7 @@ import yaml
 
 from config import (
     A2AConfig,
+    ComplianceConfig,
     DelegationConfig,
     SandboxConfig,
     WorkspaceConfig,
@@ -244,3 +245,54 @@ def test_shared_context_from_yaml(tmp_path):
 
     cfg = load_config(str(tmp_path))
     assert cfg.shared_context == ["guidelines.md", "architecture.md"]
+
+
+# ===== Compliance default lock (#2059) =====
+#
+# PR #2056 flipped ComplianceConfig.mode default from "" to "owasp_agentic"
+# so every shipped template gets prompt-injection detection + PII redaction
+# by default. These tests pin the new default at all four entry points so
+# a silent revert (or a refactor that reintroduces the old no-op default)
+# fails fast instead of shipping a workspace with compliance silently off.
+
+
+def test_compliance_dataclass_default():
+    """ComplianceConfig() — no args — must default to owasp_agentic + detect."""
+    cfg = ComplianceConfig()
+    assert cfg.mode == "owasp_agentic"
+    assert cfg.prompt_injection == "detect"
+
+
+def test_compliance_default_when_yaml_omits_block(tmp_path):
+    """A config.yaml with no `compliance:` key still gets owasp_agentic."""
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text(yaml.dump({}))
+
+    cfg = load_config(str(tmp_path))
+    assert cfg.compliance.mode == "owasp_agentic"
+    assert cfg.compliance.prompt_injection == "detect"
+
+
+def test_compliance_default_when_yaml_block_is_empty(tmp_path):
+    """An explicitly empty `compliance: {}` block still gets owasp_agentic.
+
+    This is the load_config default-fill path — `.get("mode", "owasp_agentic")`
+    must keep delivering the new default even when the operator dropped a
+    bare `compliance:` block in their yaml (a common shape during template
+    editing).
+    """
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text(yaml.dump({"compliance": {}}))
+
+    cfg = load_config(str(tmp_path))
+    assert cfg.compliance.mode == "owasp_agentic"
+    assert cfg.compliance.prompt_injection == "detect"
+
+
+def test_compliance_explicit_optout_still_works(tmp_path):
+    """Explicit `mode: ""` in yaml must disable compliance — opt-out path."""
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text(yaml.dump({"compliance": {"mode": ""}}))
+
+    cfg = load_config(str(tmp_path))
+    assert cfg.compliance.mode == ""


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes #2059.

## Why

PR #2056 flipped \`ComplianceConfig.mode\` default \`\"\"\` → \`\"owasp_agentic\"\` so every shipped template gets prompt-injection detection + PII redaction by default. Correct, already shipping — but **no test asserts the new default**. A silent revert (or refactor reintroducing the old no-op \`\"\"\` default) passes the full \`workspace/tests/\` suite. Belt-and-suspenders against silent regressions.

## Tests added

| Test | Pins |
|---|---|
| \`test_compliance_dataclass_default\` | \`ComplianceConfig()\` no-args defaults |
| \`test_compliance_default_when_yaml_omits_block\` | yaml with no \`compliance:\` key |
| \`test_compliance_default_when_yaml_block_is_empty\` | yaml with bare \`compliance: {}\` (covers load_config's \`.get(\"mode\", \"owasp_agentic\")\` path) |
| \`test_compliance_explicit_optout_still_works\` | \`mode: \"\"\` opt-out path remains functional |

23/23 pass locally (4 new + 19 existing in test_config.py).

## Test plan
- [ ] Python Lint & Test job green
- [ ] Manually verify catch by reverting \`config.py:197\` to \`mode: str = \"\"\` — test_compliance_dataclass_default + the two yaml-default tests should fail