### PR TITLE
test(e2e): diagnostic burst on step-2 provisioning failure (CP #285)

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -186,7 +186,29 @@ print('')
   fi
   case "$STATUS" in
     running)  break ;;
-    failed)   fail "Tenant provisioning failed for $SLUG" ;;
+    failed)
+      # Diagnostic burst: dump the org row so the operator sees
+      # `last_error` (CP migration 022 / handler #289 — issue #285).
+      # Pre-fix the harness only logged "Tenant provisioning failed",
+      # forcing whoever debugs canary to scrape CP server logs to
+      # learn WHY. Same shape as the TLS-readiness burst at step 4
+      # (PR #2107). Redacts nothing because /cp/admin/orgs already
+      # returns a narrow, ops-safe shape (id/slug/name/plan/
+      # member_count/instance_status/last_error/timestamps —
+      # no tokens, no encrypted fields).
+      log "── DIAGNOSTIC BURST (step 2 — tenant provisioning failed) ──"
+      echo "$LIST_JSON" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+for o in d.get('orgs', []):
+    if o.get('slug') == '$SLUG':
+        print(json.dumps(o, indent=2))
+        sys.exit(0)
+print('(no org row found for slug=$SLUG — DB drift?)')
+" 2>&1 | sed 's/^/  /'
+      log "── END DIAGNOSTIC ──"
+      fail "Tenant provisioning failed for $SLUG (see diagnostic above for last_error)"
+      ;;
     *)        sleep 15 ;;
   esac
 done


### PR DESCRIPTION
## Summary

Closes the **molecule-core-side ask** of [Molecule-AI/molecule-controlplane#285](https://github.com/Molecule-AI/molecule-controlplane/issues/285) — _Provisioning step 2 fails in <20s with no persisted reason_.

CP #289 (already merged) landed migration 022 + the \`/cp/admin/orgs\` handler change exposing \`last_error\` in the response shape. This PR makes the canary harness **actually use** that field on a step-2 failure.

## Pre-fix experience

```
[22:01:57]     status → failed
[22:01:57] ❌ Tenant provisioning failed for e2e-canary-...
```

Operator has to scrape CP server logs to learn WHY.

## Post-fix experience

```
[22:01:57]     status → failed
── DIAGNOSTIC BURST (step 2 — tenant provisioning failed) ──
  {
    "id": "abc-...",
    "slug": "e2e-canary-...",
    "instance_status": "failed",
    "last_error": "docker: Cannot connect to AWS API (timeout)",
    "created_at": "...",
    "updated_at": "..."
  }
── END DIAGNOSTIC ──
[22:01:57] ❌ Tenant provisioning failed for e2e-canary-... (see diagnostic above for last_error)
```

## Implementation notes

- Reads from \`LIST_JSON\` already in scope — no extra HTTP call
- Mirrors the PR #2107 pattern (TLS-readiness burst at step 4)
- Has not-found fallback for DB-drift cases (\`(no org row found for slug=... — DB drift?)\`)
- No redaction — \`adminOrgSummary\` is already ops-safe (no tokens, no encrypted fields)

## Verification

- ✓ Smoke-tested both branches (org found with last_error + slug-not-found fallback) with synthetic JSON
- ✓ \`bash -n\` syntax check OK
- ✓ Shellcheck clean on my changes (only pre-existing SC2015 on line 93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)