### PR TITLE
fix(tools): unify LangChain tool names with MCP — fix doc/tool drift from #2237

### DIFF
--- a/workspace/adapter_base.py
+++ b/workspace/adapter_base.py
@@ -421,8 +421,8 @@ class BaseAdapter(ABC):
         from coordinator import get_children, get_parent_context, build_children_description
         from prompt import build_system_prompt, get_peer_capabilities, get_platform_instructions
         from builtin_tools.approval import request_approval
-        from builtin_tools.delegation import delegate_to_workspace, check_delegation_status
-        from builtin_tools.memory import commit_memory, search_memory
+        from builtin_tools.delegation import delegate_task, delegate_task_async, check_task_status
+        from builtin_tools.memory import commit_memory, recall_memory
         from builtin_tools.sandbox import run_code
 
         platform_url = os.environ.get("PLATFORM_URL", "http://host.docker.internal:8080")
@@ -455,8 +455,19 @@ class BaseAdapter(ABC):
                     seen_skill_ids.add(skill.metadata.id)
         logger.info(f"Loaded {len(loaded_skills)} skills: {[s.metadata.id for s in loaded_skills]}")
 
-        # Assemble tools: 6 core + skill tools
-        all_tools = [delegate_to_workspace, check_delegation_status, request_approval, commit_memory, search_memory, run_code]
+        # Assemble tools: 7 core + skill tools.
+        # Tool naming is unified across MCP and LangChain runtimes so the
+        # platform-injected docs (get_a2a_instructions, get_hma_instructions)
+        # name tools that actually exist in both worlds:
+        #   delegate_task        — sync, returns peer's response text
+        #   delegate_task_async  — async, returns task_id
+        #   check_task_status    — poll an async delegation
+        #   commit_memory        — write to HMA with scope
+        #   recall_memory        — read from HMA (LOCAL+TEAM+GLOBAL)
+        all_tools = [
+            delegate_task, delegate_task_async, check_task_status,
+            request_approval, commit_memory, recall_memory, run_code,
+        ]
         for skill in loaded_skills:
             all_tools.extend(skill.tools)
 

--- a/workspace/builtin_tools/delegation.py
+++ b/workspace/builtin_tools/delegation.py
@@ -2,7 +2,7 @@
 
 Delegations are non-blocking: the tool fires the A2A request in the background
 and returns immediately with a task_id. The agent can check status anytime via
-check_delegation_status, or just continue working and check later.
+check_task_status, or just continue working and check later.
 
 When the delegate responds, the result is stored and the agent is notified
 via a status update.
@@ -44,7 +44,7 @@ class DelegationStatus(str, Enum):
     # The reply will arrive via the platform's stitch path when the
     # peer finishes its current work. The LLM should WAIT, not retry,
     # and definitely not fall back to doing the work itself — see the
-    # check_delegation_status docstring for the prompt-side guidance.
+    # check_task_status docstring for the prompt-side guidance.
     QUEUED = "queued"
     COMPLETED = "completed"
     FAILED = "failed"
