### PR TITLE
docs(ci): fix secret-scan reusable workflow self-doc — repo is molecule-core, ref is @staging

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,7 +12,11 @@ name: Secret scan
 #
 #   jobs:
 #     secret-scan:
-#       uses: Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main
+#       uses: Molecule-AI/molecule-core/.github/workflows/secret-scan.yml@staging
+#
+# Pin to @staging not @main — staging is the active default branch,
+# main lags via the staging-promotion workflow. Updates ride along
+# automatically on the next consumer workflow run.
 #
 # Same regex set as the runtime's bundled pre-commit hook
 # (molecule-ai-workspace-runtime: molecule_runtime/scripts/pre-commit-checks.sh).


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

Follow-up to #2109. The canonical secret-scan workflow's own self-documented enrollment example referenced `Molecule-AI/molecule-monorepo/.github/workflows/secret-scan.yml@main` which is wrong on two counts:

1. **Repo is molecule-core, not molecule-monorepo.** The repo was renamed at some point; `molecule-monorepo` is now a redirect alias (which is why the audit log review surfaced 169 'agent events on molecule-monorepo orphan' — those are events on the redirect, not a real orphaned repo).
2. **Ref must be `@staging` not `@main`.** Staging is the active default branch; main lags behind via the staging-promotion workflow.

Discovered while shipping the rollout PRs to molecule-controlplane (cp#286) and molecule-ai-workspace-runtime (#57) — both initially failed CI because the path resolved to a non-existent workflow. Fixed in both consumer PRs in the same iter; this PR fixes the canonical self-doc so future operators copy the right snippet.

## Test plan
- [ ] CI green (this PR has no behavioural change — it's a comment edit)
- [ ] Post-merge: cp#286 + runtime#57 both pass after their consumer-side fixes propagate