### PR TITLE
fix(a2a): document the metadata-attach except-pass in a2a_executor (closes #1787)

### DIFF
--- a/workspace/a2a_executor.py
+++ b/workspace/a2a_executor.py
@@ -422,7 +422,14 @@ class LangGraphA2AExecutor(AgentExecutor):
                     try:
                         msg.metadata = {"tool_trace": tool_trace}
                     except (AttributeError, TypeError):
-                        pass
+                        # `new_agent_text_message()` returns a plain string in
+                        # MagicMock paths in tests, where assignment to
+                        # .metadata raises despite hasattr being true (the
+                        # mock has the attribute as a property). Suppression
+                        # is intentional — production Message objects always
+                        # accept the assignment. See #1787 + commit dcbcf19
+                        # for the original test-mock motivation.
+                        logger.debug("metadata attach skipped (non-Message return from new_agent_text_message)")
                 await event_queue.enqueue_event(msg)
                 _result = final_text
 


### PR DESCRIPTION
## Summary

GitHub Code Quality bot flagged the empty \`except (AttributeError, TypeError): pass\` at \`workspace/a2a_executor.py:424\` on PR #1783. The suppression is intentional — \`new_agent_text_message()\` returns a plain string in MagicMock paths in tests where assignment to \`.metadata\` raises despite \`hasattr\` being true.

This PR keeps the behavior, just documents it:

- Why-comment citing the test-mock motivation, commit \`dcbcf19\` (the original guard), and issue #1787 so the next code-quality pass doesn't re-flag it.
- \`logger.debug(\"metadata attach skipped (non-Message ...\")\` for observability — debug-level so production logs stay quiet but ops can flip the level if metadata loss is ever suspected.

## Test plan
- [x] \`python3 -m pytest workspace/tests/test_a2a_executor.py\` — 43/43 pass
- [x] AST syntax check clean
- [ ] CI green
- [ ] Auto-merge on green

Closes #1787

🤖 Generated with [Claude Code](https://claude.com/claude-code)