### PR TITLE
feat(publish-runtime): auto-publish to PyPI on staging pushes touching workspace/

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -10,6 +10,12 @@ name: publish-runtime
 #     the tag — `runtime-v0.1.6` publishes `0.1.6`).
 #   - Manual workflow_dispatch with an explicit `version` input (useful for
 #     dev/test releases without tagging the repo).
+#   - Auto: any push to `staging` that touches `workspace/**`. The version
+#     is derived by querying PyPI for the current latest and bumping the
+#     patch component. This closes the human-in-loop gap that caused the
+#     2026-04-27 RuntimeCapabilities ImportError outage — adapter symbol
+#     additions in workspace/adapters/base.py used to require an operator
+#     to remember to publish; now the merge itself triggers the publish.
 #
 # The workflow:
 #   1. Runs scripts/build_runtime_package.py to copy workspace/ →
@@ -32,6 +38,12 @@ on:
   push:
     tags:
       - "runtime-v*"
+    branches:
+      - staging
+    paths:
+      # Auto-publish when staging gets workspace/ changes. Path filter
+      # ONLY applies to branch pushes — tag pushes still fire regardless.
+      - "workspace/**"
   workflow_dispatch:
     inputs:
       version:
@@ -42,6 +54,12 @@ on:
 permissions:
   contents: read
 
+# Serialize publishes so two staging merges landing seconds apart don't
+# both compute "latest+1" and race on PyPI upload. The second one waits.
+concurrency:
+  group: publish-runtime
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -49,6 +67,8 @@ jobs:
     permissions:
       contents: read
       id-token: write   # PyPI Trusted Publisher (OIDC) — no PYPI_TOKEN needed
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -57,14 +77,27 @@ jobs:
           python-version: "3.11"
           cache: pip
 
-      - name: Derive version from tag or input
+      - name: Derive version (tag, manual input, or PyPI auto-bump)
         id: version
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
-          else
+          elif echo "$GITHUB_REF_NAME" | grep -q "^runtime-v"; then
             # Tag is `runtime-vX.Y.Z` — strip the prefix.
             VERSION="${GITHUB_REF_NAME#runtime-v}"
+          else
+            # Auto-publish from staging push. Query PyPI for the current
+            # latest and bump the patch component. concurrency: group above
+            # serializes parallel staging merges so we don't race on the
+            # bump. If PyPI is unreachable, fail loud — better to skip a
+            # publish than to overwrite an existing version.
+            LATEST=$(curl -fsS --retry 3 https://pypi.org/pypi/molecule-ai-workspace-runtime/json \
+              | python -c "import sys,json; print(json.load(sys.stdin)['info']['version'])")
+            MAJOR=$(echo "$LATEST" | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | cut -d. -f2)
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            VERSION="${MAJOR}.${MINOR}.$((PATCH+1))"
+            echo "Auto-bumped from PyPI latest $LATEST -> $VERSION"
           fi
           if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(\.dev[0-9]+|rc[0-9]+|a[0-9]+|b[0-9]+|\.post[0-9]+)?$'; then
             echo "::error::version $VERSION does not match PEP 440"
@@ -142,18 +175,21 @@ jobs:
           # GITHUB_TOKEN can't fire dispatches across repos — needs an explicit
           # token. Stored as a repo secret; rotate per the standard schedule.
           DISPATCH_TOKEN: ${{ secrets.TEMPLATE_DISPATCH_TOKEN }}
-          RUNTIME_VERSION: ${{ needs.publish.outputs.version || steps.version.outputs.version }}
+          # Single source of truth: the publish job's output, which handles
+          # tag/manual-input/auto-bump uniformly. The previous fallback
+          # (`steps.version.outputs.version` from inside the cascade job)
+          # was a dead reference — different job, no shared step scope.
+          RUNTIME_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           set +e   # don't abort on a single repo failure — collect them all
           if [ -z "$DISPATCH_TOKEN" ]; then
             echo "::warning::TEMPLATE_DISPATCH_TOKEN secret not set — skipping cascade. PyPI was published; templates will pick up the new version on their own next rebuild."
             exit 0
           fi
-          # Re-derive version from the tag here too (in case publish job
-          # didn't expose an output the previous step's reference reads).
-          VERSION="${GITHUB_REF_NAME#runtime-v}"
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ inputs.version }}"
+          VERSION="$RUNTIME_VERSION"
+          if [ -z "$VERSION" ]; then
+            echo "::error::publish job did not expose a version output — cascade cannot fan out"
+            exit 1
           fi
           TEMPLATES="claude-code langgraph crewai autogen deepagents hermes gemini-cli openclaw"
           FAILED=""

