### PR TITLE
fix(e2e): teardown patience matches prod cascade duration (~30–90s)

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -86,24 +86,47 @@ cleanup_org() {
   fi
 
   log "🧹 Tearing down org $SLUG..."
-  curl "${CURL_COMMON[@]}" -X DELETE "$CP_URL/cp/admin/tenants/$SLUG" \
+
+  # The DELETE handler runs the GDPR Art. 17 cascade synchronously
+  # (Stripe + Redis + EC2 terminate + CF tunnel + DNS + DB rows). Real
+  # observed wall-time on prod-shaped infra is ~30–90s — EC2 termination
+  # alone takes 30–60s. The 5–15s estimate in `purge.go`'s comment is
+  # the API-call cost, NOT the AWS-side time-to-termination it waits on.
+  #
+  # Two-part patience to match reality:
+  #   1. 120s curl timeout on the DELETE itself (was 30s) so the
+  #      synchronous cascade has room to complete in-band.
+  #   2. Poll up to 60s after for organizations.status='purged' (or row
+  #      gone) instead of one rigid 10s sleep — covers the case where
+  #      DELETE returns 5xx mid-cascade and the cascade finishes anyway,
+  #      and the case where DELETE legitimately exceeds 120s and we want
+  #      eventual-consistency confirmation.
+  curl "${CURL_COMMON[@]}" --max-time 120 -X DELETE "$CP_URL/cp/admin/tenants/$SLUG" \
     -H "Authorization: Bearer $ADMIN_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"confirm\":\"$SLUG\"}" >/dev/null 2>&1 \
     && ok "Teardown request accepted" \
     || log "Teardown returned non-2xx (may already be gone)"
 
-  sleep 10
-  local leak_count
-  leak_count=$(curl "${CURL_COMMON[@]}" "$CP_URL/cp/admin/orgs" \
-    -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
-    | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for o in d.get('orgs', []) if o.get('slug')=='$SLUG' and o.get('status') != 'purged'))" \
-    2>/dev/null || echo 0)
+  local leak_count=1
+  local elapsed=0
+  while [ "$elapsed" -lt 60 ]; do
+    leak_count=$(curl "${CURL_COMMON[@]}" "$CP_URL/cp/admin/orgs" \
+      -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
+      | python3 -c "import json,sys; d=json.load(sys.stdin); print(sum(1 for o in d.get('orgs', []) if o.get('slug')=='$SLUG' and o.get('status') != 'purged'))" \
+      2>/dev/null || echo 1)
+    if [ "$leak_count" = "0" ]; then
+      break
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+
   if [ "$leak_count" != "0" ]; then
-    echo "⚠️  LEAK: org $SLUG still present post-teardown (count=$leak_count)" >&2
+    echo "⚠️  LEAK: org $SLUG still present post-teardown after ${elapsed}s (count=$leak_count)" >&2
     exit 4
   fi
-  ok "Teardown clean — no orphan resources for $SLUG"
+  ok "Teardown clean — no orphan resources for $SLUG (${elapsed}s)"
 
   # Normalize unexpected upstream exit codes to 1 (generic failure). The
   # script's documented contract (header "Exit codes" section) only emits


### PR DESCRIPTION
## Summary

\`E2E Staging SaaS\` has been failing every cron + push run since 2026-04-27 with:

\`\`\`
⚠️  LEAK: org e2e-… still present post-teardown (count=1)
exit code 4
\`\`\`

Root cause: the teardown gave the cascade 30s (curl timeout) + 10s sleep, but the real prod cascade takes 30–90s — EC2 termination alone waits 30–60s on AWS. Observed example: \`hongmingwang\` DELETE 2026-04-27 took **57s** to complete with HTTP 204. The test's 30s timeout aborted the curl mid-cascade and the 10s post-sleep check found \`org_instances.status\` not yet 'purged'.

## Fix

| | Before | After |
|---|---|---|
| DELETE curl timeout | 30s | **120s** (--max-time per-call override) |
| Leak check after | single 10s sleep | **poll up to 60s**, 5s steps, exit on first 'purged' |

Two cases now handled:
- Synchronous cascade legitimately taking >30s but <120s → curl returns 200, immediate leak-clean.
- Curl times out / DELETE 5xx mid-cascade but cascade finishes anyway → poll catches the eventual purge.

The 5-15s estimate in \`purge.go\`'s comment is the API-call cost only, not the AWS-side time-to-termination it waits on. Async purge would let us drop these limits back to ~15s — future work, called out in code.

## Test plan

- [x] \`bash -n\` syntax check
- [ ] After merge, watch the next cron e2e-staging-saas run go green (next scheduled fire ~09:23 UTC)
- [ ] OR \`gh workflow run e2e-staging-saas.yml\` to force an immediate run

## Unblocks

Once green, this is the prereq for **wiring auto-promote on green staging E2E** (the doc-aligned alternative to standing up a canary fleet at <20 paying tenants). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)