### PR TITLE
fix: drop state_transition_history (removed in a2a-sdk 1.x)

### DIFF
--- a/workspace/main.py
+++ b/workspace/main.py
@@ -188,6 +188,12 @@ async def main():  # pragma: no cover
         capabilities=AgentCapabilities(
             streaming=config.a2a.streaming,
             push_notifications=config.a2a.push_notifications,
+            # Note: state_transition_history (a 0.x capability flag) was
+            # removed in a2a-sdk 1.0. Per the SDK's own
+            # a2a/compat/v0_3/conversions.py: "No longer supported in
+            # v1.0". The capability is now universal — Task.history is
+            # always available and tasks/get accepts historyLength via
+            # apply_history_length(). Don't add this kwarg back.
         ),
         skills=[
             AgentSkill(

--- a/workspace/main.py
+++ b/workspace/main.py
@@ -188,7 +188,6 @@ async def main():  # pragma: no cover
         capabilities=AgentCapabilities(
             streaming=config.a2a.streaming,
             push_notifications=config.a2a.push_notifications,
-            state_transition_history=True,
         ),
         skills=[
             AgentSkill(


### PR DESCRIPTION
Single-line runtime fix. `AgentCapabilities(state_transition_history=True)` crashed every workspace at the AgentCard construction step in main.py:188. a2a-sdk 1.x removed that field from the protobuf.

Caught by manual canvas provision (Design Director crew) — every claude-code + hermes workspace was stuck in `provisioning` because of this.

Smoke gate gap: existing import-only smokes don't catch call-time field errors. Worth filing a follow-up to instantiate the AgentCard against a stub config in CI.

🤖 Generated with Claude Code