### PR TITLE
refactor(canvas): ProvisioningTimeout uses pruneStaleKeys helper (follow-up to #2110)

### DIFF
--- a/canvas/src/components/ProvisioningTimeout.tsx
+++ b/canvas/src/components/ProvisioningTimeout.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useCanvasStore, type WorkspaceNodeData } from "@/store/canvas";
+import { pruneStaleKeys } from "./canvas/useCanvasViewport";
 import { api } from "@/lib/api";
 import { showToast } from "./Toaster";
 import { ConsoleModal } from "./ConsoleModal";
@@ -125,11 +126,7 @@ export function ProvisioningTimeout({
 
     // Remove tracking for nodes that are no longer provisioning
     const activeIds = new Set(parsedProvisioningNodes.map((n) => n.id));
-    for (const id of tracking.keys()) {
-      if (!activeIds.has(id)) {
-        tracking.delete(id);
-      }
-    }
+    pruneStaleKeys(tracking, activeIds);
 
     // Also remove from timedOut list if no longer provisioning, and
     // clear `dismissed` entries for workspaces that finished so a


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Tiny follow-up to #2110 — migrate `ProvisioningTimeout.tsx` to use the now-merged `pruneStaleKeys` generic helper.

## Why

#2110 generalised the shape `for (const k of map.keys()) { if (!liveKeys.has(k)) map.delete(k); }` into `pruneStaleKeys<T>(map, liveKeys)` and the simplify reviewer flagged `ProvisioningTimeout.tsx:127-132` as the only other in-tree caller doing the exact same thing. Now that the helper is in `staging`, this PR closes the dedup loop.

## Diff

```
-    for (const id of tracking.keys()) {
-      if (!activeIds.has(id)) {
-        tracking.delete(id);
-      }
-    }
+    pruneStaleKeys(tracking, activeIds);
```

Net: -3 lines, one less hand-rolled GC loop. No behaviour change — `pruneStaleKeys` does exactly what the inline block did, and is unit-tested.

## Test plan

- [x] No new tests needed — `pruneStaleKeys` itself has 5 cases in `useCanvasViewport.test.ts` (delete-some / no-op / clear-all / never-add / preserve-value-identity)
- [ ] CI green
- [ ] No behaviour change to verify in browser — replacement is byte-equivalent semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)
