### PR TITLE
test(notify): pre-sweep prior E2E workspaces so interrupted runs don't pile up

### DIFF
--- a/tests/e2e/test_notify_attachments_e2e.sh
+++ b/tests/e2e/test_notify_attachments_e2e.sh
@@ -66,6 +66,23 @@ assert_contains() {
 }
 
 echo "=== Setup ==="
+# Idempotent pre-sweep: a prior run that got SIGPIPE'd or kill -9'd before
+# the EXIT trap fired would leave a "Notify E2E" workspace sitting on the
+# canvas. Find and delete any with this exact name so the test is safe to
+# re-run from any state. Match by name (not tag) so this also catches
+# leftovers created by older script versions.
+PRIOR=$(curl -s "$BASE/workspaces" | python3 -c '
+import json, sys
+try:
+    print(" ".join(w["id"] for w in json.load(sys.stdin) if w.get("name") == "Notify E2E"))
+except Exception:
+    pass
+')
+for _wid in $PRIOR; do
+  echo "Sweeping leftover Notify E2E workspace: $_wid"
+  curl -s -X DELETE "$BASE/workspaces/$_wid?confirm=true" > /dev/null || true
+done
+
 R=$(curl -s -X POST "$BASE/workspaces" -H "Content-Type: application/json" \
   -d '{"name":"Notify E2E","tier":1}')
 WSID=$(echo "$R" | python3 -c 'import json,sys;print(json.load(sys.stdin)["id"])' 2>/dev/null || true)


### PR DESCRIPTION
## Summary
Follow-up to PR #2132. User flagged a leftover \"Notify E2E\" workspace sitting on the canvas — caused by my earlier debug run getting SIGPIPE'd before the EXIT trap could fire. Add an idempotent pre-sweep at the top of the script so the next run cleans up any prior leftover with the same name.

Belt-and-suspenders with the existing trap; both have to fail for a leak to persist.

## Test plan
- [x] Normal run: 14/14 pass, 0 leftovers
- [x] SIGTERM mid-setup (timeout 1): trap fires, 0 leftovers
- [x] Re-run after interruption: pre-sweep + new run both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)