### PR TITLE
fix(ci): sweep prior UTC day in e2e safety nets (midnight-rollover)

### DIFF
--- a/.github/workflows/canary-staging.yml
+++ b/.github/workflows/canary-staging.yml
@@ -172,21 +172,26 @@ jobs:
           orgs=$(curl -sS "$MOLECULE_CP_URL/cp/admin/orgs" \
             -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
             | python3 -c "
-          import json, sys, os
+          import json, sys, os, datetime
           run_id = os.environ.get('GITHUB_RUN_ID', '')
           d = json.load(sys.stdin)
-          today = __import__('datetime').date.today().strftime('%Y%m%d')
           # Scope to slugs from THIS canary run when GITHUB_RUN_ID is
           # available; the canary workflow sets E2E_RUN_ID='canary-\${run_id}'
           # so the slug suffix is '-canary-\${run_id}-...'. Mirrors the
           # full-mode safety net's per-run scoping (e2e-staging-saas.yml)
           # added after the 2026-04-21 cross-run cleanup incident.
+          # Sweep both today AND yesterday's UTC dates so a run that
+          # crosses midnight still cleans up its own slug — see the
+          # 2026-04-26→27 canvas-safety-net incident.
+          today = datetime.date.today()
+          yesterday = today - datetime.timedelta(days=1)
+          dates = (today.strftime('%Y%m%d'), yesterday.strftime('%Y%m%d'))
           if run_id:
-              prefix = f'e2e-canary-{today}-canary-{run_id}'
+              prefixes = tuple(f'e2e-canary-{d}-canary-{run_id}' for d in dates)
           else:
-              prefix = f'e2e-canary-{today}-'
+              prefixes = tuple(f'e2e-canary-{d}-' for d in dates)
           candidates = [o['slug'] for o in d.get('orgs', [])
-                        if o.get('slug','').startswith(prefix)
+                        if any(o.get('slug','').startswith(p) for p in prefixes)
                         and o.get('status') not in ('purged',)]
           print('\n'.join(candidates))
           " 2>/dev/null)

--- a/.github/workflows/e2e-staging-canvas.yml
+++ b/.github/workflows/e2e-staging-canvas.yml
@@ -99,14 +99,27 @@ jobs:
           ADMIN_TOKEN: ${{ secrets.MOLECULE_STAGING_ADMIN_TOKEN }}
         run: |
           set +e
+          # Midnight-UTC rollover guard: a single-date filter misses
+          # orgs created on the prior UTC day when the run crosses
+          # midnight (incident 2026-04-26 23:46Z → 2026-04-27 00:12Z:
+          # slug `e2e-canvas-20260426-1u8nz3` survived because the
+          # safety-net step ran on the 27th, computed `today=20260427`,
+          # and the filter `e2e-canvas-20260427-` never matched). Sweep
+          # both today AND yesterday's dates so a cross-midnight run
+          # still cleans up its own slug.
           orgs=$(curl -sS "$MOLECULE_CP_URL/cp/admin/orgs" \
             -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
             | python3 -c "
-          import json, sys
+          import json, sys, datetime
           d = json.load(sys.stdin)
-          today = __import__('datetime').date.today().strftime('%Y%m%d')
+          today = datetime.date.today()
+          yesterday = today - datetime.timedelta(days=1)
+          prefixes = (
+              f'e2e-canvas-{today.strftime(\"%Y%m%d\")}-',
+              f'e2e-canvas-{yesterday.strftime(\"%Y%m%d\")}-',
+          )
           candidates = [o['slug'] for o in d.get('orgs', [])
-                        if o.get('slug','').startswith(f'e2e-canvas-{today}-')
+                        if any(o.get('slug','').startswith(p) for p in prefixes)
                         and o.get('status') not in ('purged',)]
           print('\n'.join(candidates))
           " 2>/dev/null)

--- a/.github/workflows/e2e-staging-saas.yml
+++ b/.github/workflows/e2e-staging-saas.yml
@@ -136,18 +136,26 @@ jobs:
           orgs=$(curl -sS "$MOLECULE_CP_URL/cp/admin/orgs" \
             -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
             | python3 -c "
-          import json, sys, os
+          import json, sys, os, datetime
           run_id = os.environ.get('GITHUB_RUN_ID', '')
           d = json.load(sys.stdin)
-          today = __import__('datetime').date.today().strftime('%Y%m%d')
           # ONLY sweep slugs from *this* CI run. Previously the filter was
           # f'e2e-{today}-' which stomped on parallel CI runs AND any manual
           # E2E probes a dev was running against staging (incident 2026-04-21
           # 15:02Z: this workflow's safety net deleted an unrelated manual
           # run's tenant 1s after it hit 'running').
-          prefix = f'e2e-{today}-{run_id}-' if run_id else f'e2e-{today}-'
+          # Sweep both today AND yesterday's UTC dates so a run that crosses
+          # midnight still matches its own slug — see the 2026-04-26→27
+          # canvas-safety-net incident for the same bug class.
+          today = datetime.date.today()
+          yesterday = today - datetime.timedelta(days=1)
+          dates = (today.strftime('%Y%m%d'), yesterday.strftime('%Y%m%d'))
+          if run_id:
+              prefixes = tuple(f'e2e-{d}-{run_id}-' for d in dates)
+          else:
+              prefixes = tuple(f'e2e-{d}-' for d in dates)
           candidates = [o['slug'] for o in d.get('orgs', [])
-                        if o.get('slug','').startswith(prefix)
+                        if any(o.get('slug','').startswith(p) for p in prefixes)
                         and o.get('instance_status') not in ('purged',)]
           print('\n'.join(candidates))
           " 2>/dev/null)


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

## What was breaking

All three staging e2e workflows' \"Teardown safety net\" steps filtered candidate slugs by \`f'e2e-...-{today}-...'\` where \`today\` was computed at safety-net-step time via \`datetime.date.today()\`.

When a run crossed midnight UTC (start before 00:00, end after), \`today\` became the NEXT day, but the slug it created carried the PRIOR day's date. The filter never matched its own slug → leak.

## Today's incident

E2E Staging Canvas run [24970092066](https://github.com/Molecule-AI/molecule-core/actions/runs/24970092066):
- started 2026-04-26 **23:45:59Z**
- created slug \`e2e-canvas-20260426-1u8nz3\` at 23:59Z
- ended 2026-04-27 **00:12:47Z** (failure)
- safety-net step ran with \`today=20260427\`
- filter \`e2e-canvas-20260427-\` did not match \`...20260426-1u8nz3\`
- tenant + child workspace EC2 both stayed up

Confirmed via CP staging logs: **no DELETE for \`1u8nz3\` ever issued.** The Playwright globalTeardown didn't fire (test crashed mid-run); the workflow safety-net was the last line and it missed.

## Fix

All three workflows now sweep BOTH today AND yesterday's UTC dates so a run that crosses midnight still matches its own slug:

\`\`\`python
today = datetime.date.today()
yesterday = today - datetime.timedelta(days=1)
dates = (today.strftime('%Y%m%d'), yesterday.strftime('%Y%m%d'))
prefixes = tuple(f'e2e-canvas-{d}-' for d in dates)  # canvas variant
\`\`\`

Per-run-id scoping (saas + canary) is preserved — the prior-day prefix still includes the run_id, so cross-midnight runs only sweep their own slugs.

## Why a two-day window vs arbitrary lookback

A run can't legitimately last more than 24h on GitHub-hosted runners (workflow \`timeout-minutes\` caps: canary=25, e2e-saas=45, canvas=30). Two-day window covers any cross-midnight run without widening cross-run-cleanup blast radius further. \`sweep-stale-e2e-orgs.yml\` cron (120-min age threshold) remains the catch-all for anything older.

## Test plan

- [x] Logic simulation: post-midnight slug matches yesterday's prefix; same-day still matches; 2-days-ago does NOT match; production tenant never matches
- [x] All three workflow YAMLs syntactically valid
- [ ] Next cross-midnight run cleans up its own slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)