### PR TITLE
fix(ci): auto-promote gate-check uses workflow file paths, not names

### DIFF
--- a/.github/workflows/auto-promote-staging.yml
+++ b/.github/workflows/auto-promote-staging.yml
@@ -61,13 +61,30 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Required gate workflow names. Must match the `name:` field
-          # in the respective .github/workflows/*.yml files.
+          # Required gate workflow files. Use file paths (relative to
+          # .github/workflows/) rather than display names because:
+          #
+          #   1. `gh run list --workflow=<name>` is ambiguous when two
+          #      workflows have the same `name:` — observed 2026-04-28
+          #      with "CodeQL" matching both `codeql.yml` (explicit) and
+          #      GitHub's UI-configured Code-quality default setup
+          #      (internal "codeql"). gh CLI returns "could not resolve
+          #      to a unique workflow" → empty result → gate evaluated
+          #      as missing/none → auto-promote dead-locked despite all
+          #      checks actually passing.
+          #
+          #   2. File paths are the unique identifier for workflows;
+          #      `name:` is just a display string and can collide.
+          #
+          # When adding/removing a gate, update this list AND the
+          # branch-protection required-checks list (which uses check-run
+          # display names, not workflow names; the two are decoupled and
+          # should be kept in sync manually).
           GATES=(
-            "CI"
-            "E2E Staging Canvas (Playwright)"
-            "E2E API Smoke Test"
-            "CodeQL"
+            "ci.yml"
+            "e2e-staging-canvas.yml"
+            "e2e-api.yml"
+            "codeql.yml"
           )
 
           echo "head_sha=${HEAD_SHA}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Auto-promote ran for staging head \`96955f7b\` with all gates actually green (verified via \`/commits/<sha>/check-runs\` API) but reported \`CodeQL → missing/none\` and aborted. Same SHA was promotable; auto-promote couldn't see it.

## Cause

\`gh run list --workflow="CodeQL"\` matched two workflows:
- \`codeql.yml\` (the explicit file in this repo)
- \`codeql\` (GitHub's UI-configured Code-quality default setup)

gh CLI rejects ambiguous \`--workflow=<name>\` lookups → empty result → gate fell to \`missing/none\` → \`ALL_GREEN=false\` → promote skipped. Every staging push since both names existed was silently dead-locked.

## Fix

Switch \`GATES\` from display names to workflow file paths in \`auto-promote-staging.yml\`:

\`\`\`diff
 GATES=(
-  "CI"
-  "E2E Staging Canvas (Playwright)"
-  "E2E API Smoke Test"
-  "CodeQL"
+  "ci.yml"
+  "e2e-staging-canvas.yml"
+  "e2e-api.yml"
+  "codeql.yml"
 )
\`\`\`

File paths are the canonical identifier for workflow files; display names are decoration and can collide.

## Why this over renaming

The alternative would be renaming \`codeql.yml\`'s \`name:\` to disambiguate. That:
- Couples the file to its display name being unique-by-policy
- Doesn't help the next time someone copy-pastes a workflow with a duplicated \`name:\`
- The display name shows up in lots of UI surfaces; renaming has visual blast radius

Using file paths is structurally correct and immune to future name collisions.

## Sequence after this lands

1. PR landing on staging
2. Manual \`staging → main\` bridge — yes, **another** one. The bug is on main, so the next auto-promote will use the OLD name-based query and fail again. After this fix is on main, future auto-promotes are correct.
3. Auto-promote chain becomes self-healing: every staging push that gets all 4 gates green fast-forwards main.
4. Then ship \`auto-promote-on-e2e.yml\` for \`:staging-<sha>\` → \`:latest\` retag.

## Test plan

- [x] yaml syntax valid
- [ ] After landing on main: a fresh staging push should produce a successful auto-promote run that actually pushes (visible in \`gh run view <id> --json jobs --jq '.jobs[] | {name, conclusion}'\` showing both \`check-all-gates-green: success\` and \`promote: success\`)
- [ ] Log lines now show \`ci.yml → completed/success\` etc instead of \`CI → completed/success\` — confirm no other tooling parses these strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)