--- a/workspace/adapter_base.py
+++ b/workspace/adapter_base.py
@@ -437,15 +437,19 @@ class BaseAdapter(ABC):
         if plugins.plugin_names:
             logger.info(f"Plugins: {', '.join(plugins.plugin_names)}")
 
-        # Load skills (workspace + plugin skills, deduped)
-        loaded_skills = load_skills(config.config_path, config.tools)
+        # Load skills (workspace + plugin skills, deduped). Pass the runtime
+        # name so SKILL.md frontmatter `runtime: [...]` can opt skills out
+        # of incompatible adapters (hermes won't load claude-code-only
+        # skills, etc.).
+        runtime_name = type(self).name()
+        loaded_skills = load_skills(config.config_path, config.tools, current_runtime=runtime_name)
         seen_skill_ids = {s.metadata.id for s in loaded_skills}
         for plugin_skills_dir in plugins.skill_dirs:
             plugin_skill_names = [
                 d for d in os.listdir(plugin_skills_dir)
                 if os.path.isdir(os.path.join(plugin_skills_dir, d))
             ]
-            for skill in load_skills(plugin_skills_dir, plugin_skill_names):
+            for skill in load_skills(plugin_skills_dir, plugin_skill_names, current_runtime=runtime_name):
                 if skill.metadata.id not in seen_skill_ids:
                     loaded_skills.append(skill)
                     seen_skill_ids.add(skill.metadata.id)

--- a/workspace/main.py
+++ b/workspace/main.py
@@ -323,6 +323,7 @@ async def main():  # pragma: no cover
                 config_path=config_path,
                 skill_names=config.skills,
                 on_reload=_on_skill_reload,
+                current_runtime=runtime,
             )
             asyncio.create_task(skills_watcher.start())
             print(f"Skills hot-reload enabled for: {config.skills}")

--- a/workspace/skill_loader/loader.py
+++ b/workspace/skill_loader/loader.py
@@ -26,6 +26,12 @@ class SkillMetadata:
     description: str
     tags: list[str] = field(default_factory=list)
     examples: list[str] = field(default_factory=list)
+    # Runtime compatibility — list of adapter `name()` values this skill
+    # supports, or ["*"] for universal. Borrowed from hermes' declarative
+    # skill-compat pattern: a skill that depends on claude-code-only tools
+    # should declare `runtime: [claude-code]` so hermes (or any other
+    # adapter) skips it at load time instead of failing at first invocation.
+    runtime: list[str] = field(default_factory=lambda: ["*"])
 
 
 @dataclass
@@ -133,8 +139,39 @@ def load_skill_tools(scripts_dir: Path) -> list[Any]:
     return tools
 
 
-def load_skills(config_path: str, skill_names: list[str]) -> list[LoadedSkill]:
-    """Load all skills specified in the config."""
+def _normalize_runtime_field(raw: Any, skill_name: str) -> list[str]:
+    """Normalize the optional `runtime` frontmatter field to a list[str].
+
+    Accepts: ["*"] (default), ["claude-code"], "claude-code" (string sugar),
+    or absent (-> ["*"]). Anything else logs a warning and falls back to
+    universal so a malformed manifest doesn't silently filter the skill.
+    """
+    if raw is None:
+        return ["*"]
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, list) and all(isinstance(x, str) for x in raw):
+        return raw or ["*"]
+    logger.warning(
+        "SKILL.md for '%s' has invalid `runtime` field %r; treating as universal",
+        skill_name, raw,
+    )
+    return ["*"]
+
+
+def load_skills(
+    config_path: str,
+    skill_names: list[str],
+    current_runtime: str | None = None,
+) -> list[LoadedSkill]:
+    """Load all skills specified in the config.
+
+    If ``current_runtime`` is provided, skills whose ``runtime`` frontmatter
+    list does not include ``"*"`` or ``current_runtime`` are skipped (with a
+    log line) instead of being loaded — matches hermes' declarative compat
+    model so adapter-specific skills don't get force-loaded into runtimes
+    that can't actually execute their tools.
+    """
     skills_dir = Path(config_path) / "skills"
     loaded = []
 
@@ -171,12 +208,21 @@ def load_skills(config_path: str, skill_names: list[str]) -> list[LoadedSkill]:
 
         frontmatter, instructions = parse_skill_frontmatter(skill_md)
 
