### PR TITLE
fix(a2a_executor): migrate to a2a-sdk 1.x API

### DIFF
--- a/workspace/a2a_executor.py
+++ b/workspace/a2a_executor.py
@@ -41,7 +41,7 @@ from a2a.server.events import EventQueue
 from a2a.server.tasks import TaskUpdater
 from a2a.types import Part
 # KI-009: a2a-sdk v1 renames a2a.utils → a2a.helpers; TextPart removed (Part takes text= directly)
-from a2a.helpers import new_agent_text_message
+from a2a.helpers import new_text_message
 from shared_runtime import (
     extract_history as _extract_history,
     extract_message_text,
@@ -231,7 +231,7 @@ class LangGraphA2AExecutor(AgentExecutor):
             parts = getattr(getattr(context, "message", None), "parts", None)
             logger.warning("A2A execute: no text content in message parts: %s", parts)
             await event_queue.enqueue_event(
-                new_agent_text_message("Error: message contained no text content.")
+                new_text_message("Error: message contained no text content.")
             )
             return ""
 
@@ -246,7 +246,7 @@ class LangGraphA2AExecutor(AgentExecutor):
                 )
             except PromptInjectionError as exc:
                 await event_queue.enqueue_event(
-                    new_agent_text_message(f"Request blocked: {exc}")
+                    new_text_message(f"Request blocked: {exc}")
                 )
                 return ""
 
@@ -462,21 +462,21 @@ class LangGraphA2AExecutor(AgentExecutor):
                         contextId=context_id,
                     )
                 else:
-                    msg = new_agent_text_message(final_text, task_id=task_id, context_id=context_id)
+                    msg = new_text_message(final_text, task_id=task_id, context_id=context_id)
                 # Attach tool_trace via metadata when supported. Guarded with
                 # hasattr because some test mocks return a plain string here.
                 if tool_trace and hasattr(msg, "metadata"):
                     try:
                         msg.metadata = {"tool_trace": tool_trace}
                     except (AttributeError, TypeError):
-                        # `new_agent_text_message()` returns a plain string in
+                        # `new_text_message()` returns a plain string in
                         # MagicMock paths in tests, where assignment to
                         # .metadata raises despite hasattr being true (the
                         # mock has the attribute as a property). Suppression
                         # is intentional — production Message objects always
                         # accept the assignment. See #1787 + commit dcbcf19
                         # for the original test-mock motivation.
-                        logger.debug("metadata attach skipped (non-Message return from new_agent_text_message)")
+                        logger.debug("metadata attach skipped (non-Message return from new_text_message)")
                 await event_queue.enqueue_event(msg)
                 _result = final_text
 
@@ -491,7 +491,7 @@ class LangGraphA2AExecutor(AgentExecutor):
                 # Emit a Message so both streaming and non-streaming clients
                 # receive an error response rather than hanging.
                 await event_queue.enqueue_event(
-                    new_agent_text_message(
+                    new_text_message(
                         f"Agent error: {e}", task_id=task_id, context_id=context_id
                     )
                 )

--- a/workspace/tests/conftest.py
+++ b/workspace/tests/conftest.py
@@ -75,9 +75,13 @@ def _make_a2a_mocks():
 
     types_mod.Part = Part
 
-    # a2a.helpers (v1: moved from a2a.utils)
+    # a2a.helpers (v1: moved from a2a.utils, renamed new_agent_text_message
+    # → new_text_message). Mock both names — production code only calls
+    # new_text_message, but if any test still references the old name it
+    # gets the same lambda for backward compat during the rename rollout.
     helpers_mod = ModuleType("a2a.helpers")
-    helpers_mod.new_agent_text_message = lambda text, **kwargs: text
+    helpers_mod.new_text_message = lambda text, **kwargs: text
+    helpers_mod.new_agent_text_message = helpers_mod.new_text_message
 
     # Register all module paths
     a2a_mod = ModuleType("a2a")


### PR DESCRIPTION
## Summary
- Updates \`workspace/a2a_executor.py\` from \`new_agent_text_message\` → \`new_text_message\` (a2a-sdk v1 rename)
- 5 call sites + 1 import + 1 docstring reference

## Why
a2a-sdk v1 renamed the helper. Same fix already shipped in the hermes template; this is the runtime-side equivalent.

\`a2a_executor.py\` is **NOT dead code** — \`langgraph\` and \`deepagents\` templates both import \`LangGraphA2AExecutor\` from it. Without this fix, any langgraph/deepagents workspace that calls \`create_executor()\` crashes with \`ImportError: cannot import name 'new_agent_text_message' from 'a2a.helpers'\`.

Doesn't surface for claude-code or hermes (their templates ship their own executors).

## Test plan
- [x] grep confirms zero remaining \`new_agent_text_message\` references in a2a_executor.py
- [ ] CI green (the new \`Default install + import smoke\` required check will exercise \`from molecule_runtime.main import main_sync\`, which transitively loads a2a_executor)
- [ ] After merge: 0.1.20 auto-publishes; cascade re-builds templates
- [ ] Out of scope: bare imports of \`a2a_executor\` in langgraph + deepagents templates (separate fix in those repos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)