### PR TITLE
feat(ci): add secret-scan workflow + reusable entry point for org-wide enrollment

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,152 @@
+name: Secret scan
+
+# Hard CI gate. Refuses any PR / push whose diff additions contain a
+# recognisable credential. Defense-in-depth for the #2090-class incident
+# (2026-04-24): GitHub's hosted Copilot Coding Agent leaked a ghs_*
+# installation token into tenant-proxy/package.json via `npm init`
+# slurping the URL from a token-embedded origin remote. We can't fix
+# upstream's clone hygiene, so we gate here.
+#
+# Also the canonical reusable workflow for the rest of the org. Other
+# Molecule-AI repos enroll with a single 3-line workflow:
+#
+#   jobs:
+#     secret-scan:
+#       uses: Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main
+#
+# Same regex set as the runtime's bundled pre-commit hook
+# (molecule-ai-workspace-runtime: molecule_runtime/scripts/pre-commit-checks.sh).
+# Keep the two sides aligned when adding patterns.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main, staging]
+  # Required for GitHub merge queue: the queue's pre-merge CI run on
+  # `gh-readonly-queue/...` refs needs this check to fire so the queue
+  # gets a real result instead of stalling forever AWAITING_CHECKS.
+  merge_group:
+    types: [checks_requested]
+  # Reusable workflow entry point for other Molecule-AI repos.
+  workflow_call:
+
+jobs:
+  scan:
+    name: Scan diff for credential-shaped strings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit to diff against on push events
+
+      # For pull_request events the diff base may be many commits behind
+      # HEAD and absent from the shallow clone. Fetch it explicitly.
+      - name: Fetch PR base SHA (pull_request events only)
+        if: github.event_name == 'pull_request'
+        run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
+
+      - name: Refuse if credential-shaped strings appear in diff additions
+        run: |
+          # Pattern set covers GitHub family (the actual #2090 vector),
+          # Anthropic / OpenAI / Slack / AWS. Anchored on prefixes with low
+          # false-positive rates against agent-generated content. Mirror of
+          # molecule-ai-workspace-runtime/molecule_runtime/scripts/pre-commit-checks.sh
+          # — keep aligned.
+          SECRET_PATTERNS=(
+            'ghp_[A-Za-z0-9]{36,}'           # GitHub PAT (classic)
+            'ghs_[A-Za-z0-9]{36,}'           # GitHub App installation token
+            'gho_[A-Za-z0-9]{36,}'           # GitHub OAuth user-to-server
+            'ghu_[A-Za-z0-9]{36,}'           # GitHub OAuth user
+            'ghr_[A-Za-z0-9]{36,}'           # GitHub OAuth refresh
+            'github_pat_[A-Za-z0-9_]{82,}'   # GitHub fine-grained PAT
+            'sk-ant-[A-Za-z0-9_-]{40,}'      # Anthropic API key
+            'sk-proj-[A-Za-z0-9_-]{40,}'     # OpenAI project key
+            'sk-svcacct-[A-Za-z0-9_-]{40,}'  # OpenAI service-account key
+            'xox[baprs]-[A-Za-z0-9-]{20,}'   # Slack tokens
+            'AKIA[0-9A-Z]{16}'               # AWS access key ID
+            'ASIA[0-9A-Z]{16}'               # AWS STS temp access key ID
+          )
+
+          # Determine the diff base.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.event.after }}"
+          fi
+
+          # Files added or modified in this change.
+          if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
+            # New branch / no previous SHA — check the entire tree as
+            # added content. Slower, but correct on first push.
+            CHANGED=$(git ls-tree -r --name-only HEAD)
+            DIFF_RANGE=""
+          else
+            CHANGED=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD")
+            DIFF_RANGE="$BASE $HEAD"
+          fi
+
+          if [ -z "$CHANGED" ]; then
+            echo "No changed files to inspect."
+            exit 0
+          fi
+
+          # Self-exclude: this workflow file legitimately contains the
+          # pattern strings as regex literals. Without an exclude it would
+          # block its own merge.
+          SELF=".github/workflows/secret-scan.yml"
+
+          OFFENDING=""
+          for f in $CHANGED; do
+            [ "$f" = "$SELF" ] && continue
+            if [ -n "$DIFF_RANGE" ]; then
+              ADDED=$(git diff --no-color --unified=0 "$BASE" "$HEAD" -- "$f" 2>/dev/null | grep -E '^\+[^+]' || true)
+            else
+              # No diff range (new branch first push) — scan the full file
+              # contents as if every line were new.
+              ADDED=$(cat "$f" 2>/dev/null || true)
+            fi
+            [ -z "$ADDED" ] && continue
+            for pattern in "${SECRET_PATTERNS[@]}"; do
+              if echo "$ADDED" | grep -qE "$pattern"; then
+                OFFENDING="${OFFENDING}${f} (matched: ${pattern})\n"
+                break
+              fi
+            done
+          done
+
+          if [ -n "$OFFENDING" ]; then
+            echo "::error::Credential-shaped strings detected in diff additions:"
+            printf "$OFFENDING"
+            echo ""
+            echo "The actual matched values are NOT echoed here, deliberately —"
+            echo "round-tripping a leaked credential into CI logs widens the blast"
+            echo "radius (logs are searchable + retained)."
+            echo ""
+            echo "Recovery:"
+            echo "  1. Remove the secret from the file. Replace with an env var"
+            echo "     reference (e.g. \${{ secrets.GITHUB_TOKEN }} in workflows,"
+            echo "     process.env.X in code)."
+            echo "  2. If the credential was already pushed (this PR's commit"
+            echo "     history reaches a public ref), treat it as compromised —"
+            echo "     ROTATE it immediately, do not just remove it. The token"
+            echo "     remains valid in git history forever and may be in any"
+            echo "     log/cache that consumed this branch."
+            echo "  3. Force-push the cleaned commit (or stack a revert) and"
+            echo "     re-run CI."
+            echo ""
+            echo "If the match is a false positive (test fixture, docs example,"
+            echo "or this workflow's own regex literals): use a clearly-fake"
+            echo "placeholder like ghs_EXAMPLE_DO_NOT_USE that doesn't satisfy"
+            echo "the length suffix, OR add the file path to the SELF exclude"
+            echo "list in this workflow with a short reason."
+            echo ""
+            echo "Mirror of the regex set lives in the runtime's bundled"
+            echo "pre-commit hook (molecule-ai-workspace-runtime:"
+            echo "molecule_runtime/scripts/pre-commit-checks.sh) — keep aligned."
+            exit 1
+          fi
+
+          echo "✓ No credential-shaped strings in this change."


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Org-wide CI gate against credential leaks. Defense-in-depth for the #2090-class incident — audit log proved the leak source was **GitHub's hosted Copilot Coding Agent** (UA `GitHub CLI 2.90.0 Agent/claude-code`), not Molecule's CP-BE. That agent runs in GitHub infra outside our control and clones with the token embedded in the remote URL; `npm init` then slurps it into `package.json`. We can't fix upstream's clone hygiene — we gate at the PR layer.

