### PR TITLE
fix: pass agent_card to DefaultRequestHandler (a2a-sdk 1.x)

### DIFF
--- a/workspace/main.py
+++ b/workspace/main.py
@@ -233,6 +233,13 @@ async def main():  # pragma: no cover
     handler = DefaultRequestHandler(
         agent_executor=executor,
         task_store=InMemoryTaskStore(),
+        # a2a-sdk 1.x added agent_card as a required positional/keyword
+        # argument — it's used internally for capability dispatch (e.g.
+        # routing tasks/get historyLength based on the card's protocol
+        # version). Pass the same agent_card we registered with the
+        # platform so the handler's capability surface matches what the
+        # AgentCard advertises.
+        agent_card=agent_card,
     )
 
     # v1: replace A2AStarletteApplication with Starlette route factory


### PR DESCRIPTION
Sixth a2a-sdk migration find. `DefaultRequestHandler.__init__` now requires `agent_card` as a positional/keyword arg in 1.x. Every workspace crashed at handler init with:

```
TypeError: DefaultRequestHandlerV2.__init__() missing 1 required positional argument: 'agent_card'
```

Caught by harness 8 phase 4 wire-real. The user flagged 'claude doesnt work last patch' — they were right; 0.1.23's `supported_interfaces` fix unblocked one step further into provisioning, then this surfaced as the next blocker.

Updating memory `reference_a2a_sdk_v0_to_v1_migration.md` separately with this entry.

🤖 Generated with Claude Code