### PR TITLE
fix(publish-runtime): use PyPI Trusted Publisher (OIDC) instead of PYPI_TOKEN

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -16,7 +16,11 @@ name: publish-runtime
 #      build/molecule_runtime/ with imports rewritten (`a2a_client` →
 #      `molecule_runtime.a2a_client`).
 #   2. Builds wheel + sdist with `python -m build`.
-#   3. Publishes to PyPI via twine + repo secret PYPI_TOKEN.
+#   3. Publishes to PyPI via the PyPA Trusted Publisher action (OIDC).
+#      No static API token is stored — PyPI verifies the workflow's
+#      OIDC claim against the trusted-publisher config registered for
+#      molecule-ai-workspace-runtime (Molecule-AI/molecule-core,
+#      publish-runtime.yml, environment pypi-publish).
 #
 # After publish: the 8 template repos pick up the new version on their
 # next image rebuild (their requirements.txt pin
@@ -42,6 +46,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi-publish
+    permissions:
+      contents: read
+      id-token: write   # PyPI Trusted Publisher (OIDC) — no PYPI_TOKEN needed
     steps:
       - uses: actions/checkout@v4
 
@@ -106,12 +113,15 @@ jobs:
           print('✓ smoke import passed')
           "
 
-      - name: Publish to PyPI
-        working-directory: ${{ runner.temp }}/runtime-build
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-        run: python -m twine upload dist/*
+      - name: Publish to PyPI (Trusted Publisher / OIDC)
+        # PyPI side is configured: project molecule-ai-workspace-runtime →
+        # publisher Molecule-AI/molecule-core, workflow publish-runtime.yml,
+        # environment pypi-publish. The action mints a short-lived OIDC
+        # token and exchanges it for a PyPI upload credential — no static
+        # API token in this repo's secrets.
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: ${{ runner.temp }}/runtime-build/dist/
 
   cascade:
     # After PyPI accepts the upload, fan out a repository_dispatch to each


### PR DESCRIPTION
## Summary

- Migrates `publish-runtime.yml` from twine + `PYPI_TOKEN` to PyPI Trusted Publisher (OIDC)
- Adds `id-token: write` permission on the `publish` job (least-privilege; `cascade` job unchanged)
- Updates the workflow's header comment to reflect the new auth model

## Why

A leaked `PYPI_TOKEN` would let any holder publish arbitrary versions of `molecule-ai-workspace-runtime` to PyPI from anywhere — bypassing the monorepo's review and CI gates entirely. The 8 workspace template repos pull this package, so a malicious publish poisons all of them.

Trusted Publisher (OIDC) eliminates that exfil path: no long-lived credential exists to leak. Only this exact workflow, on this repo, in the `pypi-publish` environment, can upload.

This is the belt-and-suspenders companion to the sibling-repo lockdown PR (PR #56 in `molecule-ai-workspace-runtime`) — without OIDC, the sibling lockdown alone doesn't prevent a local \`python -m build && twine upload\` from a laptop with a personal PyPI maintainer credential.

## PyPI side (already done)

Trusted Publisher is configured at https://pypi.org/manage/project/molecule-ai-workspace-runtime/settings/publishing/ pointing at:
- Repository: `Molecule-AI/molecule-core`
- Workflow: `publish-runtime.yml`
- Environment: `pypi-publish`

## After this merges

1. Run a `workflow_dispatch` of `publish-runtime` with a dev version (e.g. \`0.1.6.dev1\`) to confirm OIDC end-to-end
2. Once a real publish succeeds, **delete the \`PYPI_TOKEN\` repo secret** (it becomes dead weight + a leak surface with no purpose)
3. Audit PyPI maintainers for the package and prune to the minimum (ideally zero human accounts; OIDC handles all publishes)

## Test plan

- [ ] CI green
- [ ] Manual `workflow_dispatch` with `version: 0.1.6.dev1` (or similar) succeeds and the version appears on PyPI
- [ ] Confirm `PYPI_TOKEN` secret is no longer referenced anywhere in the repo (\`gh secret list\` + \`grep -r PYPI_TOKEN .github/\`)

## Notes

- Conflicts with PR #2112 (smoke-test fix) — both touch lines around the publish step. Whichever lands second needs a trivial rebase
- Doc updates for \`docs/workspace-runtime-package.md\` (PYPI_TOKEN refs in PR #2111) follow in a separate change

🤖 Generated with [Claude Code](https://claude.com/claude-code)