### PR TITLE
fix(ci): printf format-string sink + filename word-split in secret-scan

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -148,7 +148,13 @@ jobs:
           SELF=".github/workflows/secret-scan.yml"
 
           OFFENDING=""
-          for f in $CHANGED; do
+          # `while IFS= read -r` (not `for f in $CHANGED`) so filenames
+          # containing whitespace don't word-split silently — a path
+          # with a space would otherwise produce two iterations on
+          # tokens that aren't real filenames, breaking the
+          # self-exclude + diff lookup.
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
             [ "$f" = "$SELF" ] && continue
             if [ -n "$DIFF_RANGE" ]; then
               ADDED=$(git diff --no-color --unified=0 "$BASE" "$HEAD" -- "$f" 2>/dev/null | grep -E '^\+[^+]' || true)
@@ -164,11 +170,18 @@ jobs:
                 break
               fi
             done
-          done
+          done <<< "$CHANGED"
 
           if [ -n "$OFFENDING" ]; then
             echo "::error::Credential-shaped strings detected in diff additions:"
-            printf "$OFFENDING"
+            # `printf '%b' "$OFFENDING"` interprets backslash escapes
+            # (the literal `\n` we appended above becomes a newline)
+            # WITHOUT treating OFFENDING as a format string. Plain
+            # `printf "$OFFENDING"` is a format-string sink: a filename
+            # containing `%` would be interpreted as a conversion
+            # specifier, corrupting the error message (or printing
+            # `%(missing)` artifacts).
+            printf '%b' "$OFFENDING"
             echo ""
             echo "The actual matched values are NOT echoed here, deliberately —"
             echo "round-tripping a leaked credential into CI logs widens the blast"


### PR DESCRIPTION
## Summary

Closes #138. Two latent bugs in the canonical secret-scan workflow caught during the post-merge review of molecule-controlplane #301 (a private consumer that inlined this workflow's logic and got both fixes there). Fixing here means every public consumer (gh-identity, github-app-auth, the 8 workspace template repos) inherits the fix on their next `workflow_call`.

## Bug 1 — `printf "$OFFENDING"` is a format-string sink

`OFFENDING` is built from filenames. A filename containing `%` characters would be interpreted as a conversion specifier by printf, corrupting the error message. Fix: `printf '%b' "$OFFENDING"`.

## Bug 2 — `for f in $CHANGED` word-splits on whitespace

Filenames containing spaces would silently split into multiple tokens, breaking the self-exclude + diff-lookup loop. Fix: `while IFS= read -r f; do ... done <<< "$CHANGED"`.

## Net diff

~16 lines, mostly comments documenting the WHY. No behavior change for filenames in the current tree; strictly better for the edge cases.

## Verification

YAML parses. Logic-equivalent for the existing tree: every filename in molecule-core is whitespace-free + percent-free, so neither edge case fires today. The fix is preventive.

## Follow-up

The runtime's pre-commit hook (`molecule-ai-workspace-runtime: molecule_runtime/scripts/pre-commit-checks.sh`) likely has the same bugs. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)