### PR TITLE
feat(ci): auto-sync main → staging to keep staging-as-superset invariant

### DIFF
--- a/.github/workflows/auto-sync-main-to-staging.yml
+++ b/.github/workflows/auto-sync-main-to-staging.yml
@@ -1,0 +1,136 @@
+name: Auto-sync main → staging
+
+# Reflects every push to `main` back onto `staging` so the
+# staging-as-superset-of-main invariant holds.
+#
+# Background:
+#
+# `auto-promote-staging.yml` advances main via `git merge --ff-only`
+# + `git push origin main` — that's a clean fast-forward, no merge
+# commit. But manual merges of `staging → main` PRs through the
+# GitHub UI / API create a merge commit on main that staging
+# doesn't have. The next `staging → main` PR then evaluates as
+# "BEHIND" because staging is missing that merge commit, requiring
+# a manual `gh pr update-branch` round-trip.
+#
+# This happened twice on 2026-04-28 (PRs #2202, #2205, both manual
+# bridges). Each time the bridge needed update-branch + a re-CI
+# round before merging. Operationally annoying and avoidable.
+#
+# This workflow closes the gap automatically:
+#
+#   1. Push to main fires (regardless of source: auto-promote, UI
+#      merge, API merge, direct push).
+#   2. Check whether main is already in staging's ancestry — if
+#      yes, no-op (auto-promote-staging already kept them in sync
+#      via fast-forward).
+#   3. If not, try fast-forward staging to main first (works when
+#      staging hasn't diverged with its own commits).
+#   4. If ff fails (staging has commits main doesn't — feature work
+#      in flight), do a real merge with a "chore: sync" commit so
+#      staging absorbs main's tip while keeping its own history.
+#   5. Push staging.
+#
+# Loop safety:
+#
+# Pushing the synced staging triggers `auto-promote-staging.yml`,
+# which checks gates on staging's new tip and, if green, ff-pushes
+# staging to main. Since staging now == main (ff case) or ⊇ main
+# (merge case where promote then advances), the resulting push to
+# main is either a no-op (no actual ref change → no push event) or
+# advances main further. In the latter case auto-sync fires again,
+# sees main already in staging's ancestry, no-ops. No infinite loop.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout staging
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: staging
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Check if staging already contains main
+        id: check
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "needs_sync=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## ✅ No-op"
+              echo
+              echo "staging already contains \`origin/main\` ($(git rev-parse --short=8 origin/main))."
+              echo "auto-promote-staging or a previous auto-sync run already kept them aligned."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "needs_sync=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::staging is missing main's tip — sync needed"
+          fi
+
+      - name: Fast-forward staging → main
+        if: steps.check.outputs.needs_sync == 'true'
+        id: ff
+        run: |
+          set -euo pipefail
+          if git merge --ff-only origin/main; then
+            echo "did_ff=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Fast-forwarded staging to origin/main"
+          else
+            echo "did_ff=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::ff failed — staging has its own commits; will create merge"
+          fi
+
+      - name: Merge main into staging (when ff fails)
+        if: |
+          steps.check.outputs.needs_sync == 'true' &&
+          steps.ff.outputs.did_ff != 'true'
+        run: |
+          set -euo pipefail
+          # ff failed because staging has commits main doesn't — typical
+          # in-flight feature work. Create a merge commit so staging
+          # absorbs main's tip while keeping its own history.
+          if ! git merge --no-ff origin/main -m "chore: sync main → staging (auto)"; then
+            {
+              echo "## ❌ Conflict"
+              echo
+              echo "Auto-merge \`main → staging\` failed with conflicts."
+              echo "A human needs to resolve manually:"
+              echo
+              echo "    git checkout staging"
+              echo "    git merge origin/main"
+              echo "    # resolve, commit, push"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Push staging
+        if: steps.check.outputs.needs_sync == 'true'
+        run: |
+          set -euo pipefail
+          git push origin staging
+          {
+            if [ "${{ steps.ff.outputs.did_ff }}" = "true" ]; then
+              echo "## ✅ staging fast-forwarded"
+              echo
+              echo "staging is now at \`$(git rev-parse --short=8 HEAD)\` (== origin/main)."
+            else
+              echo "## ✅ staging absorbed main"
+              echo
+              echo "staging is now at \`$(git rev-parse --short=8 HEAD)\` with a merge commit absorbing main's tip."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Eliminates the bridge-PR-thrash class that bit us twice today (#2202, #2205). Whenever main moves, staging absorbs the new tip automatically — no more manual `gh pr update-branch` round-trips on follow-up PRs.

## Mechanism

Triggered on every \`push: branches: [main]\`:

1. **No-op case** (steady state): \`origin/main\` is already in staging's ancestry. Workflow logs and exits. This is the common case after \`auto-promote-staging.yml\` ff-advanced main from staging.

2. **Manual main merge case** (the bug we hit twice today): main has a merge commit not on staging. Try ff first; if staging hasn't diverged it succeeds and staging fast-forwards to main.

3. **Diverged case** (staging has in-flight feature work main doesn't): create a merge commit \`chore: sync main → staging (auto)\` so staging absorbs main's tip while keeping its own history.

4. Push staging.

## Loop safety

Pushing synced staging triggers auto-promote-staging.yml, which ff-pushes staging to main. main now equals staging; that push is a no-op ref-update so no push event fires → auto-sync doesn't re-trigger. Bounded.

## Conflict handling

If \`merge --no-ff main\` hits conflicts (staging and main diverged with incompatible changes), workflow fails with a clear summary pointing to manual resolution. Shouldn't happen in practice — conflicts indicate a direct main hotfix touching the same code as in-flight staging work, which is itself an anti-pattern (hotfixes should land on staging first).

## Test plan

- [x] yaml syntax valid
- [ ] After merge: any future direct main push (e.g. another manual bridge, or a CEO direct merge) triggers this workflow and updates staging within ~30s
- [ ] After merge: the next staging → main PR no longer needs \`gh pr update-branch\` because staging always contains main

## Out-of-scope (track separately)

- Apply the same workflow to molecule-controlplane (lower urgency; molecule-core sees more cross-branch traffic)
- Pin third-party Actions to commit SHAs (separate task #15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)