### PR TITLE
refactor(canvas): remove RUNTIME_PROFILES.hermes — value flows server-side (#2054 phase 3)

### DIFF
--- a/canvas/src/components/__tests__/ProvisioningTimeout.test.tsx
+++ b/canvas/src/components/__tests__/ProvisioningTimeout.test.tsx
@@ -226,13 +226,18 @@ describe("ProvisioningTimeout", () => {
         );
       });
 
-      it("returns hermes override when runtime = hermes", () => {
+      it("hermes returns default — value moved server-side post-#2054 phase 3", () => {
+        // RUNTIME_PROFILES.hermes was removed when template-hermes
+        // started declaring provision_timeout_seconds in its
+        // config.yaml. The value now flows server-side via the
+        // workspace API → WorkspaceData.provision_timeout_ms →
+        // resolver overrides path. With no override supplied, the
+        // resolver falls through to the default — same as any other
+        // runtime without a canvas-side override.
         expect(provisionTimeoutForRuntime("hermes")).toBe(
-          RUNTIME_PROFILES.hermes?.provisionTimeoutMs,
+          DEFAULT_RUNTIME_PROFILE.provisionTimeoutMs,
         );
-        expect(provisionTimeoutForRuntime("hermes")).toBeGreaterThanOrEqual(
-          DEFAULT_RUNTIME_PROFILE.provisionTimeoutMs * 5,
-        );
+        expect(RUNTIME_PROFILES.hermes).toBeUndefined();
       });
 
       it("server-side workspace override wins over runtime profile", () => {
@@ -309,7 +314,7 @@ describe("ProvisioningTimeout", () => {
         expect(node?.data.provisionTimeoutMs).toBe(600_000);
       });
 
-      it("absent provision_timeout_ms hydrates to null (falls through to runtime profile)", () => {
+      it("absent provision_timeout_ms hydrates to null (falls through to default post-cleanup)", () => {
         useCanvasStore.getState().hydrate([
           makeWS({ id: "ws-default", name: "Default", status: "provisioning", runtime: "hermes" }),
         ]);
@@ -317,27 +322,32 @@ describe("ProvisioningTimeout", () => {
           .getState()
           .nodes.find((n) => n.id === "ws-default");
         expect(node?.data.provisionTimeoutMs).toBeNull();
-        // And the resolver still returns hermes' profile value when
-        // no override is supplied — proves the fall-through stays intact.
+        // Post-#2054 phase 3: hermes no longer has a canvas-side
+        // RUNTIME_PROFILES entry. With no node override the resolver
+        // falls all the way through to DEFAULT_RUNTIME_PROFILE. In
+        // production the workspace-server-side template lookup
+        // populates node.provisionTimeoutMs to 720000 before this
+        // resolver runs (#2094); this test isolates the fall-through
+        // behavior when that population hasn't happened yet.
         expect(
           provisionTimeoutForRuntime("hermes", {
             provisionTimeoutMs: node?.data.provisionTimeoutMs ?? undefined,
           }),
-        ).toBe(RUNTIME_PROFILES.hermes.provisionTimeoutMs);
+        ).toBe(DEFAULT_RUNTIME_PROFILE.provisionTimeoutMs);
       });
 
-      it("server override wins over runtime profile via the resolver path the component uses", () => {
-        // Mirrors ProvisioningTimeout.tsx:144 where node.provisionTimeoutMs
-        // is passed as overrides — verifies the resolver respects it
-        // even when the runtime has its own profile entry.
-        const override = 30_000;
+      it("server override wins over default via the resolver path the component uses", () => {
+        // Mirrors ProvisioningTimeout.tsx where node.provisionTimeoutMs
+        // is passed as overrides — verifies the resolver respects the
+        // override regardless of the runtime's profile state.
+        const override = 600_000;
         expect(
           provisionTimeoutForRuntime("hermes", {
             provisionTimeoutMs: override,
           }),
         ).toBe(override);
-        // Sanity — the runtime profile would have been much larger.
-        expect(RUNTIME_PROFILES.hermes.provisionTimeoutMs).toBeGreaterThan(
+        // Sanity — the override is the path that wins (default is much smaller).
+        expect(DEFAULT_RUNTIME_PROFILE.provisionTimeoutMs).toBeLessThan(
           override,
         );
       });

--- a/canvas/src/lib/runtimeProfiles.ts
+++ b/canvas/src/lib/runtimeProfiles.ts
@@ -60,21 +60,23 @@ export const DEFAULT_RUNTIME_PROFILE: Required<
 /**
  * Named per-runtime overrides. Keep this map small and explicit —
  * each entry is a deliberate statement that this runtime's cold-boot
- * behavior differs materially from the default.
+ * behavior differs materially from the default AND that the runtime's
+ * template manifest hasn't yet declared a server-side
+ * `provision_timeout_seconds` (the preferred path post-#2054).
  *
  * Each override must also ship with a comment explaining WHY the default
  * is wrong for this runtime. Unexplained numbers rot.
+ *
+ * Empty today — `hermes` previously lived here at 720_000ms, but
+ * Molecule-AI/molecule-ai-workspace-template-hermes now declares the
+ * value in its config.yaml manifest, so the value flows through the
+ * server (workspace API → WorkspaceData.provision_timeout_ms → resolver
+ * overrides) instead of being canvas-hardcoded. New runtimes that need
+ * a non-default cold-boot threshold should follow the same pattern:
+ * declare `runtime_config.provision_timeout_seconds` in their template
+ * manifest, NOT add an entry here.
  */
-export const RUNTIME_PROFILES: Record<string, RuntimeProfile> = {
-  hermes: {
-    // 12 min. Installs ripgrep + ffmpeg + node22 + builds hermes-agent
-    // from source + Playwright + Chromium (~300MB download). Measured
-    // cold boots on staging EC2 routinely land at 8-13 min. Aligns
-    // with SaaS E2E's PROVISION_TIMEOUT_SECS=900 (15 min) so the UI
-    // warning lands shortly before the backend itself gives up.
-    provisionTimeoutMs: 720_000,
-  },
-};
+export const RUNTIME_PROFILES: Record<string, RuntimeProfile> = {};
 
 /**
  * Data fields the canvas can consult for per-workspace overrides. These


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Final canvas-side cleanup for #2054. The hardcoded \`RUNTIME_PROFILES.hermes = 720_000ms\` entry is redundant now that the value flows from the template manifest through workspace-server to the canvas socket payload.

## End-state flow for hermes

1. \`template-hermes config.yaml\` declares \`runtime_config.provision_timeout_seconds: 720\` ([template PR](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/23))
2. \`workspace-server\` reads it at request time ([#2094 MERGED](https://github.com/Molecule-AI/molecule-core/pull/2094))
3. Workspace API response includes \`provision_timeout_ms: 720000\`
4. Canvas \`hydrate\` populates \`node.data.provisionTimeoutMs\` ([#2092 MERGED](https://github.com/Molecule-AI/molecule-core/pull/2092))
5. \`ProvisioningTimeout\` resolver picks it up via overrides

Same effective 720s threshold, now declarative and one-edit-point per runtime.

## Changes

- \`canvas/src/lib/runtimeProfiles.ts\` — \`RUNTIME_PROFILES.hermes\` deleted, jsdoc explains the empty-map-by-design + new-runtime guidance
- \`canvas/src/components/__tests__/ProvisioningTimeout.test.tsx\` — 3 tests updated to assert post-cleanup state (hermes returns default, profile is undefined)

## Tests

19/19 pass. The deleted hermes override is replaced by an assertion that \`RUNTIME_PROFILES.hermes\` is \`undefined\` — locks in the post-cleanup state so a future re-add gets caught.

## Test plan
- [ ] CI green
- [ ] After merge + workspace-server picks up the template change: confirm a fresh hermes workspace's \`provision_timeout_ms\` field is 720000 in the API response
- [ ] Confirm canvas ProvisioningTimeout still uses 12-min threshold for hermes via the server-declared path (not the now-deleted RUNTIME_PROFILES.hermes)
- [ ] No regression on other runtimes (claude-code/langgraph/crewai still get 2-min default)

## Related PRs in this chain

- [template PR #23](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/23) — declares the field
- [#2094](https://github.com/Molecule-AI/molecule-core/pull/2094) — workspace-server reads + surfaces (MERGED)
- [#2092](https://github.com/Molecule-AI/molecule-core/pull/2092) — canvas plumbing (MERGED)