@@ -110,7 +110,7 @@ async def _record_delegation_on_platform(task_id: str, target_workspace_id: str,
     Best-effort POST to /workspaces/<self>/delegations/record. The agent still
     fires A2A directly for speed + OTEL propagation, but the platform's
     GET /delegations endpoint now mirrors the same set an agent's local
-    check_delegation_status sees.
+    check_task_status sees.
     """
     try:
         async with httpx.AsyncClient(timeout=10) as client:
@@ -129,11 +129,11 @@ async def _record_delegation_on_platform(task_id: str, target_workspace_id: str,
 async def _refresh_queued_from_platform(task_id: str) -> bool:
     """Lazy-refresh a QUEUED delegation's local state from the platform.
 
-    Called by check_delegation_status when local status is QUEUED. The
+    Called by check_task_status when local status is QUEUED. The
     platform's drain stitch (a2a_queue.go) updates the delegate_result
     activity_logs row when a queued delegation eventually completes,
     but it has no callback to this runtime — without this lazy refresh,
-    the LLM polling check_delegation_status would see "queued" forever
+    the LLM polling check_task_status would see "queued" forever
     even after the platform has the result.
 
     Returns True if the local delegation was updated to a terminal state
@@ -215,7 +215,7 @@ async def _execute_delegation(task_id: str, workspace_id: str, task: str):
     delegation.status = DelegationStatus.IN_PROGRESS
 
     # #64: register on the platform so GET /workspaces/<self>/delegations
-    # sees the same set as check_delegation_status. Best-effort — platform
+    # sees the same set as check_task_status. Best-effort — platform
     # unreachability must not block the actual A2A delegation.
     await _record_delegation_on_platform(task_id, workspace_id, task)
 
@@ -286,7 +286,7 @@ async def _execute_delegation(task_id: str, workspace_id: str, task: str):
                     # accepted the request but the peer's runtime is
                     # mid-task. Platform-side drain will deliver the
                     # reply asynchronously. Mark QUEUED locally so
-                    # check_delegation_status can surface that state
+                    # check_task_status can surface that state
                     # to the LLM with explicit "wait, don't bypass"
                     # guidance. Do NOT mark FAILED — the request is
                     # alive in the platform's queue, not lost.
@@ -371,14 +371,41 @@ async def _execute_delegation(task_id: str, workspace_id: str, task: str):
 
 
 @tool
-async def delegate_to_workspace(
+async def delegate_task(
+    workspace_id: str,
+    task: str,
+) -> str:
+    """Delegate a task to a peer workspace via A2A and WAIT for the response.
+
+    Synchronous variant — blocks until the peer replies (or the platform's
+    A2A round-trip times out). Use this for QUICK questions and small
+    sub-tasks where you can afford to wait inline.
+
+    For longer-running work (research, synthesis, multi-minute jobs), use
+    delegate_task_async + check_task_status instead so you don't hold this
+    workspace busy waiting.
+
+    Args:
+        workspace_id: The ID of the target workspace to delegate to.
+        task: The task description to send to the peer.
+
+    Returns:
+        The peer's response text directly (or a "DELEGATION FAILED" string
+        prefixed with recovery guidance if the round-trip errored).
+    """
+    from a2a_tools import tool_delegate_task
+    return await tool_delegate_task(workspace_id, task)
+
+
+@tool
+async def delegate_task_async(
     workspace_id: str,
     task: str,
 ) -> dict:
     """Delegate a task to a peer workspace via A2A protocol (non-blocking).
 
     Sends the task in the background and returns immediately with a task_id.
-    Use check_delegation_status to poll for the result, or continue working
+    Use check_task_status to poll for the result, or continue working
     and check later. The delegate works independently.
 
     Args:
@@ -386,7 +413,7 @@ async def delegate_to_workspace(
         task: The task description to send to the peer.
 
     Returns:
-        A dict with task_id and status="delegated". Use check_delegation_status(task_id) to get results.
+        A dict with task_id and status="delegated". Use check_task_status(task_id) to get results.
     """
     task_id = str(uuid.uuid4())
 
@@ -417,12 +444,12 @@ async def delegate_to_workspace(
         "success": True,
         "task_id": task_id,
         "status": "delegated",
-        "message": f"Task delegated to {workspace_id}. Use check_delegation_status('{task_id}') to get the result when ready.",
+        "message": f"Task delegated to {workspace_id}. Use check_task_status('{task_id}') to get the result when ready.",
     }
 
 
 @tool
-async def check_delegation_status(
+async def check_task_status(
     task_id: str = "",
 ) -> dict:
     """Check the status of a delegated task, or list all active delegations.
@@ -434,7 +461,7 @@ async def check_delegation_status(
       processing a prior task. The reply WILL arrive — the platform's
       drain re-dispatches when the peer is free. This tool transparently
       polls the platform for the eventual outcome on each call, so
-      keep polling check_delegation_status periodically and you'll see
+      keep polling check_task_status periodically and you'll see
       the status flip to "completed" / "failed" automatically.
       Do NOT retry the delegation. Do NOT do the work yourself.
       Acknowledge to the user that the peer is busy and will reply,
@@ -445,7 +472,7 @@ async def check_delegation_status(
       yourself if status is "failed", never if status is "queued".
 
     Args:
-        task_id: The task_id returned by delegate_to_workspace. If empty, lists all delegations.
+        task_id: The task_id returned by delegate_task_async. If empty, lists all delegations.
 
     Returns:
         Status and result (if completed) of the delegation.

--- a/workspace/builtin_tools/memory.py
+++ b/workspace/builtin_tools/memory.py
@@ -8,7 +8,7 @@ Hierarchical Memory Architecture:
 RBAC enforcement
 ----------------
 ``commit_memory`` requires the ``"memory.write"`` action.
-``search_memory`` requires the ``"memory.read"`` action.
+``recall_memory`` requires the ``"memory.read"`` action.
 Roles are read from ``config.yaml`` under ``rbac.roles`` (default: operator).
 
 Audit trail
@@ -188,7 +188,7 @@ async def commit_memory(content: str, scope: str = "LOCAL") -> dict:
 
 
 @tool
-async def search_memory(query: str = "", scope: str = "") -> dict:
+async def recall_memory(query: str = "", scope: str = "") -> dict:
     """Search stored memories.
 
     Args:

--- a/workspace/coordinator.py
+++ b/workspace/coordinator.py
@@ -81,7 +81,7 @@ def build_children_description(children: list[dict]) -> str:
         children,
         heading="## Your Team (sub-workspaces you coordinate)",
         instruction=(
-            "Use the `delegate_to_workspace` tool to send tasks to the chosen member. "
+            "Use the `delegate_task_async` tool to send tasks to the chosen member. "
             "Only delegate to members listed above."
         ),
     )
@@ -92,7 +92,7 @@ def build_children_description(children: list[dict]) -> str:
             "",
             "### Coordination Rules — MANDATORY",
             "1. You are a COORDINATOR. Your ONLY job is to delegate and synthesize. NEVER do the work yourself.",
-            "2. For EVERY task, use `delegate_to_workspace` to send it to the appropriate team member(s). "
+            "2. For EVERY task, use `delegate_task_async` to send it to the appropriate team member(s). "
             "Do this BEFORE writing any analysis, code, or research yourself.",
             "3. If a task spans multiple members, delegate to ALL of them in parallel and aggregate results.",
             "4. If ALL members are offline/paused, tell the caller which members are unavailable. "
@@ -120,7 +120,7 @@ async def route_task_to_team(
         task: The task description to route.
         preferred_member_id: Optional — directly delegate to this member.
     """
-    from builtin_tools.delegation import delegate_to_workspace as delegate
+    from builtin_tools.delegation import delegate_task_async as delegate
 
     children = await get_children()
     decision = build_team_routing_payload(

--- a/workspace/main.py
+++ b/workspace/main.py
@@ -337,11 +337,13 @@ async def main():  # pragma: no cover
                 # Rebuild the agent's tool list from updated skills
                 if hasattr(adapter, "all_tools") and hasattr(adapter, "system_prompt"):
                     from builtin_tools.approval import request_approval
-                    from builtin_tools.delegation import delegate_to_workspace
-                    from builtin_tools.memory import commit_memory, search_memory
+                    from builtin_tools.delegation import delegate_task, delegate_task_async, check_task_status
+                    from builtin_tools.memory import commit_memory, recall_memory
                     from builtin_tools.sandbox import run_code
-                    base_tools = [delegate_to_workspace, request_approval,
-                                  commit_memory, search_memory, run_code]
+                    base_tools = [
+                        delegate_task, delegate_task_async, check_task_status,
+                        request_approval, commit_memory, recall_memory, run_code,
+                    ]
                     skill_tools = []
                     for sk in adapter.loaded_skills:
                         skill_tools.extend(sk.tools)

--- a/workspace/policies/routing.py
+++ b/workspace/policies/routing.py
@@ -64,7 +64,7 @@ def build_team_routing_payload(
         "action": "choose_member",
         "message": (
             f"You have {len(members)} team members. "
-            "Choose the best one for this task and call delegate_to_workspace with their ID."
+            "Choose the best one for this task and call delegate_task_async with their ID."
         ),
         "task": task,
         "members": members,

--- a/workspace/shared_runtime.py
+++ b/workspace/shared_runtime.py
@@ -140,7 +140,7 @@ def build_peer_section(
     *,
     heading: str = "## Your Peers (workspaces you can delegate to)",
     instruction: str = (
-        "Use the `delegate_to_workspace` tool to send tasks to peers. "
+        "Use the `delegate_task_async` tool to send tasks to peers. "
         "Only delegate to peers listed above."
     ),
 ) -> str:

--- a/workspace/tests/conftest.py
+++ b/workspace/tests/conftest.py
@@ -113,10 +113,12 @@ def _make_tools_mocks():
     tools_mod.__path__ = []  # Make it a proper package
 
     tools_delegation_mod = ModuleType("builtin_tools.delegation")
-    tools_delegation_mod.delegate_to_workspace = MagicMock()
-    tools_delegation_mod.delegate_to_workspace.name = "delegate_to_workspace"
-    tools_delegation_mod.check_delegation_status = MagicMock()
-    tools_delegation_mod.check_delegation_status.name = "check_delegation_status"
+    tools_delegation_mod.delegate_task = MagicMock()
+    tools_delegation_mod.delegate_task.name = "delegate_task"
+    tools_delegation_mod.delegate_task_async = MagicMock()
+    tools_delegation_mod.delegate_task_async.name = "delegate_task_async"
+    tools_delegation_mod.check_task_status = MagicMock()
+    tools_delegation_mod.check_task_status.name = "check_task_status"
 
     tools_approval_mod = ModuleType("builtin_tools.approval")
     tools_approval_mod.request_approval = MagicMock()
@@ -125,8 +127,8 @@ def _make_tools_mocks():
     tools_memory_mod = ModuleType("builtin_tools.memory")
     tools_memory_mod.commit_memory = MagicMock()
     tools_memory_mod.commit_memory.name = "commit_memory"
-    tools_memory_mod.search_memory = MagicMock()
-    tools_memory_mod.search_memory.name = "search_memory"
+    tools_memory_mod.recall_memory = MagicMock()
+    tools_memory_mod.recall_memory.name = "recall_memory"
 
     tools_sandbox_mod = ModuleType("builtin_tools.sandbox")
     tools_sandbox_mod.run_code = MagicMock()

--- a/workspace/tests/test_coordinator_routing.py
+++ b/workspace/tests/test_coordinator_routing.py
@@ -28,7 +28,7 @@ async def test_route_task_to_team_delegates_preferred_member(monkeypatch):
 
     delegate = MagicMock()
     delegate.ainvoke = AsyncMock(return_value={"ok": True})
-    monkeypatch.setattr(sys.modules["builtin_tools.delegation"], "delegate_to_workspace", delegate)
+    monkeypatch.setattr(sys.modules["builtin_tools.delegation"], "delegate_task_async", delegate)
 
     result = await coordinator.route_task_to_team(
         "Do the thing",
@@ -58,4 +58,4 @@ def test_build_children_description_reuses_shared_renderer():
     assert "## Your Team (sub-workspaces you coordinate)" in description
     assert "**Alpha** (id: `child-1`, status: online)" in description
     assert "Skills: research" in description
-    assert "delegate_to_workspace" in description
+    assert "delegate_task_async" in description

--- a/workspace/tests/test_delegation.py
+++ b/workspace/tests/test_delegation.py
@@ -4,7 +4,7 @@ The delegation tool now returns immediately with a task_id and runs the
 A2A request in the background. Tests verify:
 1. Immediate return with task_id
 2. Background task completion
-3. check_delegation_status retrieval
+3. check_task_status retrieval
 4. Error handling (RBAC, discovery, network)
 """
 
@@ -109,22 +109,22 @@ def delegation_mocks(monkeypatch):
 
 
 async def _invoke(mod, workspace_id="target", task="do stuff"):
-    """Call delegate_to_workspace and return the immediate result."""
-    fn = mod.delegate_to_workspace
+    """Call delegate_task_async and return the immediate result."""
+    fn = mod.delegate_task_async
     if hasattr(fn, "ainvoke"):
         return await fn.ainvoke({"workspace_id": workspace_id, "task": task})
     return await fn(workspace_id=workspace_id, task=task)
 
 
 async def _invoke_and_wait(mod, workspace_id="target", task="do stuff"):
-    """Call delegate_to_workspace, wait for background task, return status."""
+    """Call delegate_task_async, wait for background task, return status."""
     result = await _invoke(mod, workspace_id, task)
     # Wait for all background tasks to complete
     if mod._background_tasks:
         await asyncio.gather(*mod._background_tasks, return_exceptions=True)
     # Get final status
     if "task_id" in result:
-        fn = mod.check_delegation_status
+        fn = mod.check_task_status
         if hasattr(fn, "ainvoke"):
             return await fn.ainvoke({"task_id": result["task_id"]})
         return await fn(task_id=result["task_id"])
@@ -182,7 +182,7 @@ class TestAsyncDelegation:
             await _invoke(mod, workspace_id="ws-a", task="task A")
             await _invoke(mod, workspace_id="ws-b", task="task B")
 
-        fn = mod.check_delegation_status
+        fn = mod.check_task_status
         if hasattr(fn, "ainvoke"):
             result = await fn.ainvoke({"task_id": ""})
         else:
@@ -194,7 +194,7 @@ class TestAsyncDelegation:
     async def test_check_delegation_not_found(self, delegation_mocks):
         mod, *_ = delegation_mocks
 
-        fn = mod.check_delegation_status
+        fn = mod.check_task_status
         if hasattr(fn, "ainvoke"):
             result = await fn.ainvoke({"task_id": "nonexistent"})
         else:
@@ -354,7 +354,7 @@ class TestA2AQueued:
 
 
 class TestQueuedLazyRefresh:
-    """When a delegation is QUEUED, check_delegation_status must lazily
+    """When a delegation is QUEUED, check_task_status must lazily
     refresh from the platform's GET /delegations to pick up drain-stitch
     completions. Without this refresh, the LLM sees "queued" forever
     because the platform never pushes back to the runtime.
@@ -401,7 +401,7 @@ class TestQueuedLazyRefresh:
         refresh_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", refresh_cls):
-            fn = mod.check_delegation_status
+            fn = mod.check_task_status
             if hasattr(fn, "ainvoke"):
                 refreshed = await fn.ainvoke({"task_id": task_id})
             else:
@@ -443,7 +443,7 @@ class TestQueuedLazyRefresh:
         refresh_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", refresh_cls):
-            fn = mod.check_delegation_status
+            fn = mod.check_task_status
             if hasattr(fn, "ainvoke"):
                 refreshed = await fn.ainvoke({"task_id": task_id})
             else:
@@ -486,7 +486,7 @@ class TestQueuedLazyRefresh:
         refresh_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", refresh_cls):
-            fn = mod.check_delegation_status
+            fn = mod.check_task_status
             if hasattr(fn, "ainvoke"):
                 refreshed = await fn.ainvoke({"task_id": task_id})
             else:
@@ -515,7 +515,7 @@ class TestQueuedLazyRefresh:
         refresh_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         with patch("httpx.AsyncClient", refresh_cls):
-            fn = mod.check_delegation_status
+            fn = mod.check_task_status
             if hasattr(fn, "ainvoke"):
                 refreshed = await fn.ainvoke({"task_id": task_id})
             else:

--- a/workspace/tests/test_memory.py
+++ b/workspace/tests/test_memory.py
@@ -98,7 +98,7 @@ def test_commit_memory_uses_awareness_client_when_configured(monkeypatch, memory
     assert captured["json"] == {"content": "remember this", "scope": "TEAM"}
 
 
-def test_search_memory_uses_platform_fallback_without_awareness(monkeypatch, memory_modules):
+def test_recall_memory_uses_platform_fallback_without_awareness(monkeypatch, memory_modules):
     memory, _awareness_client = memory_modules
     captured = {}
 
@@ -119,7 +119,7 @@ def test_search_memory_uses_platform_fallback_without_awareness(monkeypatch, mem
 
     monkeypatch.setattr(memory.httpx, "AsyncClient", FakeAsyncClient)
 
-    result = asyncio.run(memory.search_memory("status", "local"))
+    result = asyncio.run(memory.recall_memory("status", "local"))
 
     assert result == {
         "success": True,
@@ -236,10 +236,10 @@ def test_commit_memory_promoted_packet_logs_skill_promotion(monkeypatch, tmp_pat
     assert not (tmp_path / "skills").exists()
 
 
-def test_search_memory_rejects_invalid_scope(memory_modules):
+def test_recall_memory_rejects_invalid_scope(memory_modules):
     memory, _awareness_client = memory_modules
 
-    result = asyncio.run(memory.search_memory("status", "bad"))
+    result = asyncio.run(memory.recall_memory("status", "bad"))
 
     assert result == {"error": "scope must be LOCAL, TEAM, GLOBAL, or empty"}
 
@@ -457,15 +457,15 @@ def test_commit_memory_result_failure(memory_modules_with_mocks):
 
 
 # ---------------------------------------------------------------------------
-# search_memory — RBAC deny
+# recall_memory — RBAC deny
 # ---------------------------------------------------------------------------
 
-def test_search_memory_rbac_deny(memory_modules_with_mocks):
+def test_recall_memory_rbac_deny(memory_modules_with_mocks):
     memory, mock_audit, _ = memory_modules_with_mocks
     mock_audit.check_permission.return_value = False
     mock_audit.get_workspace_roles.return_value = (["read-only-special"], {})
 
-    result = asyncio.run(memory.search_memory("find something", "local"))
+    result = asyncio.run(memory.recall_memory("find something", "local"))
 
     assert result["success"] is False
     assert "RBAC" in result["error"]
@@ -473,22 +473,22 @@ def test_search_memory_rbac_deny(memory_modules_with_mocks):
 
 
 # ---------------------------------------------------------------------------
-# search_memory — invalid scope
+# recall_memory — invalid scope
 # ---------------------------------------------------------------------------
 
-def test_search_memory_invalid_scope(memory_modules_with_mocks):
+def test_recall_memory_invalid_scope(memory_modules_with_mocks):
     memory, _mock_audit, _ = memory_modules_with_mocks
 
-    result = asyncio.run(memory.search_memory("q", "BAD"))
+    result = asyncio.run(memory.recall_memory("q", "BAD"))
 
     assert result == {"error": "scope must be LOCAL, TEAM, GLOBAL, or empty"}
 
 
 # ---------------------------------------------------------------------------
-# search_memory — awareness_client success
+# recall_memory — awareness_client success
 # ---------------------------------------------------------------------------
 
-def test_search_memory_awareness_client_success(memory_modules_with_mocks):
+def test_recall_memory_awareness_client_success(memory_modules_with_mocks):
     from unittest.mock import AsyncMock, MagicMock
     memory, mock_audit, mock_awareness_mod = memory_modules_with_mocks
 
@@ -501,7 +501,7 @@ def test_search_memory_awareness_client_success(memory_modules_with_mocks):
     # Patch directly on the loaded module since it imported the name at load time
     memory.build_awareness_client = MagicMock(return_value=mock_ac)
 
-    result = asyncio.run(memory.search_memory("find", "team"))
+    result = asyncio.run(memory.recall_memory("find", "team"))
 
     assert result["success"] is True
     assert result["count"] == 2
@@ -509,10 +509,10 @@ def test_search_memory_awareness_client_success(memory_modules_with_mocks):
 
 
 # ---------------------------------------------------------------------------
-# search_memory — awareness_client raises
+# recall_memory — awareness_client raises
 # ---------------------------------------------------------------------------
 
-def test_search_memory_awareness_client_exception(memory_modules_with_mocks):
+def test_recall_memory_awareness_client_exception(memory_modules_with_mocks):
     from unittest.mock import AsyncMock, MagicMock
     memory, mock_audit, mock_awareness_mod = memory_modules_with_mocks
 
@@ -521,7 +521,7 @@ def test_search_memory_awareness_client_exception(memory_modules_with_mocks):
     # Patch directly on the loaded module since it imported the name at load time
     memory.build_awareness_client = MagicMock(return_value=mock_ac)
 
-    result = asyncio.run(memory.search_memory("query", "local"))
+    result = asyncio.run(memory.recall_memory("query", "local"))
 
     assert result["success"] is False
     assert "awareness search failed" in result["error"]
@@ -530,10 +530,10 @@ def test_search_memory_awareness_client_exception(memory_modules_with_mocks):
 
 
 # ---------------------------------------------------------------------------
-# search_memory — httpx 200 success (no awareness_client)
+# recall_memory — httpx 200 success (no awareness_client)
 # ---------------------------------------------------------------------------
 
-def test_search_memory_httpx_200_success(memory_modules_with_mocks):
+def test_recall_memory_httpx_200_success(memory_modules_with_mocks):
     memory, _mock_audit, _ = memory_modules_with_mocks
 
     class FakeAsyncClient:
@@ -545,7 +545,7 @@ def test_search_memory_httpx_200_success(memory_modules_with_mocks):
 
     memory.httpx.AsyncClient = FakeAsyncClient
 
-    result = asyncio.run(memory.search_memory("find", "global"))
+    result = asyncio.run(memory.recall_memory("find", "global"))
 
     assert result["success"] is True
     assert result["count"] == 2
@@ -553,10 +553,10 @@ def test_search_memory_httpx_200_success(memory_modules_with_mocks):
 
 
 # ---------------------------------------------------------------------------
-# search_memory — httpx non-200
+# recall_memory — httpx non-200
 # ---------------------------------------------------------------------------
 
-def test_search_memory_httpx_non_200(memory_modules_with_mocks):
+def test_recall_memory_httpx_non_200(memory_modules_with_mocks):
     memory, mock_audit, _ = memory_modules_with_mocks
 
     class FakeAsyncClient:
@@ -568,17 +568,17 @@ def test_search_memory_httpx_non_200(memory_modules_with_mocks):
 
     memory.httpx.AsyncClient = FakeAsyncClient
 
-    result = asyncio.run(memory.search_memory("q", ""))
+    result = asyncio.run(memory.recall_memory("q", ""))
 
     assert result["success"] is False
     assert "server error" in result["error"]
 
 
 # ---------------------------------------------------------------------------
-# search_memory — httpx raises
+# recall_memory — httpx raises
 # ---------------------------------------------------------------------------
 
-def test_search_memory_httpx_exception(memory_modules_with_mocks):
+def test_recall_memory_httpx_exception(memory_modules_with_mocks):
     memory, mock_audit, _ = memory_modules_with_mocks
 
     class FakeAsyncClient:
@@ -590,7 +590,7 @@ def test_search_memory_httpx_exception(memory_modules_with_mocks):
 
     memory.httpx.AsyncClient = FakeAsyncClient
 
-    result = asyncio.run(memory.search_memory("query", "local"))
+    result = asyncio.run(memory.recall_memory("query", "local"))
 
     assert result["success"] is False
     assert "request timed out" in result["error"]
@@ -672,7 +672,7 @@ def test_commit_memory_awareness_exception_span_record_fails(memory_modules_with
     assert result["success"] is False  # error propagated despite span failure
 
 
-def test_search_memory_awareness_exception_span_record_fails(memory_modules_with_mocks):
+def test_recall_memory_awareness_exception_span_record_fails(memory_modules_with_mocks):
     """awareness_client.search raises + span.record_exception also raises: error still returned."""
     from unittest.mock import AsyncMock, MagicMock
     memory, mock_audit, mock_awareness_mod = memory_modules_with_mocks
@@ -685,7 +685,7 @@ def test_search_memory_awareness_exception_span_record_fails(memory_modules_with
     mock_ac.search = AsyncMock(side_effect=RuntimeError("awareness down"))
     memory.build_awareness_client = MagicMock(return_value=mock_ac)
 
-    result = asyncio.run(memory.search_memory("test", "local"))
+    result = asyncio.run(memory.recall_memory("test", "local"))
     assert result["success"] is False
 
 
@@ -711,8 +711,8 @@ def test_commit_memory_httpx_exception_span_record_fails(memory_modules_with_moc
     assert result["success"] is False
 
 
-def test_search_memory_httpx_exception_span_record_fails(memory_modules_with_mocks):
-    """httpx raises in search_memory + span.record_exception also raises: error still returned."""
+def test_recall_memory_httpx_exception_span_record_fails(memory_modules_with_mocks):
+    """httpx raises in recall_memory + span.record_exception also raises: error still returned."""
     from unittest.mock import MagicMock
     memory, mock_audit, mock_awareness_mod = memory_modules_with_mocks
 
@@ -729,7 +729,7 @@ def test_search_memory_httpx_exception_span_record_fails(memory_modules_with_moc
 
     memory.httpx.AsyncClient = FakeAsyncClient
 
-    result = asyncio.run(memory.search_memory("query", "local"))
+    result = asyncio.run(memory.recall_memory("query", "local"))
     assert result["success"] is False
 
 

--- a/workspace/tests/test_prompt.py
+++ b/workspace/tests/test_prompt.py
@@ -202,7 +202,7 @@ def test_peer_capabilities_format(tmp_path):
     assert "## Your Peers" in result
     assert "**Echo Agent** (id: `peer-1`, status: online)" in result
     assert "Skills: echo, repeat" in result
-    assert "delegate_to_workspace" in result
+    assert "delegate_task_async" in result
     # peer-2 has no agent_card but DOES have a DB name + status — must
     # still render so coordinators can delegate to freshly-created peers
     # whose A2A discovery hasn't populated a card yet (regression of the
@@ -469,3 +469,42 @@ def test_tool_instructions_precede_peer_section(tmp_path):
     a2a_idx = result.index("## Inter-Agent Communication")
     peers_idx = result.index("## Your Peers")
     assert a2a_idx < peers_idx, "A2A instructions must come before the peer list"
+
+
+def test_a2a_doc_lists_unified_tool_names(tmp_path):
+    """Pin tool naming alignment: A2A docs reference the actual @tool symbols.
+
+    Regression for the CP review finding (Issue 1+3): the LangChain runtimes
+    used to expose `delegate_to_workspace` / `check_delegation_status` while
+    the docs referenced MCP-world names (`delegate_task`, `check_task_status`).
+    Workers saw docs for tools that didn't exist. After the rename, both
+    sides use the unified names; this test fails if either side drifts.
+    """
+    (tmp_path / "system-prompt.md").write_text("Base.")
+    result = build_system_prompt(
+        config_path=str(tmp_path),
+        workspace_id="ws-1",
+        loaded_skills=[],
+        peers=[],
+    )
+
+    for name in ("delegate_task", "delegate_task_async", "check_task_status"):
+        assert name in result, f"{name} missing from injected A2A docs"
+    # The pre-rename names must NOT appear — they would mislead workers.
+    assert "delegate_to_workspace" not in result
+    assert "check_delegation_status" not in result
+
+
+def test_hma_doc_lists_unified_tool_names(tmp_path):
+    """commit_memory and recall_memory are the unified HMA tool names."""
+    (tmp_path / "system-prompt.md").write_text("Base.")
+    result = build_system_prompt(
+        config_path=str(tmp_path),
+        workspace_id="ws-1",
+        loaded_skills=[],
+        peers=[],
+    )
+
+    for name in ("commit_memory", "recall_memory"):
+        assert name in result, f"{name} missing from injected HMA docs"
+    assert "search_memory" not in result, "old search_memory name leaked back into docs"


### PR DESCRIPTION
## Summary

**Follow-up fix for #2237 (just merged).** That PR injected the A2A and HMA tool docs into the system prompt — necessary for workers to know how to use platform tools. But it shipped MCP-world tool names (\`delegate_task\`, \`check_task_status\`, \`recall_memory\`) while LangChain runtimes only had the older names (\`delegate_to_workspace\`, \`check_delegation_status\`, \`search_memory\`). **Right now in production, LangChain workers see docs telling them to call tools that don't exist.**

This PR lands the harmonization that should have shipped alongside #2237. After this PR, both MCP and LangChain runtimes share a single tool naming so the platform-injected docs are accurate everywhere.

## Renames (per CP review Issues 2 + 3)

| LangChain @tool (old) | LangChain @tool (new) | Matches MCP server | Tool in docs |
|---|---|---|---|
| \`delegate_to_workspace\` | \`delegate_task_async\` | ✓ | ✓ |
| \`check_delegation_status\` | \`check_task_status\` | ✓ | ✓ |
| \`search_memory\` | \`recall_memory\` | ✓ | ✓ |
| (missing) | \`delegate_task\` (NEW, sync) | ✓ | ✓ |

## New tool: sync \`delegate_task\` (closes Issue 3)

Wraps \`a2a_tools.tool_delegate_task\` as a LangChain \`@tool\`. Returns the peer's response text directly — no \`task_id\` polling. Use for QUICK questions; use \`delegate_task_async\` + \`check_task_status\` for longer work.

## Files touched

All under \`workspace/\`:
- \`builtin_tools/delegation.py\` — rename + new \`delegate_task\`
- \`builtin_tools/memory.py\` — \`search_memory\` → \`recall_memory\`
- \`adapter_base.py\`, \`main.py\` — register all 7 tools (was 6)
- \`coordinator.py\`, \`shared_runtime.py\`, \`policies/routing.py\` — update prompt-text references
- \`tests/conftest.py\` — module mocks include \`delegate_task\`
- \`tests/test_delegation.py\`, \`tests/test_memory.py\`, \`tests/test_coordinator_routing.py\` — name updates
- \`tests/test_prompt.py\` — **2 new alignment regression tests** that fail if docs drift from \`@tool\` symbols again

## Tests

\`WORKSPACE_ID=test pytest workspace/tests/\` — **1225 passed, 2 xfailed**.

## Why this needed to be its own PR

#2237 reached the merge queue while I was still extending the branch. By the time I tried to add the harmonization, #2237 had already landed. Shipping as a follow-up to close the regression window ASAP.

## Refs

- #2237 — A2A/HMA docs injection (merged 23:51Z, created the regression this PR fixes)
- CP review 2026-04-28 — Issues 1, 2, 3, 5
- Issue 4 (no coordinator-level execution timeout) noted, deferred — could be by design

🤖 Generated with [Claude Code](https://claude.com/claude-code)