### PR TITLE
chore: add CODEOWNERS to auto-route agent PRs to your personal review account

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# Default reviewer routing for molecule-core.
+#
+# `*` matches every changed path, so every PR auto-requests review from
+# @hongmingwang-moleculeai. The agent-PR pattern is that the
+# HongmingWang-Rabbit (agent) account authors PRs; this file routes
+# them into the personal account's review queue automatically — no
+# manual `gh pr edit --add-reviewer` per PR.
+#
+# Why CODEOWNERS instead of branch-protection's review-from-anyone gate:
+# the gate just says "1 review needed"; CODEOWNERS specifies *which*
+# reviewer the request goes to. Without it, agent PRs sit unreviewed
+# until a human happens to look at the queue.
+#
+# Note: `require_code_owner_reviews` on the staging branch protection
+# is currently OFF, so the routing is informational rather than
+# enforced. Flip it on (in branch protection settings) if you want
+# CODEOWNERS approval to be the *required* review type. Until then,
+# any approving review still satisfies the 1-review gate — this just
+# makes sure the right person sees it.
+*  @hongmingwang-moleculeai


### PR DESCRIPTION
## Summary

After the 1-required-review gate landed on staging in cycle 24, every agent-authored PR sits with \`REVIEW_REQUIRED\` until someone notices. \`CODEOWNERS\` solves the routing half: every changed path matches \`*\`, so GitHub auto-requests review from @hongmingwang-moleculeai (your personal account, separate from the HongmingWang-Rabbit agent identity). PRs land in your notification queue automatically — no per-PR \`gh pr edit --add-reviewer\` dance.

## What this does NOT do (yet)

The \`* @hongmingwang-moleculeai\` line is **informational** rather than enforced. Branch protection's \`require_code_owner_reviews\` flag is currently off, so any approving review still satisfies the 1-review gate. Flip that on later if you want CODEOWNERS approval to be the *required* review type.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: open a fresh PR (any of the upcoming agent-authored ones), verify \`@hongmingwang-moleculeai\` shows up in the requested-reviewers list automatically with no manual action

🤖 Generated with [Claude Code](https://claude.com/claude-code)