### PR TITLE
feat(ci): auto-promote-on-e2e — retag :latest on green E2E Staging SaaS

### DIFF
--- a/.github/workflows/auto-promote-on-e2e.yml
+++ b/.github/workflows/auto-promote-on-e2e.yml
@@ -1,0 +1,114 @@
+name: Auto-promote :latest on E2E green
+
+# Retags `ghcr.io/molecule-ai/{platform,platform-tenant}:staging-<sha>`
+# → `:latest` whenever E2E Staging SaaS passes for a `main` push.
+#
+# This is the doc-aligned alternative to the (deferred) Phase 2 canary
+# fleet — staging E2E catches ~90% of what canary would catch at 0%
+# ongoing infra cost. See `molecule-controlplane/docs/canary-tenants.md`
+# section "Do we actually need canary right now?" — recommended
+# sequencing for the current scale (≤20 paying tenants).
+#
+# Why a separate workflow rather than folding into e2e-staging-saas.yml:
+#   - Keeps test concerns separate from release concerns.
+#   - Disabling promote (e.g. during an incident) is one toggle, not an
+#     edit to the long E2E workflow file.
+#   - When Phase 2 canary work eventually lands, the canary path can
+#     replace this file's trigger without touching the E2E workflow.
+#
+# Why trigger on `main` only:
+#   - `:latest` is what prod tenants pull. We only want SHAs that have
+#     reached `main` (via auto-promote-staging) to advance `:latest`.
+#   - Triggering on staging would let a staging-only revert advance
+#     `:latest` to a SHA that never reaches `main`, breaking the
+#     "production runs what's on `main`" invariant.
+
+on:
+  workflow_run:
+    workflows: ['E2E Staging SaaS (full lifecycle)']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Short sha to promote (override; defaults to upstream workflow_run head_sha)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/molecule-ai/platform
+  TENANT_IMAGE_NAME: ghcr.io/molecule-ai/platform-tenant
+
+jobs:
+  promote:
+    # Skip if E2E failed — `:latest` stays on the prior known-good
+    # digest. Manual dispatch always proceeds (the operator already
+    # decided to promote).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute short sha
+        id: sha
+        run: |
+          set -euo pipefail
+          if [ -n "${{ github.event.inputs.sha }}" ]; then
+            FULL="${{ github.event.inputs.sha }}"
+          else
+            FULL="${{ github.event.workflow_run.head_sha }}"
+          fi
+          echo "short=${FULL:0:7}" >> "$GITHUB_OUTPUT"
+          echo "full=${FULL}" >> "$GITHUB_OUTPUT"
+
+      - uses: imjasonh/setup-crane@v0.4
+
+      - name: GHCR login
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            crane auth login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Verify :staging-<sha> exists for both images
+        # Better to fail fast with a clear message than to half-tag
+        # (platform retagged but platform-tenant missing → tenants pull
+        # a stale image).
+        run: |
+          set -euo pipefail
+          for img in "${IMAGE_NAME}" "${TENANT_IMAGE_NAME}"; do
+            tag="${img}:staging-${{ steps.sha.outputs.short }}"
+            if ! crane manifest "$tag" >/dev/null 2>&1; then
+              echo "::error::Missing tag: $tag"
+              echo "::error::publish-workspace-server-image must complete on this SHA before auto-promote-on-e2e can retag :latest."
+              exit 1
+            fi
+            echo "  ok: $tag exists"
+          done
+
+      - name: Retag platform :staging-<sha> → :latest
+        run: |
+          crane tag "${IMAGE_NAME}:staging-${{ steps.sha.outputs.short }}" latest
+
+      - name: Retag tenant :staging-<sha> → :latest
+        run: |
+          crane tag "${TENANT_IMAGE_NAME}:staging-${{ steps.sha.outputs.short }}" latest
+
+      - name: Summary
+        run: |
+          {
+            echo "## E2E green → :latest promoted"
+            echo
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "- Trigger: manual dispatch"
+            else
+              echo "- Upstream E2E run: ${{ github.event.workflow_run.html_url }}"
+            fi
+            echo "- platform:staging-${{ steps.sha.outputs.short }} → :latest"
+            echo "- platform-tenant:staging-${{ steps.sha.outputs.short }} → :latest"
+            echo
+            echo "Tenant fleet auto-pulls within 5 min via IMAGE_AUTO_REFRESH=true."
+            echo "Force immediate fanout: dispatch redeploy-tenants-on-main.yml."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Final piece of the SaaS pipeline self-healing loop. Adds \`auto-promote-on-e2e.yml\` which retags \`platform:staging-<sha>\` + \`platform-tenant:staging-<sha>\` → \`:latest\` whenever \`E2E Staging SaaS (full lifecycle)\` passes for a \`main\` push.

After this lands, the chain is end-to-end automatic:

\`\`\`
staging push → CI + E2E Canvas + E2E API Smoke + CodeQL all green
   → auto-promote-staging fast-forwards main
   → publish-workspace-server-image builds :staging-<sha>
   → E2E Staging SaaS runs on the main commit
   → THIS WORKFLOW retags :latest on green
   → tenants auto-pull within 5 min (or redeploy-tenants-on-main fans out faster)
\`\`\`

## Why trigger only on \`main\`

\`:latest\` is what prod tenants pull. We only advance \`:latest\` for SHAs that have reached \`main\` (via auto-promote-staging). Triggering on staging would let a staging-only revert advance \`:latest\` to a SHA that never reaches main, breaking the "production runs what's on main" invariant.

## Why a separate workflow

- Test concerns and release concerns separate
- Disabling promote during an incident is one workflow toggle, not an edit to the long E2E file
- When Phase 2 canary work eventually lands, the canary path can replace this trigger without touching the E2E workflow

## Doc-aligned

Per \`molecule-controlplane/docs/canary-tenants.md\` section "Do we actually need canary right now?", the recommendation for current scale (≤20 paying tenants) is "fix staging E2E + use it as the promote gate" — exactly what this PR ships. Phase 2 canary fleet stays deferred until blast radius grows.

## Safety

- \`if:\` skips the job when E2E failed (\`:latest\` stays on the prior known-good digest)
- Verifies both \`platform:staging-<sha>\` and \`platform-tenant:staging-<sha>\` exist before retagging either — half-published state is impossible
- \`workflow_dispatch\` provided as manual escape hatch (with optional \`sha\` override)

## Test plan

- [x] yaml syntax valid
- [ ] After merge: this PR's own merge to main triggers E2E Staging SaaS (path filter touches \`.github/workflows/**\` so the SaaS suite includes the workflow file in its watched paths — verify it runs)
- [ ] On green E2E for main commit: this workflow fires, retags both images
- [ ] Verify with \`gh api repos/Molecule-AI/molecule-core/pulls/<n>/check-runs\` and \`docker manifest inspect ghcr.io/molecule-ai/platform-tenant:latest\` that \`:latest\` digest matches \`:staging-<sha>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)