### PR TITLE
feat(workspaces): wire max_concurrent_tasks from template config.yaml (#1408)

### DIFF
--- a/workspace-server/internal/handlers/handlers_additional_test.go
+++ b/workspace-server/internal/handlers/handlers_additional_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -31,7 +32,7 @@ func TestWorkspaceCreate_WithParentID(t *testing.T) {
 	mock.ExpectBegin()
 	// Default tier is 3 (Privileged) — see workspace.go create-handler comment.
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Child Agent", nil, 3, "langgraph", sqlmock.AnyArg(), &parentID, nil, "none", (*int64)(nil), 1).
+		WithArgs(sqlmock.AnyArg(), "Child Agent", nil, 3, "langgraph", sqlmock.AnyArg(), &parentID, nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -66,7 +67,7 @@ func TestWorkspaceCreate_ExplicitClaudeCodeRuntime(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "CC Agent", nil, 2, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 1).
+		WithArgs(sqlmock.AnyArg(), "CC Agent", nil, 2, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -277,12 +278,8 @@ func TestWorkspaceList_WithData(t *testing.T) {
 	}
 }
 
-// ---------- workspace.go: Create with explicit max_concurrent_tasks (#1408) ----------
+// ---------- workspace.go: Create with explicit max_concurrent_tasks ----------
 
-// Locks the wire-up that lets a leader workspace's template config.yaml
-// (or a direct API caller) set max_concurrent_tasks > 1 so an in-flight
-// cron doesn't reject incoming A2A delegations. Schema default is 1; a
-// non-zero payload value must reach the INSERT verbatim.
 func TestWorkspaceCreate_MaxConcurrentTasksOverride(t *testing.T) {
 	mock := setupTestDB(t)
 	setupTestRedis(t)
@@ -290,7 +287,6 @@ func TestWorkspaceCreate_MaxConcurrentTasksOverride(t *testing.T) {
 	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
 
 	mock.ExpectBegin()
-	// 11th arg = max_concurrent_tasks; payload says 3, must propagate.
 	mock.ExpectExec("INSERT INTO workspaces").
 		WithArgs(sqlmock.AnyArg(), "Leader Agent", nil, 3, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 3).
 		WillReturnResult(sqlmock.NewResult(0, 1))

--- a/workspace-server/internal/handlers/handlers_additional_test.go
+++ b/workspace-server/internal/handlers/handlers_additional_test.go
@@ -31,7 +31,7 @@ func TestWorkspaceCreate_WithParentID(t *testing.T) {
 	mock.ExpectBegin()
 	// Default tier is 3 (Privileged) — see workspace.go create-handler comment.
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Child Agent", nil, 3, "langgraph", sqlmock.AnyArg(), &parentID, nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "Child Agent", nil, 3, "langgraph", sqlmock.AnyArg(), &parentID, nil, "none", (*int64)(nil), 1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -66,7 +66,7 @@ func TestWorkspaceCreate_ExplicitClaudeCodeRuntime(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "CC Agent", nil, 2, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "CC Agent", nil, 2, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -271,6 +271,45 @@ func TestWorkspaceList_WithData(t *testing.T) {
 	}
 	if resp[1]["agent_card"] != nil {
 		t.Errorf("expected nil agent_card for 'null', got %v", resp[1]["agent_card"])
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+// ---------- workspace.go: Create with explicit max_concurrent_tasks (#1408) ----------
+
+// Locks the wire-up that lets a leader workspace's template config.yaml
+// (or a direct API caller) set max_concurrent_tasks > 1 so an in-flight
+// cron doesn't reject incoming A2A delegations. Schema default is 1; a
+// non-zero payload value must reach the INSERT verbatim.
+func TestWorkspaceCreate_MaxConcurrentTasksOverride(t *testing.T) {
+	mock := setupTestDB(t)
+	setupTestRedis(t)
+	broadcaster := newTestBroadcaster()
+	handler := NewWorkspaceHandler(broadcaster, nil, "http://localhost:8080", t.TempDir())
+
+	mock.ExpectBegin()
+	// 11th arg = max_concurrent_tasks; payload says 3, must propagate.
+	mock.ExpectExec("INSERT INTO workspaces").
+		WithArgs(sqlmock.AnyArg(), "Leader Agent", nil, 3, "claude-code", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 3).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+	mock.ExpectExec("INSERT INTO canvas_layouts").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec("INSERT INTO structure_events").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	body := `{"name":"Leader Agent","runtime":"claude-code","max_concurrent_tasks":3}`
+	c.Request = httptest.NewRequest("POST", "/workspaces", bytes.NewBufferString(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Create(c)
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected 201, got %d: %s", w.Code, w.Body.String())
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unmet expectations: %v", err)

--- a/workspace-server/internal/handlers/handlers_test.go
+++ b/workspace-server/internal/handlers/handlers_test.go
@@ -290,8 +290,10 @@ func TestWorkspaceCreate(t *testing.T) {
 
 	// Expect workspace INSERT (uuid is dynamic, use AnyArg for id, runtime, awareness_namespace).
 	// Default tier is 3 (Privileged) — see workspace.go create-handler comment.
+	// 11th arg: max_concurrent_tasks defaults to 1 when payload omits it
+	// (see workspace.go Create handler — schema default mirror, #1408).
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Test Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "Test Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 1).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// Expect transaction commit (no secrets in this payload)

--- a/workspace-server/internal/handlers/handlers_test.go
+++ b/workspace-server/internal/handlers/handlers_test.go
@@ -290,10 +290,8 @@ func TestWorkspaceCreate(t *testing.T) {
 
 	// Expect workspace INSERT (uuid is dynamic, use AnyArg for id, runtime, awareness_namespace).
 	// Default tier is 3 (Privileged) — see workspace.go create-handler comment.
-	// 11th arg: max_concurrent_tasks defaults to 1 when payload omits it
-	// (see workspace.go Create handler — schema default mirror, #1408).
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Test Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), 1).
+		WithArgs(sqlmock.AnyArg(), "Test Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	// Expect transaction commit (no secrets in this payload)

--- a/workspace-server/internal/handlers/org.go
+++ b/workspace-server/internal/handlers/org.go
@@ -287,13 +287,7 @@ type OrgWorkspace struct {
 	// InitialMemories are memories seeded into this workspace at creation
 	// time. If empty, defaults.initial_memories are used. Issue #1050.
 	InitialMemories []models.MemorySeed `yaml:"initial_memories" json:"initial_memories"`
-	// MaxConcurrentTasks lets a leader workspace handle multiple A2A
-	// messages + cron fires concurrently (#1408). Default 1 keeps the
-	// classic worker-style serialised execution; bump to 3 for leaders
-	// (PM, leads with 5-min orchestrator pulses) so an in-flight cron
-	// doesn't reject incoming A2A delegations. Wired into the workspaces
-	// table at template-import time + read by the scheduler's capacity
-	// check (workspace-server/internal/scheduler/scheduler.go).
+	// MaxConcurrentTasks: see models.CreateWorkspacePayload.
 	MaxConcurrentTasks int                 `yaml:"max_concurrent_tasks" json:"max_concurrent_tasks"`
 	Schedules          []OrgSchedule       `yaml:"schedules" json:"schedules"`
 	Channels           []OrgChannel        `yaml:"channels" json:"channels"`

--- a/workspace-server/internal/handlers/org.go
+++ b/workspace-server/internal/handlers/org.go
@@ -287,8 +287,16 @@ type OrgWorkspace struct {
 	// InitialMemories are memories seeded into this workspace at creation
 	// time. If empty, defaults.initial_memories are used. Issue #1050.
 	InitialMemories []models.MemorySeed `yaml:"initial_memories" json:"initial_memories"`
-	Schedules       []OrgSchedule       `yaml:"schedules" json:"schedules"`
-	Channels        []OrgChannel        `yaml:"channels" json:"channels"`
+	// MaxConcurrentTasks lets a leader workspace handle multiple A2A
+	// messages + cron fires concurrently (#1408). Default 1 keeps the
+	// classic worker-style serialised execution; bump to 3 for leaders
+	// (PM, leads with 5-min orchestrator pulses) so an in-flight cron
+	// doesn't reject incoming A2A delegations. Wired into the workspaces
+	// table at template-import time + read by the scheduler's capacity
+	// check (workspace-server/internal/scheduler/scheduler.go).
+	MaxConcurrentTasks int                 `yaml:"max_concurrent_tasks" json:"max_concurrent_tasks"`
+	Schedules          []OrgSchedule       `yaml:"schedules" json:"schedules"`
+	Channels           []OrgChannel        `yaml:"channels" json:"channels"`
 	External        bool                `yaml:"external" json:"external"`
 	URL             string              `yaml:"url" json:"url"`
 	Canvas          struct {

--- a/workspace-server/internal/handlers/org_import.go
+++ b/workspace-server/internal/handlers/org_import.go
@@ -103,10 +103,17 @@ func (h *OrgHandler) createWorkspaceTree(ws OrgWorkspace, parentID *string, absX
 	// (see canvas-topology.ts), so imports don't spray the viewport.
 	initialCollapsed := false
 
+	// max_concurrent_tasks from org template (#1408). 0/omitted → schema
+	// default of 1. Leaders typically set 3 in their org.yaml so an
+	// in-flight cron doesn't reject incoming A2A delegations.
+	maxConcurrent := ws.MaxConcurrentTasks
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
 	_, err := db.DB.ExecContext(ctx, `
-		INSERT INTO workspaces (id, name, role, tier, runtime, awareness_namespace, status, parent_id, workspace_dir, workspace_access)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
-	`, id, ws.Name, role, tier, runtime, awarenessNS, "provisioning", parentID, workspaceDir, workspaceAccess)
+		INSERT INTO workspaces (id, name, role, tier, runtime, awareness_namespace, status, parent_id, workspace_dir, workspace_access, max_concurrent_tasks)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+	`, id, ws.Name, role, tier, runtime, awarenessNS, "provisioning", parentID, workspaceDir, workspaceAccess, maxConcurrent)
 	if err != nil {
 		log.Printf("Org import: failed to create %s: %v", ws.Name, err)
 		return fmt.Errorf("failed to create %s: %w", ws.Name, err)

--- a/workspace-server/internal/handlers/org_import.go
+++ b/workspace-server/internal/handlers/org_import.go
@@ -103,12 +103,9 @@ func (h *OrgHandler) createWorkspaceTree(ws OrgWorkspace, parentID *string, absX
 	// (see canvas-topology.ts), so imports don't spray the viewport.
 	initialCollapsed := false
 
-	// max_concurrent_tasks from org template (#1408). 0/omitted → schema
-	// default of 1. Leaders typically set 3 in their org.yaml so an
-	// in-flight cron doesn't reject incoming A2A delegations.
 	maxConcurrent := ws.MaxConcurrentTasks
 	if maxConcurrent <= 0 {
-		maxConcurrent = 1
+		maxConcurrent = models.DefaultMaxConcurrentTasks
 	}
 	_, err := db.DB.ExecContext(ctx, `
 		INSERT INTO workspaces (id, name, role, tier, runtime, awareness_namespace, status, parent_id, workspace_dir, workspace_access, max_concurrent_tasks)

--- a/workspace-server/internal/handlers/workspace.go
+++ b/workspace-server/internal/handlers/workspace.go
@@ -210,12 +210,9 @@ func (h *WorkspaceHandler) Create(c *gin.Context) {
 		return
 	}
 
-	// max_concurrent_tasks: payload-supplied → write as-is; 0/omitted →
-	// fall back to the schema default (1). Single INSERT shape regardless,
-	// avoids a forked column list. (#1408)
 	maxConcurrent := payload.MaxConcurrentTasks
 	if maxConcurrent <= 0 {
-		maxConcurrent = 1
+		maxConcurrent = models.DefaultMaxConcurrentTasks
 	}
 	// Insert workspace with runtime persisted in DB (inside transaction)
 	_, err := tx.ExecContext(ctx, `

--- a/workspace-server/internal/handlers/workspace.go
+++ b/workspace-server/internal/handlers/workspace.go
@@ -210,11 +210,18 @@ func (h *WorkspaceHandler) Create(c *gin.Context) {
 		return
 	}
 
+	// max_concurrent_tasks: payload-supplied → write as-is; 0/omitted →
+	// fall back to the schema default (1). Single INSERT shape regardless,
+	// avoids a forked column list. (#1408)
+	maxConcurrent := payload.MaxConcurrentTasks
+	if maxConcurrent <= 0 {
+		maxConcurrent = 1
+	}
 	// Insert workspace with runtime persisted in DB (inside transaction)
 	_, err := tx.ExecContext(ctx, `
-		INSERT INTO workspaces (id, name, role, tier, runtime, awareness_namespace, status, parent_id, workspace_dir, workspace_access, budget_limit)
-		VALUES ($1, $2, $3, $4, $5, $6, 'provisioning', $7, $8, $9, $10)
-	`, id, payload.Name, role, payload.Tier, payload.Runtime, awarenessNamespace, payload.ParentID, workspaceDir, workspaceAccess, payload.BudgetLimit)
+		INSERT INTO workspaces (id, name, role, tier, runtime, awareness_namespace, status, parent_id, workspace_dir, workspace_access, budget_limit, max_concurrent_tasks)
+		VALUES ($1, $2, $3, $4, $5, $6, 'provisioning', $7, $8, $9, $10, $11)
+	`, id, payload.Name, role, payload.Tier, payload.Runtime, awarenessNamespace, payload.ParentID, workspaceDir, workspaceAccess, payload.BudgetLimit, maxConcurrent)
 	if err != nil {
 		tx.Rollback() //nolint:errcheck
 		log.Printf("Create workspace error: %v", err)

--- a/workspace-server/internal/handlers/workspace_budget_test.go
+++ b/workspace-server/internal/handlers/workspace_budget_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -150,6 +151,7 @@ func TestWorkspaceBudget_Create_WithLimit(t *testing.T) {
 			nil,              // workspace_dir
 			"none",           // workspace_access
 			&budgetVal,       // budget_limit ($10)
+			models.DefaultMaxConcurrentTasks, // max_concurrent_tasks default
 		).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()

--- a/workspace-server/internal/handlers/workspace_test.go
+++ b/workspace-server/internal/handlers/workspace_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/models"
 	"github.com/gin-gonic/gin"
 )
 
@@ -154,7 +155,7 @@ func TestWorkspaceCreate_DBInsertError(t *testing.T) {
 	// Transaction begins, workspace INSERT fails, transaction is rolled back.
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Failing Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "Failing Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnError(sql.ErrConnDone)
 	mock.ExpectRollback()
 
@@ -187,7 +188,7 @@ func TestWorkspaceCreate_DefaultsApplied(t *testing.T) {
 	// Expect workspace INSERT with defaulted tier=3 (Privileged — the
 	// handler default in workspace.go), runtime="langgraph"
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Default Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "Default Agent", nil, 3, "langgraph", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 
@@ -238,7 +239,7 @@ func TestWorkspaceCreate_WithSecrets_Persists(t *testing.T) {
 
 	mock.ExpectBegin()
 	mock.ExpectExec("INSERT INTO workspaces").
-		WithArgs(sqlmock.AnyArg(), "Hermes Agent", nil, 3, "hermes", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+		WithArgs(sqlmock.AnyArg(), "Hermes Agent", nil, 3, "hermes", sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	// Secret inserted inside the same transaction.
 	mock.ExpectExec("INSERT INTO workspace_secrets").
@@ -1257,7 +1258,7 @@ runtime_config:
 	mock.ExpectExec("INSERT INTO workspaces").
 		WithArgs(
 			sqlmock.AnyArg(), "Hermes Agent", nil, 3, "hermes",
-			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -1314,7 +1315,7 @@ model: anthropic:claude-sonnet-4-5
 	mock.ExpectExec("INSERT INTO workspaces").
 		WithArgs(
 			sqlmock.AnyArg(), "Legacy Agent", nil, 3, "langgraph",
-			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").
@@ -1367,7 +1368,7 @@ runtime_config:
 	mock.ExpectExec("INSERT INTO workspaces").
 		WithArgs(
 			sqlmock.AnyArg(), "Custom Hermes", nil, 3, "hermes",
-			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil)).
+			sqlmock.AnyArg(), (*string)(nil), nil, "none", (*int64)(nil), models.DefaultMaxConcurrentTasks).
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	mock.ExpectCommit()
 	mock.ExpectExec("INSERT INTO canvas_layouts").

--- a/workspace-server/internal/models/workspace.go
+++ b/workspace-server/internal/models/workspace.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+// DefaultMaxConcurrentTasks mirrors the workspaces.max_concurrent_tasks
+// schema default. Handlers that resolve a 0/omitted payload value write
+// this constant so the read-side (scheduler capacity check) sees a
+// guaranteed non-zero column on every row.
+const DefaultMaxConcurrentTasks = 1
+
 type Workspace struct {
 	ID                 string          `json:"id" db:"id"`
 	Name               string          `json:"name" db:"name"`
@@ -85,11 +91,8 @@ type CreateWorkspacePayload struct {
 	// workspace secrets at creation time.  Stored encrypted (same path as
 	// POST /workspaces/:id/secrets).  Nil/empty map is a no-op.
 	Secrets map[string]string `json:"secrets"`
-	// MaxConcurrentTasks caps how many A2A messages + cron fires the
-	// scheduler will dispatch in parallel for this workspace (#1408).
-	// 0 = use the schema default of 1 (serialised, worker-style).
-	// Set to 3 for leaders with frequent orchestrator pulses so an
-	// in-flight cron doesn't reject incoming A2A delegations.
+	// MaxConcurrentTasks caps parallel A2A + cron dispatch. 0 means use
+	// DefaultMaxConcurrentTasks. Leaders typically set 3.
 	MaxConcurrentTasks int `json:"max_concurrent_tasks"`
 	Canvas   struct {
 		X float64 `json:"x"`

--- a/workspace-server/internal/models/workspace.go
+++ b/workspace-server/internal/models/workspace.go
@@ -85,6 +85,12 @@ type CreateWorkspacePayload struct {
 	// workspace secrets at creation time.  Stored encrypted (same path as
 	// POST /workspaces/:id/secrets).  Nil/empty map is a no-op.
 	Secrets map[string]string `json:"secrets"`
+	// MaxConcurrentTasks caps how many A2A messages + cron fires the
+	// scheduler will dispatch in parallel for this workspace (#1408).
+	// 0 = use the schema default of 1 (serialised, worker-style).
+	// Set to 3 for leaders with frequent orchestrator pulses so an
+	// in-flight cron doesn't reject incoming A2A delegations.
+	MaxConcurrentTasks int `json:"max_concurrent_tasks"`
 	Canvas   struct {
 		X float64 `json:"x"`
 		Y float64 `json:"y"`


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

## Summary

Phase 4 of #1408 (active_tasks counter for fair cron-vs-A2A dispatch). Wires the missing write path so a leader workspace's `max_concurrent_tasks: 3` in `org.yaml` actually reaches the DB column.

## Background

Three of the four pieces of #1408 already shipped:

| Piece | Status | Location |
|---|---|---|
| Runtime increment/decrement of `active_tasks` on heartbeat | shipped | `molecule-runtime/molecule_runtime/adapters/shared_runtime.py:162-166` |
| Schema column `max_concurrent_tasks INTEGER NOT NULL DEFAULT 1` | shipped | `migrations/037_max_concurrent_tasks.up.sql` |
| Scheduler capacity check (`activeTasks >= maxConcurrent → defer`) | shipped | `internal/scheduler/scheduler.go:312` |
| **Write path: template config.yaml + POST /workspaces → column** | **MISSING (this PR)** | `internal/handlers/{org_import.go, workspace.go}` |

Result: every workspace silently fell through to the schema default of 1, even when the template asked for 3. The capacity gate was effectively a no-op for the use case it was built for (PM / leads with frequent orchestrator pulses where a 5-min cron tick was rejecting incoming A2A delegations).

## Changes

- `models.CreateWorkspacePayload`: new `MaxConcurrentTasks int` json field
- `OrgWorkspace`: new `MaxConcurrentTasks int` yaml+json field (so `max_concurrent_tasks: 3` in `org.yaml` parses)
- `workspace.go` Create handler: INSERT now writes the 11th column; `0/omitted → 1` (schema-default mirror) keeps a single INSERT shape
- `org_import.go` insertWorkspace: same pattern for the template-driven path
- Existing two `Create`-handler test mocks updated to expect the 11th arg (`1`)
- New `TestWorkspaceCreate_MaxConcurrentTasksOverride` locks the payload→DB propagation for the leader case (`value=3`)

## Test plan

- [ ] CI: `go build ./...` + `go test ./internal/handlers/...` green
- [ ] Post-merge: bump PM org template to `max_concurrent_tasks: 3`, re-import, query `SELECT name, max_concurrent_tasks FROM workspaces` and confirm PM row shows 3
- [ ] Verify scheduler.go:312 capacity check now actually defers a 4th in-flight task on PM (rather than always firing because 1==max)

🤖 Generated with [Claude Code](https://claude.com/claude-code)