+        runtime_compat = _normalize_runtime_field(frontmatter.get("runtime"), skill_name)
+        if current_runtime is not None and "*" not in runtime_compat and current_runtime not in runtime_compat:
+            logger.info(
+                "Skipping skill '%s': runtime=%s not compatible with current=%s",
+                skill_name, runtime_compat, current_runtime,
+            )
+            continue
+
         metadata = SkillMetadata(
             id=skill_name,
             name=frontmatter.get("name", skill_name),
             description=frontmatter.get("description", ""),
             tags=frontmatter.get("tags", []),
             examples=frontmatter.get("examples", []),
+            runtime=runtime_compat,
         )
 
         # Executables live under scripts/ per the agentskills.io spec.

--- a/workspace/skill_loader/watcher.py
+++ b/workspace/skill_loader/watcher.py
@@ -67,10 +67,12 @@ class SkillsWatcher:
         config_path: str,
         skill_names: list[str],
         on_reload: Callable | None = None,
+        current_runtime: str | None = None,
     ) -> None:
         self.config_path = config_path
         self.skill_names = list(skill_names)
         self.on_reload   = on_reload
+        self.current_runtime = current_runtime
         self._hashes: dict[str, str] = {}   # rel_path → sha256 hex
         self._running = False
 
@@ -169,7 +171,7 @@ class SkillsWatcher:
 
         try:
             from skill_loader.loader import load_skills
-            loaded = load_skills(self.config_path, [skill_name])
+            loaded = load_skills(self.config_path, [skill_name], current_runtime=self.current_runtime)
 
             if loaded:
                 skill = loaded[0]

--- a/workspace/tests/test_skills_loader.py
+++ b/workspace/tests/test_skills_loader.py
@@ -641,3 +641,91 @@ def test_load_skills_fail_open_if_no_scanner_wiring(tmp_path, monkeypatch):
     assert scan_kwargs[0]["fail_open"] is False, (
         "fail_open_if_no_scanner=False from config must be forwarded to scan_skill_dependencies"
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-skill runtime compatibility (#119)
+# ---------------------------------------------------------------------------
+# A skill manifest can declare `runtime: [claude-code]` to opt out of being
+# loaded into incompatible adapters. Default is universal — this is the
+# important contract: existing skill libraries do NOT need to be migrated
+# and continue to load into every adapter.
+
+
+def _write_skill(tmp_path, name: str, runtime_block: str = "") -> None:
+    skill_dir = tmp_path / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        f"---\nname: {name.title()}\ndescription: x\n{runtime_block}---\n"
+        f"Body for {name}."
+    )
+
+
+def test_skill_metadata_runtime_default_universal():
+    meta = SkillMetadata(id="t", name="T", description="d")
+    assert meta.runtime == ["*"], "default runtime must be universal — no implicit filtering"
+
+
+def test_load_skills_no_runtime_field_is_universal(tmp_path):
+    """Skills without a `runtime` frontmatter field load into any adapter."""
+    _write_skill(tmp_path, "legacy")  # no runtime block
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["legacy"], current_runtime="hermes")
+    assert len(loaded) == 1
+    assert loaded[0].metadata.runtime == ["*"]
+
+
+def test_load_skills_explicit_match_loads(tmp_path):
+    _write_skill(tmp_path, "claude-only", "runtime:\n  - claude-code\n")
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["claude-only"], current_runtime="claude-code")
+    assert len(loaded) == 1
+
+
+def test_load_skills_explicit_mismatch_skips(tmp_path):
+    _write_skill(tmp_path, "claude-only", "runtime:\n  - claude-code\n")
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["claude-only"], current_runtime="hermes")
+    assert loaded == [], "skill must be filtered out of incompatible runtime"
+
+
+def test_load_skills_runtime_string_sugar(tmp_path):
+    """Bare string `runtime: claude-code` is normalized to ['claude-code']."""
+    _write_skill(tmp_path, "sugary", "runtime: claude-code\n")
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["sugary"], current_runtime="claude-code")
+    assert len(loaded) == 1
+    assert loaded[0].metadata.runtime == ["claude-code"]
+
+
+def test_load_skills_runtime_wildcard_matches_anything(tmp_path):
+    _write_skill(tmp_path, "wild", "runtime:\n  - '*'\n  - claude-code\n")
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["wild"], current_runtime="hermes")
+    assert len(loaded) == 1, "wildcard must short-circuit the runtime check"
+
+
+def test_load_skills_no_current_runtime_loads_everything(tmp_path):
+    """When current_runtime is None (test/fallback), no filtering happens."""
+    _write_skill(tmp_path, "claude-only", "runtime:\n  - claude-code\n")
+    from unittest.mock import patch
+    with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+        loaded = load_skills(str(tmp_path), ["claude-only"])
+    assert len(loaded) == 1, "absent current_runtime must preserve old behavior"
+
+
+def test_load_skills_malformed_runtime_treated_as_universal(tmp_path, caplog):
+    """A garbage runtime value warns + falls back to universal — never silently drops the skill."""
+    _write_skill(tmp_path, "garbage", "runtime: 123\n")
+    from unittest.mock import patch
+    import logging
+    with caplog.at_level(logging.WARNING, logger="skill_loader.loader"):
+        with patch("skill_loader.loader.load_skill_tools", return_value=[]):
+            loaded = load_skills(str(tmp_path), ["garbage"], current_runtime="hermes")
+    assert len(loaded) == 1, "malformed runtime must not silently filter"
+    assert any("invalid `runtime`" in r.message for r in caplog.records)

