### PR TITLE
test(e2e): add 'Invalid API key' regression assertion to staging A2A check (#1900)

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -410,6 +410,13 @@ fi
 if echo "$AGENT_TEXT" | grep -qF "Unknown provider"; then
   fail "A2A — REGRESSION: install.sh set PROVIDER to a value not in hermes's registry. Run 'hermes doctor' on the workspace to see valid values. Raw: $AGENT_TEXT"
 fi
+# "Invalid API key" — the comment block lists this as a CP #238 race
+# (tenant auth chain) signal but the grep was missing. Caller-side
+# 401's containing this exact phrase don't match the generic
+# "error|exception" catch-all below, so they'd slip through.
+if echo "$AGENT_TEXT" | grep -qF "Invalid API key"; then
+  fail "A2A — REGRESSION: tenant auth chain returned 'Invalid API key'. Likely CP boot-event 401 race (CP #238) or stale OPENAI_API_KEY in the runtime env. Raw: $AGENT_TEXT"
+fi
 # Generic catch-all — falls through if none of the known regressions hit.
 if echo "$AGENT_TEXT" | grep -qiE "error|exception"; then
   fail "A2A returned an error-shaped response: $AGENT_TEXT"


### PR DESCRIPTION
## Summary

The staging E2E suite at \`tests/e2e/test_staging_full_saas.sh:398-411\` already grep's for 5 known regression patterns in the A2A response (\`[hermes-agent error 401]\`, \`hermes-agent unreachable\`, \`model_not_found\`, \`Encrypted content is not supported\`, \`Unknown provider\`).

The comment block at lines 386-395 lists **\"Invalid API key\"** as the signal for the CP #238 boot-event 401 race + stale \`OPENAI_API_KEY\` paths, but the explicit \`grep\` for it was never added. \"Invalid API key\" doesn't match the generic \`error|exception\` catch-all that follows, so a regression in that class would slip through.

This PR closes that gap with one specific-pattern check that fails loud with the relevant bug references in the message.

## What this catches

- CP #238 — boot-event 401 race during tenant provision (org_instances INSERT order issue)
- Stale \`OPENAI_API_KEY\` in the runtime env after a token rotation

Both have a clean signature: the LLM caller-side returns a 401 / 403 with the body containing \"Invalid API key\". Adding the explicit grep makes the regression unambiguous in CI logs instead of falling through to the catch-all.

## Test plan
- [x] \`bash -n tests/e2e/test_staging_full_saas.sh\` — syntax clean
- [x] shellcheck shows only the pre-existing SC2015 at line 88 (unrelated)
- [ ] CI green
- [ ] Auto-merge on green

Partial close of #1900 (one row of the meta-tracker — \"E2E asserts A2A real response\" priority item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)