### PR TITLE
docs(ci): correct overstated comments in publish + pin-compat workflows

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -318,9 +318,24 @@ jobs:
           python -m venv /tmp/propagation-probe
           PROBE=/tmp/propagation-probe/bin
           $PROBE/pip install --upgrade --quiet pip
-          # Poll budget: 30 attempts × 4s ≈ 2 min. Generous vs PyPI's
+          # Poll budget: 30 attempts × (~3-5s pip install + 4s sleep)
+          # ≈ 4-5 min wall on a slow GH runner. Generous vs PyPI's
           # typical few-seconds propagation; failures past this are
           # signal of a real PyPI / Fastly issue, not just lag.
+          #
+          # Caveat: --no-cache-dir busts pip's local cache, but it does
+          # NOT bust upstream Fastly CDN caches. If Fastly serves a
+          # stale 404 for the new version, this probe correctly fails
+          # and retries (the live propagation case we're protecting
+          # against). If Fastly serves stale CONTENT under the new
+          # version's URL — i.e. PyPI accepts the upload, the metadata
+          # endpoint shows the new version, but Fastly's edge is still
+          # caching an older wheel under the same path — this probe
+          # would resolve `==VERSION` successfully against that stale
+          # body and exit 0 with the wrong content. That's a separate
+          # PyPI-corruption failure mode, not a propagation lag — we
+          # don't currently validate wheel hash against the just-
+          # uploaded dist. Tracked as a follow-up.
           for i in $(seq 1 30); do
             # --no-cache-dir + --force-reinstall: never trust pip's
             # local cache or a previous successful install — every poll
@@ -342,7 +357,7 @@ jobs:
             fi
             sleep 4
           done
-          echo "::error::pip never resolved molecule-ai-workspace-runtime==${RUNTIME_VERSION} within 2 min — refusing to fan out cascade against stale PyPI surfaces"
+          echo "::error::pip never resolved molecule-ai-workspace-runtime==${RUNTIME_VERSION} within ~4 min — refusing to fan out cascade against stale PyPI surfaces"
           exit 1
 
       - name: Fan out repository_dispatch

--- a/.github/workflows/runtime-pin-compat.yml
+++ b/.github/workflows/runtime-pin-compat.yml
@@ -121,9 +121,14 @@ jobs:
       - name: Build wheel from PR source (mirrors publish-runtime.yml)
         # Use a fixed test version so the wheel filename is predictable.
         # Doesn't reach PyPI — this build is local-only for the smoke.
-        # Keep the build invocation byte-identical with publish-runtime.yml's
-        # build step so we test the SAME artifact pipeline; if they drift,
-        # the gate stops catching what publish actually ships.
+        # Use the SAME build script with the SAME args as
+        # publish-runtime.yml's build step. The temp dir path differs
+        # (`/tmp/runtime-build` here vs `${{ runner.temp }}/runtime-build`
+        # in publish-runtime.yml — they coincide on ubuntu-latest but
+        # the call sites are not byte-identical). The smoke import is
+        # also intentionally narrower than publish's: this gate exists
+        # to catch SDK-version-import drift specifically; full invariant
+        # coverage lives in publish-runtime.yml's own pre-PyPI smoke.
         run: |
           python scripts/build_runtime_package.py \
             --version "0.0.0.dev0+pin-compat" \


### PR DESCRIPTION
## Summary

Two doc-only fixes from the post-merge review of #2196 + #2197:

1. **`publish-runtime.yml`** — comment claimed "≈ 2 min" but real wall is ~4-5 min (30 attempts × (~3-5s pip install + 4s sleep) on a slow runner). Updated both the comment and the final `::error::` message. Also added a caveat about Fastly content-under-URL staleness (separate from propagation lag — needs a follow-up wheel-hash check).

2. **`runtime-pin-compat.yml`** — comment claimed "byte-identical with publish-runtime.yml's build step" but the temp dirs differ (`/tmp/runtime-build` here vs `${{ runner.temp }}/runtime-build` there). Softened to "same build script with the same args" and noted the smoke import is intentionally narrower than publish's.

## No behavior change

Comment-only edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)