### PR TITLE
fix(a2a): isSafeURL guard inside dispatchA2A (closes #1483)

### DIFF
--- a/workspace-server/internal/handlers/a2a_proxy.go
+++ b/workspace-server/internal/handlers/a2a_proxy.go
@@ -483,6 +483,16 @@ func normalizeA2APayload(body []byte) ([]byte, string, *proxyA2AError) {
 // canvas (callerID == "") = 5 min, agent-to-agent = 30 min. Callers can
 // override via the X-Timeout header (applied to ctx upstream in ProxyA2A).
 func (h *WorkspaceHandler) dispatchA2A(ctx context.Context, agentURL string, body []byte, callerID string) (*http.Response, context.CancelFunc, error) {
+	// #1483 SSRF defense-in-depth: the primary call path through
+	// proxyA2ARequest → resolveAgentURL already validates via isSafeURL
+	// (a2a_proxy.go:424), but adding the check here closes the gap for
+	// any future code path that calls dispatchA2A directly without
+	// going through resolveAgentURL. Wrapping as proxyDispatchBuildError
+	// keeps the caller's error-classification path unchanged — the same
+	// shape it already produces a 500 for.
+	if err := isSafeURL(agentURL); err != nil {
+		return nil, nil, &proxyDispatchBuildError{err: err}
+	}
 	forwardCtx := context.WithoutCancel(ctx)
 	var cancel context.CancelFunc
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {

--- a/workspace-server/internal/handlers/a2a_proxy_test.go
+++ b/workspace-server/internal/handlers/a2a_proxy_test.go
@@ -1155,6 +1155,39 @@ func TestDispatchA2A_ContextDeadline_NoCancelAdded(t *testing.T) {
 	}
 }
 
+// TestDispatchA2A_RejectsUnsafeURL is the #1483 defense-in-depth
+// regression. setupTestDB disables SSRF for normal tests so existing
+// dispatchA2A unit tests can hit httptest.NewServer (loopback) — we
+// re-enable it here to verify the new in-function isSafeURL guard.
+// Production callers go through resolveAgentURL which already
+// validates; this test pins that dispatchA2A is now safe even when
+// called directly by a future caller that skips resolveAgentURL.
+func TestDispatchA2A_RejectsUnsafeURL(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+	restoreSSRF := setSSRFCheckForTest(true)
+	t.Cleanup(restoreSSRF)
+	handler := NewWorkspaceHandler(newTestBroadcaster(), nil, "http://localhost:8080", t.TempDir())
+
+	// Cloud metadata IP — must be rejected before any HTTP call goes out.
+	_, cancel, err := handler.dispatchA2A(
+		context.Background(),
+		"http://169.254.169.254/latest/meta-data/",
+		[]byte(`{}`),
+		"",
+	)
+	if cancel != nil {
+		cancel()
+		t.Error("cancel must be nil when the URL is rejected pre-request")
+	}
+	if err == nil {
+		t.Fatal("expected SSRF rejection error, got nil")
+	}
+	if _, ok := err.(*proxyDispatchBuildError); !ok {
+		t.Errorf("expected *proxyDispatchBuildError (caller maps to 500), got %T: %v", err, err)
+	}
+}
+
 // --- handleA2ADispatchError ---
 
 func TestHandleA2ADispatchError_ContextDeadline(t *testing.T) {


### PR DESCRIPTION
## Summary

#1483 flagged that \`dispatchA2A()\` doesn't call \`isSafeURL\` internally — the guard exists only at the caller level (\`resolveAgentURL\` at \`a2a_proxy.go:424\`). The primary call path through \`proxyA2ARequest\` is safe today, but if any future code path ever calls \`dispatchA2A\` directly without going through \`resolveAgentURL\`, the SSRF check would be silently bypassed.

Sister issue to #1484 (\`discoverHostPeer\` / \`writeExternalWorkspaceURL\` SSRF gap, [PR #2095](https://github.com/Molecule-AI/molecule-core/pull/2095)) — same defense-in-depth pattern.

## Fix

Adds the one-line guard the issue prescribed:

\`\`\`go
if err := isSafeURL(agentURL); err != nil {
    return nil, nil, &proxyDispatchBuildError{err: err}
}
\`\`\`

Wrapping as \`*proxyDispatchBuildError\` preserves the existing caller error-classification path — the same shape that already maps to 500 elsewhere.

## Test

\`TestDispatchA2A_RejectsUnsafeURL\` — re-enables SSRF (existing tests use \`setupTestDB\` which disables it), passes a metadata-IP URL (\`169.254.169.254\`), asserts:
1. Build error returns
2. \`cancel\` is nil — proves the request was rejected pre-allocation, no resource leak

The 4 existing \`dispatchA2A\` unit tests continue passing unchanged because \`setupTestDB\` keeps SSRF disabled for them.

## Test plan
- [x] \`go test ./internal/handlers/ -count=1\` — full suite passes
- [x] \`go vet ./internal/handlers/\` clean
- [x] \`go build ./...\` clean
- [ ] CI green
- [ ] Auto-merge on green

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)