### PR TITLE
fix(canvas): prune lastFitSubtreeIdsRef on stale roots (#2070)

### DIFF
--- a/canvas/src/components/canvas/__tests__/useCanvasViewport.test.ts
+++ b/canvas/src/components/canvas/__tests__/useCanvasViewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { pruneStaleSubtreeIds, shouldFitGrowing } from "../useCanvasViewport";
+import { pruneStaleKeys, shouldFitGrowing } from "../useCanvasViewport";
 
 // Tests cover the auto-fit gate in isolation. The hook itself is
 // effects + refs + React Flow handles, awkward to exercise directly —
@@ -52,37 +52,47 @@ describe("shouldFitGrowing", () => {
   });
 });
 
-describe("pruneStaleSubtreeIds (#2070)", () => {
-  it("drops entries whose root is no longer in the live node set", () => {
+describe("pruneStaleKeys (#2070)", () => {
+  it("drops entries whose key is no longer in the live key set", () => {
     const map = new Map<string, Set<string>>([
       ["root-1", new Set(["root-1", "a"])],
       ["root-2", new Set(["root-2", "b"])],
       ["root-3", new Set(["root-3", "c"])],
     ]);
-    pruneStaleSubtreeIds(map, new Set(["root-1", "root-3"]));
+    pruneStaleKeys(map, new Set(["root-1", "root-3"]));
     expect([...map.keys()].sort()).toEqual(["root-1", "root-3"]);
   });
 
-  it("is a no-op when every root is still live", () => {
+  it("is a no-op when every key is still live", () => {
     const map = new Map<string, Set<string>>([
       ["root-1", new Set(["root-1"])],
       ["root-2", new Set(["root-2"])],
     ]);
-    pruneStaleSubtreeIds(map, new Set(["root-1", "root-2"]));
+    pruneStaleKeys(map, new Set(["root-1", "root-2"]));
     expect(map.size).toBe(2);
   });
 
-  it("clears the map when no live roots remain", () => {
+  it("clears the map when no live keys remain", () => {
     const map = new Map<string, Set<string>>([
       ["root-1", new Set(["root-1"])],
     ]);
-    pruneStaleSubtreeIds(map, new Set());
+    pruneStaleKeys(map, new Set());
     expect(map.size).toBe(0);
   });
 
   it("does not add new entries — only deletes stale ones", () => {
     const map = new Map<string, Set<string>>();
-    pruneStaleSubtreeIds(map, new Set(["root-1", "root-2"]));
+    pruneStaleKeys(map, new Set(["root-1", "root-2"]));
     expect(map.size).toBe(0);
+  });
+
+  it("preserves value identity for survivors (no rebuild)", () => {
+    const survivor = new Set(["root-1", "a"]);
+    const map = new Map<string, Set<string>>([
+      ["root-1", survivor],
+      ["root-2", new Set(["root-2", "b"])],
+    ]);
+    pruneStaleKeys(map, new Set(["root-1"]));
+    expect(map.get("root-1")).toBe(survivor);
   });
 });

--- a/canvas/src/components/canvas/__tests__/useCanvasViewport.test.ts
+++ b/canvas/src/components/canvas/__tests__/useCanvasViewport.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { shouldFitGrowing } from "../useCanvasViewport";
+import { pruneStaleSubtreeIds, shouldFitGrowing } from "../useCanvasViewport";
 
 // Tests cover the auto-fit gate in isolation. The hook itself is
 // effects + refs + React Flow handles, awkward to exercise directly —
@@ -49,5 +49,40 @@ describe("shouldFitGrowing", () => {
   it("does NOT fit on shrink-only when the user has panned (deletion alone shouldn't override exploration)", () => {
     const prev = new Set(["root", "a", "b", "c"]);
     expect(shouldFitGrowing(["root", "a", "b"], prev, 5_000, 1_000)).toBe(false);
+  });
+});
+
+describe("pruneStaleSubtreeIds (#2070)", () => {
+  it("drops entries whose root is no longer in the live node set", () => {
+    const map = new Map<string, Set<string>>([
+      ["root-1", new Set(["root-1", "a"])],
+      ["root-2", new Set(["root-2", "b"])],
+      ["root-3", new Set(["root-3", "c"])],
+    ]);
+    pruneStaleSubtreeIds(map, new Set(["root-1", "root-3"]));
+    expect([...map.keys()].sort()).toEqual(["root-1", "root-3"]);
+  });
+
+  it("is a no-op when every root is still live", () => {
+    const map = new Map<string, Set<string>>([
+      ["root-1", new Set(["root-1"])],
+      ["root-2", new Set(["root-2"])],
+    ]);
+    pruneStaleSubtreeIds(map, new Set(["root-1", "root-2"]));
+    expect(map.size).toBe(2);
+  });
+
+  it("clears the map when no live roots remain", () => {
+    const map = new Map<string, Set<string>>([
+      ["root-1", new Set(["root-1"])],
+    ]);
+    pruneStaleSubtreeIds(map, new Set());
+    expect(map.size).toBe(0);
+  });
+
+  it("does not add new entries — only deletes stale ones", () => {
+    const map = new Map<string, Set<string>>();
+    pruneStaleSubtreeIds(map, new Set(["root-1", "root-2"]));
+    expect(map.size).toBe(0);
   });
 });

--- a/canvas/src/components/canvas/useCanvasViewport.ts
+++ b/canvas/src/components/canvas/useCanvasViewport.ts
@@ -41,6 +41,24 @@ export function shouldFitGrowing(
 }
 
 /**
+ * Drop entries from the last-fit snapshot map whose root id no longer
+ * exists in the live node set. Called on every fit attempt — the cost
+ * is O(map_size) and runs only at user-driven cadence (deploys), so
+ * the map is bounded by "roots present right now" instead of growing
+ * unbounded across long sessions of import-then-delete cycles. (#2070)
+ */
+export function pruneStaleSubtreeIds(
+  map: Map<string, Set<string>>,
+  liveNodeIds: ReadonlySet<string>,
+): void {
+  for (const rootId of map.keys()) {
+    if (!liveNodeIds.has(rootId)) {
+      map.delete(rootId);
+    }
+  }
+}
+
+/**
  * Wires the two canvas-wide CustomEvent listeners and the viewport
  * save/restore bookkeeping so Canvas.tsx doesn't have to.
  *
@@ -251,10 +269,9 @@ export function useCanvasViewport() {
   // brand-new node landed off-screen. The id-set sees the new id
   // wasn't in the snapshot and forces the fit.
   //
-  // Map is keyed by root id and never pruned. Acceptable today because
-  // org roots are UUIDs (no collisions on retry / template re-import),
-  // canvas sessions are per-tab, and entries are tiny. Worth a sweep
-  // if long-lived sessions ever start importing hundreds of orgs.
+  // Map is keyed by root id. Pruned at the top of `runFit` against the
+  // live node set, so deleted roots don't accumulate across long
+  // sessions of import-then-delete cycles (#2070).
   const lastFitSubtreeIdsRef = useRef<Map<string, Set<string>>>(new Map());
   useEffect(() => {
     const runFit = () => {
@@ -262,6 +279,10 @@ export function useCanvasViewport() {
       pendingFitRootRef.current = null;
       if (!rootCandidate) return;
       const state = useCanvasStore.getState();
+      pruneStaleSubtreeIds(
+        lastFitSubtreeIdsRef.current,
+        new Set(state.nodes.map((n) => n.id)),
+      );
       // Climb to the true root — the event's rootId is the just-
       // landed child's direct parent, which may itself be nested.
       let topId = rootCandidate;

--- a/canvas/src/components/canvas/useCanvasViewport.ts
+++ b/canvas/src/components/canvas/useCanvasViewport.ts
@@ -41,19 +41,16 @@ export function shouldFitGrowing(
 }
 
 /**
- * Drop entries from the last-fit snapshot map whose root id no longer
- * exists in the live node set. Called on every fit attempt — the cost
- * is O(map_size) and runs only at user-driven cadence (deploys), so
- * the map is bounded by "roots present right now" instead of growing
- * unbounded across long sessions of import-then-delete cycles. (#2070)
+ * Drop entries from `map` whose key isn't in `liveKeys`. Generic so the
+ * same shape can be reused for any keyed-by-node-id cache (#2070).
  */
-export function pruneStaleSubtreeIds(
-  map: Map<string, Set<string>>,
-  liveNodeIds: ReadonlySet<string>,
+export function pruneStaleKeys<T>(
+  map: Map<string, T>,
+  liveKeys: ReadonlySet<string>,
 ): void {
-  for (const rootId of map.keys()) {
-    if (!liveNodeIds.has(rootId)) {
-      map.delete(rootId);
+  for (const key of map.keys()) {
+    if (!liveKeys.has(key)) {
+      map.delete(key);
     }
   }
 }
@@ -269,9 +266,11 @@ export function useCanvasViewport() {
   // brand-new node landed off-screen. The id-set sees the new id
   // wasn't in the snapshot and forces the fit.
   //
-  // Map is keyed by root id. Pruned at the top of `runFit` against the
-  // live node set, so deleted roots don't accumulate across long
-  // sessions of import-then-delete cycles (#2070).
+  // Map is keyed by root id. Pruned in `runFit` against the live node
+  // set so deleted roots don't accumulate across long sessions of
+  // import-then-delete cycles (#2070). Bounded to "roots present right
+  // now" by that prune; cleanup runs only at user-driven cadence
+  // (deploys), so the rate naturally tracks growth.
   const lastFitSubtreeIdsRef = useRef<Map<string, Set<string>>>(new Map());
   useEffect(() => {
     const runFit = () => {
@@ -279,7 +278,7 @@ export function useCanvasViewport() {
       pendingFitRootRef.current = null;
       if (!rootCandidate) return;
       const state = useCanvasStore.getState();
-      pruneStaleSubtreeIds(
+      pruneStaleKeys(
         lastFitSubtreeIdsRef.current,
         new Set(state.nodes.map((n) => n.id)),
       );


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes #2070.

## Why

The `Map<rootId, Set<nodeId>>` in `canvas/src/components/canvas/useCanvasViewport.ts:258` accumulated entries indefinitely — added on every successful auto-fit, never deleted when a root left `state.nodes` (cascade delete or manual remove). Source comment already flagged this as a known leak; this PR is the actual cleanup.

Operationally invisible until thousands of imports, but the fix is cheap and lock-it-down-able with a unit test.

## How

Adds a small pure helper next to the existing `shouldFitGrowing` exporter:

```ts
export function pruneStaleSubtreeIds(
  map: Map<string, Set<string>>,
  liveNodeIds: ReadonlySet<string>,
): void { ... }
```

Called at the top of `runFit` before any read/write to the map. Bounds the map to "roots present right now" instead of "every root ever auto-fitted in this session." O(map_size) per fit, runs only at user-driven cadence (deploys), so the cleanup rate naturally tracks the growth rate.

**Why polling-on-fit instead of subscribe-to-store-deletes:**

Considered an event-driven cleanup via store subscription, but rejected:
- Adds subscription lifecycle (unsubscribe on unmount, ref equality vs subscriber identity).
- Map only matters during fit attempts. Cleanup *at fit time* is sufficient.
- Worst-case staleness window between an import-then-delete burst and the next fit is bounded by ~map_size × ~20 IDs × ~36 bytes = sub-MB. Issue's own priority assessment says "Low — operationally invisible until thousands of imports."

## Test plan

- [x] Unit tests added for `pruneStaleSubtreeIds` covering 4 cases: delete-some / no-op / clear-all / never-add (additive only)
- [x] CI green
- [ ] Post-merge: no behaviour change for any single-org session — fits still happen exactly when `shouldFitGrowing` says they should. Long-session import-delete-cycles will see the map size stay bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
