### PR TITLE
fix(release): drift-gate TOP_LEVEL_MODULES + smoke-import main (post-0.1.16 incident)

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -135,6 +135,14 @@ jobs:
           WORKSPACE_ID=00000000-0000-0000-0000-000000000000 \
           PLATFORM_URL=http://localhost:8080 \
             /tmp/smoke/bin/python -c "
+          # Importing main is the strongest smoke test we can do here:
+          # main.py is the entry point and pulls every other module
+          # transitively. If the build script missed an import rewrite
+          # (e.g. left a bare \`from transcript_auth import ...\` instead
+          # of \`from molecule_runtime.transcript_auth import ...\` — the
+          # 0.1.16 incident), this fails with ModuleNotFoundError instead
+          # of shipping to PyPI and breaking every workspace startup.
+          import molecule_runtime.main  # noqa: F401
           from molecule_runtime import a2a_client, a2a_tools
           from molecule_runtime.builtin_tools import memory
           from molecule_runtime.adapters import get_adapter, BaseAdapter, AdapterConfig

--- a/scripts/build_runtime_package.py
+++ b/scripts/build_runtime_package.py
@@ -42,8 +42,13 @@ from pathlib import Path
 # matches one of these) gets rewritten to use the package prefix.
 #
 # Closed list (not "every .py we copy") because a typo in workspace/ would
-# otherwise leak into a wrong rewrite. Update this when adding a new
-# top-level module to workspace/.
+# otherwise leak into a wrong rewrite. The set is asserted against
+# `workspace/*.py` at build time — if the disk contents drift from this
+# list (new module added, old one removed), the build fails loud instead
+# of silently shipping unrewritten imports. That gap caused 0.1.16 to
+# ship `from transcript_auth import ...` (unrewritten — module added
+# without updating this set), which broke every workspace startup with
+# `ModuleNotFoundError: No module named 'transcript_auth'`.
 TOP_LEVEL_MODULES = {
     "a2a_cli",
     "a2a_client",
@@ -53,15 +58,12 @@ TOP_LEVEL_MODULES = {
     "adapter_base",
     "agent",
     "agents_md",
-    "claude_sdk_executor",
-    "cli_executor",
     "config",
     "consolidation",
     "coordinator",
     "events",
     "executor_helpers",
     "heartbeat",
-    "hermes_executor",
     "initial_prompt",
     "main",
     "molecule_ai_status",
@@ -69,7 +71,10 @@ TOP_LEVEL_MODULES = {
     "plugins",
     "preflight",
     "prompt",
+    "runtime_wedge",
     "shared_runtime",
+    "transcript_auth",
+    "watcher",
 }
 
 # Subdirectory packages — these are already real packages (they have or will
@@ -249,6 +254,26 @@ def main() -> int:
     if not src.is_dir():
         print(f"error: source not a directory: {src}", file=sys.stderr)
         return 2
+
+    # Drift gate: assert TOP_LEVEL_MODULES matches workspace/*.py.
+    # Without this, a new top-level module added to workspace/ ships
+    # with unrewritten `from <name> import` statements that explode at
+    # runtime with ModuleNotFoundError. (See 0.1.16 transcript_auth
+    # incident — closed list silently went stale.)
+    on_disk_modules = {
+        f.stem for f in src.glob("*.py")
+        if f.stem not in {"__init__", "conftest"}
+    }
+    missing = on_disk_modules - TOP_LEVEL_MODULES
+    stale = TOP_LEVEL_MODULES - on_disk_modules
+    if missing or stale:
+        print("error: TOP_LEVEL_MODULES drifted from workspace/*.py contents:", file=sys.stderr)
+        if missing:
+            print(f"  in workspace/ but NOT in TOP_LEVEL_MODULES (will ship un-rewritten): {sorted(missing)}", file=sys.stderr)
+        if stale:
+            print(f"  in TOP_LEVEL_MODULES but NOT in workspace/ (no-op, but misleading): {sorted(stale)}", file=sys.stderr)
+        print("  Edit scripts/build_runtime_package.py:TOP_LEVEL_MODULES to match.", file=sys.stderr)
+        return 3
 
     pkg_dir = out / "molecule_runtime"
     print(f"[build] source: {src}")


### PR DESCRIPTION
## Summary
Two release-pipeline bugs that compounded into the 0.1.16 outage where every workspace startup died with \`ModuleNotFoundError: No module named 'transcript_auth'\`.

### Bug 1: stale TOP_LEVEL_MODULES set
\`scripts/build_runtime_package.py\` rewrites bare imports (\`from foo import bar\` → \`from molecule_runtime.foo import bar\`) using a hand-curated set. The set drifted:

**Missing** (added to workspace/, never added to set → unrewritten imports shipped):
- \`transcript_auth\` (since #87 phase 1c)
- \`runtime_wedge\`
- \`watcher\`

**Stale** (no longer exists in workspace/, still listed):
- \`claude_sdk_executor\` (removed in #87)
- \`cli_executor\` (removed in #87)
- \`hermes_executor\` (never existed)

### Bug 2: wheel smoke didn't import main
\`publish-runtime.yml\`'s \`Verify package contents (sanity)\` step asserted on stable invariants (\`BaseAdapter\`, \`AdapterConfig\`, the a2a error sentinel) but never imported \`main\`. \`main.py\` is where the unrewritten \`from transcript_auth import ...\` lived. Smoke passed; production broke.

## Fix
- Build script auto-asserts \`TOP_LEVEL_MODULES == {f.stem for f in workspace/*.py}\` (excluding \`__init__\`/\`conftest\`). Diff in either direction fails build with a specific error.
- \`TOP_LEVEL_MODULES\` updated to current reality.
- Wheel smoke step now does \`import molecule_runtime.main\` first — main pulls every other module transitively, so any bare-import bug surfaces as \`ModuleNotFoundError\` before PyPI accepts the upload.

## Test plan
- [x] Local build of 0.1.99 succeeds; \`main.py\` correctly contains \`from molecule_runtime.transcript_auth import ...\`
- [ ] CI green
- [ ] After merge, fire publish-runtime workflow_dispatch with version 0.1.18; wheel smoke must pass; PyPI upload succeeds; cascade rebuilds all 8 templates
- [ ] Re-run priority-runtimes wire-real E2E against fresh template images — claude-code + hermes both reach \`online\` and reply non-error to "Reply with PONG"

🤖 Generated with [Claude Code](https://claude.com/claude-code)