### PR TITLE
fix: restore main_sync entry point in workspace/main.py

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -142,7 +142,14 @@ jobs:
           # of \`from molecule_runtime.transcript_auth import ...\` — the
           # 0.1.16 incident), this fails with ModuleNotFoundError instead
           # of shipping to PyPI and breaking every workspace startup.
-          import molecule_runtime.main  # noqa: F401
+          # Import the entry-point target by NAME — not just the module.
+          # The wheel's pyproject.toml declares
+          # `molecule-runtime = molecule_runtime.main:main_sync` so if
+          # main_sync goes missing (it did in 0.1.16-0.1.18), every
+          # workspace startup fails with `ImportError: cannot import name
+          # 'main_sync'`. Plain `import molecule_runtime.main` doesn't
+          # catch that because the module loads fine.
+          from molecule_runtime.main import main_sync  # noqa: F401
           from molecule_runtime import a2a_client, a2a_tools
           from molecule_runtime.builtin_tools import memory
           from molecule_runtime.adapters import get_adapter, BaseAdapter, AdapterConfig

--- a/workspace/main.py
+++ b/workspace/main.py
@@ -613,5 +613,18 @@ async def main():  # pragma: no cover
         await temporal_wrapper.stop()
 
 
-if __name__ == "__main__":  # pragma: no cover
+def main_sync():  # pragma: no cover
+    """Synchronous entry point for the `molecule-runtime` console script.
+
+    Declared in scripts/build_runtime_package.py as the wheel's entry-point
+    target (`molecule-runtime = "molecule_runtime.main:main_sync"`). Removed
+    silently during the pre-monorepo consolidation, which broke every
+    workspace startup against 0.1.16/0.1.17/0.1.18 with `ImportError:
+    cannot import name 'main_sync'`. The .github/workflows/runtime-pin-compat.yml
+    smoke step is the regression gate.
+    """
     asyncio.run(main())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main_sync()


### PR DESCRIPTION
## Summary
- Restores \`def main_sync()\` in \`workspace/main.py\` — the wheel's pyproject.toml has declared \`molecule-runtime = molecule_runtime.main:main_sync\` since the build script was created on 2026-04-26, but the function was lost during the pre-monorepo consolidation
- Strengthens publish-runtime.yml smoke from \`import molecule_runtime.main\` (loads module — passes even with missing entry-point target) to \`from molecule_runtime.main import main_sync\` (the actual contract)

## Root cause
Pre-monorepo, \`molecule-ai-workspace-runtime\` was a separate repo where \`main_sync\` was hand-added to \`main.py\`. Consolidation made \`workspace/\` the source of truth but the \`def main_sync()\` wrapper never made the trip. The 0.1.15 wheel still shipped \`main_sync\` from a leftover snapshot, so the regression hid until 0.1.16 (first wheel built from the new build script).

Symptom: every workspace container restart loops with:
\`\`\`
ImportError: cannot import name 'main_sync' from 'molecule_runtime.main'
\`\`\`
The \`molecule-runtime\` console script tries to import the missing symbol → CLI exits 1 → docker restarts → forever loop → workspace stays in \`provisioning\` until the 10-min sweep marks it failed.

This is the actual reason the wire-real E2E kept failing tonight, even after fixing transcript_auth.

## Why the existing CI didn't catch it
\`runtime-pin-compat.yml\` DOES test \`from molecule_runtime.main import main_sync\` and has been failing RED on every merge_group run (24988852292, 24989562674, 24989965921). It was treated as a non-required check and merges proceeded anyway.

## Test plan
- [x] \`python3 scripts/build_runtime_package.py --version 0.1.99 --out /tmp/build-test\` — output wheel contains \`def main_sync()\` at the bottom of \`main.py\`
- [ ] CI green
- [ ] After merge: auto-publish fires (workspace/main.py changed → trigger fires); 0.1.19 wheel ships
- [ ] runtime-pin-compat.yml goes green on a re-run against 0.1.19
- [ ] Cascade rebuilds all 8 templates with smoke gate green
- [ ] Re-run priority-runtimes wire-real E2E against fresh template images — claude-code + hermes both reach \`online\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)