Pairs with `Molecule-AI/molecule-ai-workspace-runtime#55` which adds the same scan as a runtime-side pre-commit hook (catches commits made by **our** runtime; this PR catches commits made by GitHub-hosted agents that bypass our runtime).

## Single workflow, dual purpose

| Mode | Trigger | Effect |
|------|---------|--------|
| Self-gate | `pull_request`, `push` (main/staging), `merge_group` | Required check on this repo |
| Reusable | `workflow_call` | Other Molecule-AI repos enroll with 3 lines (see Rollout below) |

## Pattern set

Covers GitHub family (`ghp_`, `ghs_`, `gho_`, `ghu_`, `ghr_`, `github_pat_`), Anthropic, OpenAI, Slack, AWS. **Mirror of the runtime's bundled pre-commit hook** (`molecule-ai-workspace-runtime: molecule_runtime/scripts/pre-commit-checks.sh`). When either side adds a pattern, update both.

Anchored on prefixes with low false-positive rates against agent-generated content. No plain hex blobs (would false-positive on commit hashes / IDs).

## Error message redacts the matched value

Prints `<file> (matched: <pattern>)` only — the secret value never lands in CI logs (logs are searchable + retained, so echoing widens the blast radius).

## Self-exclude

`.github/workflows/secret-scan.yml` is on the SELF exclude list because the file's own regex literals would otherwise block its own merge.

## Rollout plan (follow-up PRs, separate scope)

After this lands, enroll the high-traffic repos surfaced in the audit log (top 5 by Copilot Coding Agent activity over 7 days):

| Rank | Repo | Agent events / 7d |
|------|------|-------------------|
| 1 | `molecule-core` | 1,781 — covered by this PR |
| 2 | `docs` | 170 |
| 3 | `molecule-monorepo` | 169 (suspect orphan — investigate first) |
| 4 | `molecule-controlplane` | TBD (high-value: provisions tenants) |
| 5 | `molecule-ai-workspace-runtime` | TBD (publishes to PyPI — secret leak = supply chain risk) |

Each enrollment PR is 3 lines:

```yaml
name: Secret scan
on: [pull_request, push, merge_group]
jobs:
  scan:
    uses: Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main
```

Plus a one-line branch-protection update to mark `Scan diff for credential-shaped strings` as required.

## Test plan

- [ ] CI on this PR: the workflow self-runs and passes (no secret-shaped strings in the workflow file itself thanks to SELF exclude)
- [ ] Verify SELF exclude: the regex literals in the workflow file would otherwise match `ghs_[A-Za-z0-9]{36,}` against itself; if SELF didn't work the workflow would fail on its own merge
- [ ] Post-merge: open a follow-up enrollment PR for `molecule-controlplane` as the canary consumer to confirm `workflow_call` cross-repo invocation works
- [ ] Post-merge follow-up: confirm `molecule-monorepo` repo's 169 agent events are legitimate (not orphan) before enrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
