### PR TITLE
docs(saas-federation): fix workspace-limit response code (409, not 402) (#1754)

### DIFF
--- a/docs/tutorials/saas-federation/index.md
+++ b/docs/tutorials/saas-federation/index.md
@@ -185,7 +185,7 @@ curl -X PATCH https://api.moleculesai.app/cp/orgs/acme \
   }'
 ```
 
-When a tenant hits their workspace limit, `POST /workspaces` returns `402 Payment Required` with a message pointing them to upgrade.
+When a tenant hits their workspace limit, `POST /workspaces` returns **`409 Conflict`** (not `402 Payment Required` — quota gates are resource-state conflicts, not payment failures, per RFC 9110). The response body's `error` field carries an upgrade hint.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes **#1754** — fixes the 402 → 409 status-code bug in the molecule-core copy of the SaaS federation tutorial. The canonical Molecule-AI/docs PR #82 (merged 2026-04-23) already shipped the corrected text; this brings the monorepo's duplicate copy in line.

## Why 409 not 402

Per **RFC 9110**:
- **402 Payment Required** — reserved for actual payment failures (e.g. expired card, declined transaction)
- **409 Conflict** — request conflicts with the current state of the resource

Hitting a workspace quota is a resource-state conflict (the tenant's account state has reached the configured limit), not a payment failure. The system isn't asking for money — it's saying "your current state doesn't allow this request." 409 is the semantically correct code.

402 stays appropriate for genuine payment-domain limits — e.g. `workspace_budget_test.go` legitimately uses 402 for monthly-spend exceedance. That's not a state conflict; that's a billing-domain failure.

## Regression anchor

The inline parenthetical in the new wording — _"(not 402 Payment Required — quota gates are resource-state conflicts, not payment failures, per RFC 9110)"_ — doubles as a self-documenting anchor. A future edit that flips 409 back to 402 would have to also reword the parenthetical, making the change a deliberate two-step act rather than a casual oversight.

## Verification

- ✓ Diff matches the wording shipped in Molecule-AI/docs PR #82
- ✓ `git diff` shows a single-line replacement; nothing else touched
- ✓ No backend behavior change (this is doc-only — backend semantics are out of scope; the docs reflect the contract that should be exposed when quota gates are wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)