### PR TITLE
fix(ci): block-internal-paths handle merge_group + shallow-clone BASE

### DIFF
--- a/.github/workflows/block-internal-paths.yml
+++ b/.github/workflows/block-internal-paths.yml
@@ -37,7 +37,28 @@ jobs:
         if: github.event_name == 'pull_request'
         run: git fetch --depth=1 origin ${{ github.event.pull_request.base.sha }}
 
+      # For merge_group events the queue's pre-merge ref is a commit on
+      # `gh-readonly-queue/...` whose parent is the queue's base_sha.
+      # That parent isn't part of the queue branch's shallow clone, so
+      # we fetch it explicitly. Mirrors the equivalent step in
+      # secret-scan.yml (#2120) — same shallow-clone bug class.
+      - name: Fetch merge_group base SHA (merge_group events only)
+        if: github.event_name == 'merge_group'
+        run: git fetch --depth=1 origin ${{ github.event.merge_group.base_sha }}
+
       - name: Refuse if forbidden paths appear
+        env:
+          # Plumb event-specific SHAs through env so the script doesn't
+          # need conditional `${{ ... }}` interpolation per event type.
+          # github.event.before/after only exist on push events;
+          # merge_group has its own base_sha/head_sha; pull_request has
+          # pull_request.base.sha / pull_request.head.sha.
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MG_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MG_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          PUSH_BEFORE: ${{ github.event.before }}
+          PUSH_AFTER: ${{ github.event.after }}
         run: |
           # Paths that must NEVER live in the public monorepo. Add to this
           # list narrowly — broader patterns belong in .gitignore so day-to-day
@@ -52,18 +73,44 @@ jobs:
             ".*-temp\.(md|txt)$"
           )
 
-          # Determine the diff base.
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
-          else
-            BASE="${{ github.event.before }}"
-            HEAD="${{ github.event.after }}"
+          # Determine the diff base. Each event type stores its SHAs in
+          # a different place — see the env block above.
+          case "${{ github.event_name }}" in
+            pull_request)
+              BASE="$PR_BASE_SHA"
+              HEAD="$PR_HEAD_SHA"
+              ;;
+            merge_group)
+              BASE="$MG_BASE_SHA"
+              HEAD="$MG_HEAD_SHA"
+              ;;
+            *)
+              BASE="$PUSH_BEFORE"
+              HEAD="$PUSH_AFTER"
+              ;;
+          esac
+
+          # On push events with shallow clones, BASE may be present in
+          # the event payload but absent from the local object DB
+          # (fetch-depth=2 doesn't always reach the previous commit
+          # across true merges). Try fetching it on demand. If the
+          # fetch fails — e.g. the SHA was force-overwritten — we fall
+          # through to the empty-BASE branch below, which scans the
+          # entire tree as if every file were new. Correct, just slow.
+          # Same recovery shape as secret-scan.yml (#2120 — incident
+          # 2026-04-27 06:50Z block-internal-paths exit 128 with
+          # "fatal: bad object <sha>" on staging push).
+          if [ -n "$BASE" ] && ! echo "$BASE" | grep -qE '^0+$'; then
+            if ! git cat-file -e "$BASE" 2>/dev/null; then
+              git fetch --depth=1 origin "$BASE" 2>/dev/null || true
+            fi
           fi
 
           # Files added or modified in this change.
-          if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$'; then
-            # New branch / no previous SHA — check entire tree.
+          if [ -z "$BASE" ] || echo "$BASE" | grep -qE '^0+$' || ! git cat-file -e "$BASE" 2>/dev/null; then
+            # New branch / no previous SHA / BASE unreachable — check
+            # the entire tree as if every file were new. Slower but
+            # correct on first push or post-fetch-failure recovery.
             CHANGED=$(git ls-tree -r --name-only HEAD)
           else
             CHANGED=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD")


### PR DESCRIPTION
[Molecule-Platform-Evolvement-Manager]

## What was broken

Same bug class as the \`secret-scan.yml\` fix in #2120. \`block-internal-paths\` hit \`fatal: bad object <sha>\` exit 128 on the staging push at **2026-04-27 06:50:33Z** (the failure you flagged).

Two cases:

1. **\`merge_group\` events**: BASE/HEAD came from \`github.event.before\` / \`.after\` which are push-event-only. On merge_group both came back empty → fell through to entire-tree scan. Correct but inefficient, and runs on every queue-check tick when this workflow is required by the merge queue.

2. **\`push\` events with shallow clones**: \`fetch-depth: 2\` doesn't always reach BASE across true merge commits. When BASE is in the event payload but absent from the local object DB, \`git diff\` errors with \`fatal: bad object <sha>\` and the job exits 128. **That's the failure.**

## Fix

Mirrors the secret-scan.yml fix (#2120):

- Dedicated \`git fetch\` step for \`merge_group.base_sha\`
- Event-specific SHAs in a step \`env:\` block; \`case\` over \`github.event_name\` covering pull_request / merge_group / push
- On-demand fetch + \`git cat-file -e\` guard for push BASE so a SHA that's payload-present-but-DB-absent triggers the fetch, and a fetch failure falls through cleanly to \"scan entire tree\" instead of exiting 128

## Test plan

- [x] YAML structure preserved
- [x] Bash logic mirrors the secret-scan recovery path tested in #2120
- [ ] CI green on this PR's pull_request scan + push to staging post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)