### PR TITLE
fix(canary): bump job timeout to 25m so bash fail + diagnostic can fire (#2090)

### DIFF
--- a/.github/workflows/canary-staging.yml
+++ b/.github/workflows/canary-staging.yml
@@ -38,7 +38,14 @@ jobs:
   canary:
     name: Canary smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # 25 min headroom over the 15-min TLS-readiness deadline in
+    # tests/e2e/test_staging_full_saas.sh (#2107). Without the buffer
+    # the job is killed at the wall-clock 15:00 mark BEFORE the bash
+    # `fail` + diagnostic burst can fire, leaving every cancellation
+    # silent. Sibling staging E2E jobs run at 20-45 min — keeping
+    # canary tighter than them so a true wedge still surfaces here
+    # first.
+    timeout-minutes: 25
 
     env:
       MOLECULE_CP_URL: https://staging-api.moleculesai.app


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Closes (the second-order bug in) #2090.

## What I missed in #2107

PR #2107 bumped the bash-side TLS-readiness deadline in `tests/e2e/test_staging_full_saas.sh` from 600s to 900s (15 min) AND added a diagnostic burst on the fail path so the next failure would identify the broken layer (DNS / TLS / HTTP).

I missed that **the canary workflow's own `timeout-minutes` was also 15**. So GitHub Actions killed the job at the 15:00 wall-clock mark BEFORE the bash `fail` + diagnostic could fire — every cancellation silent, no failure comment on #2090, no diagnostic data attached. The 21:03 UTC canary cancelled at 14:03 step time (~15:18 wall) without ever reaching the diagnostic block.

## What's even more interesting

cp#282 (admin-token cache-recovery) merged at 20:21 UTC. The 21:03 canary should have been the first one running with the fix on staging CP. The fact that it still timed out at TLS readiness — never reaching the workspace-online step — means **either**:

1. cp#282 hasn't deployed to staging CP yet (Railway lag — possible)
2. cp#282 is deployed but the failure mode is **different now** (DNS instead of HTTP 500 — possible — needs the diagnostic burst to confirm)
3. There's a third bug downstream

This PR doesn't pick a side — it just makes the diagnostic burst actually able to fire so the **next** canary cancellation ships data we can act on.

## Diff

```yaml
  canary:
    name: Canary smoke
    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25  # 10-min headroom over the 15-min bash deadline
```

Sibling staging E2E jobs run at 20/40/45 min — keeping canary tighter than them so a genuine wedge surfaces here first.

## Test plan

- [ ] CI green on this PR (workflow itself doesn't run on PR — only on schedule)
- [ ] Post-merge: next 22:00 UTC canary fire either (a) goes green = cp#282 fixed it, #2090 auto-closes, OR (b) fails-loud at the bash `fail` and posts the diagnostic burst (DNS lookup + curl -kv) on the issue thread, telling us the actual broken layer
- [ ] Either outcome is informative — current state (silent cancellation) is the only failure mode worth eliminating

🤖 Generated with [Claude Code](https://claude.com/claude-code)
