### PR TITLE
fix(ci): handle merge_group + shallow-clone BASE in secret-scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -46,7 +46,29 @@ jobs:
         if: github.event_name == 'pull_request'
         run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
 
+      # For merge_group events the queue's pre-merge ref is a commit on
+      # `gh-readonly-queue/...` whose parent is the queue's base_sha.
+      # That parent isn't part of the queue branch's shallow clone, so
+      # we fetch it explicitly. Without this the diff falls through to
+      # "no BASE → scan entire tree" mode and false-positives on legit
+      # test fixtures (e.g. canvas/src/lib/validation/__tests__/secret-formats.test.ts).
+      - name: Fetch merge_group base SHA (merge_group events only)
+        if: github.event_name == 'merge_group'
+        run: git fetch --depth=1 origin ${{ github.event.merge_group.base_sha }}
+
       - name: Refuse if credential-shaped strings appear in diff additions
+        env:
+          # Plumb event-specific SHAs through env so the script doesn't
+          # need conditional `${{ ... }}` interpolation per event type.
+          # github.event.before/after only exist on push events;
+          # merge_group has its own base_sha/head_sha; pull_request has
+          # pull_request.base.sha / pull_request.head.sha.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
         run: |
           # Pattern set covers GitHub family (the actual #2090 vector),
           # Anthropic / OpenAI / Slack / AWS. Anchored on prefixes with low
@@ -68,19 +90,41 @@ jobs:
             'ASIA[0-9A-Z]{16}'               # AWS STS temp access key ID
           )
 
-          # Determine the diff base.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.event.after }}"
+          # Determine the diff base. Each event type stores its SHAs in
+          # a different place — see the env block above.
+          case "${{ github.event_name }}" in
+            pull_request)
+              BASE="$PR_BASE_SHA"
+              HEAD="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              BASE="$MG_BASE_SHA"
+              HEAD="$MG_HEAD_SHA"
+              ;;
+            *)
+              BASE="$PUSH_BEFORE"
+              HEAD="$PUSH_AFTER"
+              ;;
+          esac
+
+          # On push events with shallow clones, BASE may be present in
+          # the event payload but absent from the local object DB
+          # (fetch-depth=2 doesn't always reach the previous commit
+          # across true merges). Try fetching it on demand. If the
+          # fetch fails — e.g. the SHA was force-overwritten — we fall
+          # through to the empty-BASE branch below, which scans the
+          # entire tree as if every file were new. Correct, just slow.
+          if [ -n "$BASE" ] && ! echo "$BASE" | grep -qE '^0+$'; then
+            if ! git cat-file -e "$BASE" 2>/dev/null; then
+              git fetch --depth=1 origin "$BASE" 2>/dev/null || true
+            fi
           fi
 
           # Files added or modified in this change.
-          if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
-            # New branch / no previous SHA — check the entire tree as
-            # added content. Slower, but correct on first push.
+          if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$' || ! git cat-file -e "$BASE" 2>/dev/null; then
+            # New branch / no previous SHA / BASE unreachable — check the
+            # entire tree as added content. Slower, but correct on first
+            # push.
             CHANGED=$(git ls-tree -r --name-only HEAD)
             DIFF_RANGE=""
           else

--- a/canvas/src/lib/validation/__tests__/secret-formats.test.ts
+++ b/canvas/src/lib/validation/__tests__/secret-formats.test.ts
@@ -143,7 +143,10 @@ describe('inferGroup', () => {
 
 describe('maskSecretValue', () => {
   it('masks ghp_ prefixed values showing prefix and last 4', () => {
-    const value = 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+    // Built via concatenation, not as a literal continuous string —
+    // a literal `ghp_` + 36+ alphanumerics matches the secret-scan
+    // workflow's own regex and false-positives merge_group / push runs.
+    const value = 'ghp_' + 'x'.repeat(40);
     const masked = maskSecretValue(value);
     expect(masked.startsWith('ghp_')).toBe(true);
     expect(masked.endsWith(value.slice(-4))).toBe(true);
@@ -151,7 +154,7 @@ describe('maskSecretValue', () => {
   });
 
   it('masks github_pat_ prefixed values', () => {
-    const value = 'github_pat_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx';
+    const value = 'github_pat_' + 'x'.repeat(82);
     const masked = maskSecretValue(value);
     expect(masked.startsWith('github_pat_')).toBe(true);
     expect(masked.endsWith(value.slice(-4))).toBe(true);


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

## What was breaking

Two distinct failure modes in `.github/workflows/secret-scan.yml`, both visible after PR #2115 / #2117 hit the merge queue:

1. **`merge_group` events**: the script reads `github.event.before / after` to determine BASE/HEAD. Those properties only exist on `push` events. On `merge_group` events both came back empty, the script fell through to *no BASE → scan entire tree* mode, and false-positived on `canvas/src/lib/validation/__tests__/secret-formats.test.ts` which contains a `ghp_xxxx…` literal as a masking-function fixture.
   - Run [24966890424](https://github.com/Molecule-AI/molecule-core/actions/runs/24966890424) — exit 1, `matched: ghp_[A-Za-z0-9]{36,}`.

2. **`push` events with shallow clone**: `fetch-depth: 2` doesn't always cover BASE across true merge commits. When BASE is in the payload but absent from the local object DB, `git diff` errors out with `fatal: bad object <sha>` and the job exits 128.
   - Run [24966796278](https://github.com/Molecule-AI/molecule-core/actions/runs/24966796278) — push at 20:53Z merging #2115.

## Fixes

- Dedicated fetch step for `merge_group.base_sha` (mirrors the existing pull_request base fetch).
- Event-specific SHAs moved into a step `env:` block; script now uses `case` over `${{ github.event_name }}` instead of *if pull_request / else push* which left merge_group on the empty branch.
- On-demand fetch for the push-event BASE when it isn't in the shallow clone, plus a `git cat-file -e` guard before the diff so we fall through cleanly to the *scan entire tree* path if the fetch fails (correct, just slower) instead of exiting 128.

## Defense-in-depth

`secret-formats.test.ts` had two literal continuous-string fixtures (`'ghp_xxxx…'`, `'github_pat_xxxx…'`). The ghp_ one matched the secret-scan regex. Switched both to the `'prefix_' + 'x'.repeat(N)` pattern already used elsewhere in the same file — runtime value is the same, but the literal source text no longer matches the regex even if BASE detection ever falls back to tree-scan mode again.

## Test plan

- [x] No remaining regex matches in `secret-formats.test.ts` source (verified via local grep)
- [x] YAML structure preserved
- [ ] CI passes on this PR's pull_request scan (was already passing for the green PR-event path)
- [ ] CI passes on this PR's merge_group scan (the new path under test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)