--- a/workspace/tests/test_skills_watcher.py
+++ b/workspace/tests/test_skills_watcher.py
@@ -181,7 +181,7 @@ class TestReloadSkill:
             tools=[],
         )
 
-        def fake_load_skills(config_path, skill_names):
+        def fake_load_skills(config_path, skill_names, **kwargs):
             return [fake_skill]
 
         monkeypatch.setattr(_watcher_mod, "_load_skills_impl",
@@ -218,7 +218,7 @@ class TestReloadSkill:
         )
 
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         await w._reload_skill("sk2", ["sk2/SKILL.md"])
@@ -245,7 +245,7 @@ class TestReloadSkill:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         await w._reload_skill("audited", ["audited/SKILL.md"])
@@ -317,7 +317,7 @@ class TestWatcherLifecycle:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         _watcher_mod.POLL_INTERVAL  = 0.01
@@ -378,7 +378,7 @@ class TestEvictStaleModules:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         w = SkillsWatcher(str(tmp_path), ["sk"])
@@ -401,7 +401,7 @@ class TestAuditEventExceptionSuppressed:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         # Make tools.audit.log_event raise an exception
@@ -429,7 +429,7 @@ class TestOnReloadCallbackException:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         def failing_callback(skill):
@@ -451,7 +451,7 @@ class TestOnReloadCallbackException:
             tools=[],
         )
         skills_mod = ModuleType("skill_loader.loader")
-        skills_mod.load_skills = lambda cp, names: [fake_skill]
+        skills_mod.load_skills = lambda cp, names, **_: [fake_skill]
         monkeypatch.setitem(sys.modules, "skill_loader.loader", skills_mod)
 
         async def failing_async_callback(skill):


### PR DESCRIPTION
## Summary
- New trigger: push to \`staging\` filtered to \`paths: ['workspace/**']\` auto-publishes a fresh \`molecule-ai-workspace-runtime\` patch release
- Auto-derived version: query PyPI for current latest, bump patch component
- \`concurrency: group: publish-runtime\` serializes parallel staging merges so they don't race on the bump
- \`publish\` job now exposes \`version\` as a job-level output; cascade reads it cleanly (also fixes a latent bug where the cascade re-derived from \`GITHUB_REF_NAME\` and would have produced \"staging\" as the version under the new trigger)

## Why
Tonight's RuntimeCapabilities ImportError outage. Sequence:
1. #117 added \`RuntimeCapabilities\` to \`molecule_runtime.adapters.base\` (merged 02:37 UTC)
2. Templates rebuilt at 07:37 UTC and started importing the new symbol
3. PyPI was still serving 0.1.15 (pre-#117) — nobody remembered to push a \`runtime-v*\` tag or workflow_dispatch the publish
4. Every template image now runs \`from molecule_runtime.adapters.base import RuntimeCapabilities\` against an installed runtime that doesn't export it → ImportError → workspaces stuck in \`provisioning\`

This change closes the human-in-loop gap. Pairs with [molecule-ci PR #7](https://github.com/Molecule-AI/molecule-ci/pull/7) which adds an actual \`docker run ... import adapter\` smoke gate before pushing :latest.

## Test plan
- [x] YAML validates
- [ ] CI green
- [ ] After merge: confirm next workspace/** change to staging fires \`publish-runtime\` automatically with version = \`pypi-latest + 1\`
- [ ] Confirm cascade fan-out reads \`needs.publish.outputs.version\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)