### PR TITLE
chore(secret-scan): add sk-cp- MiniMax pattern (F1088 retroactive fix)

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -89,6 +89,7 @@ jobs:
             'sk-ant-[A-Za-z0-9_-]{40,}'      # Anthropic API key
             'sk-proj-[A-Za-z0-9_-]{40,}'     # OpenAI project key
             'sk-svcacct-[A-Za-z0-9_-]{40,}'  # OpenAI service-account key
+            'sk-cp-[A-Za-z0-9_-]{60,}'       # MiniMax API key (F1088 vector — caught only after the fact)
             'xox[baprs]-[A-Za-z0-9-]{20,}'   # Slack tokens
             'AKIA[0-9A-Z]{16}'               # AWS access key ID
             'ASIA[0-9A-Z]{16}'               # AWS STS temp access key ID


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

F1088 leaked a MiniMax sk-cp-* token in plaintext, undetected by the original pattern set in #2109 because sk-cp- was never in it. This PR closes that gap retroactively — adds `sk-cp-[A-Za-z0-9_-]{60,}` so future MiniMax leaks get caught.

Discovered while shipping the docs#96 + docs#97 scrub: the F1088 INCIDENT_LOG had three credentials (MiniMax, GitHub PAT, admin) but only the GitHub PAT matched our regex set. The other two slipped through because:
- `sk-cp-` (MiniMax) wasn't in the pattern list — added here
- Admin token is opaque base64 with no recognisable prefix — can't be added without false-positive risk on every base64 string in the codebase

Min-length 60 chars after the prefix is conservative against false positives (no normal `sk-cp-XXX` variable name reaches that length).

Paired with Molecule-AI/molecule-ai-workspace-runtime#58 (same pattern in the runtime's bundled pre-commit hook).

## Test plan
- [ ] Self-test: this PR's own diff doesn't include any sk-cp-* string (the workflow file's regex literal isn't a token)
- [ ] Post-merge: rolled-out repos pick up the new pattern automatically on next workflow run (we use @staging ref)