### PR TITLE
chore(deps): batch GitHub Actions major bumps — 4 safe upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         working-directory: canvas
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
       - run: rm -f package-lock.json && npm install
@@ -277,7 +277,7 @@ jobs:
         working-directory: workspace
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,7 +69,7 @@ jobs:
       # jq is pre-installed on ubuntu-latest — no setup step needed.
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           # security-extended widens past the default to include the
@@ -77,11 +77,11 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/autobuild@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
 
       - name: Perform CodeQL Analysis
         id: analyze
-        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{ matrix.language }}"
           # upload: never — GHAS isn't enabled on this repo, so the
@@ -121,7 +121,7 @@ jobs:
         # 14-day retention — longer than default 3, short enough not
         # to bloat quota.
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codeql-sarif-${{ matrix.language }}
           path: sarif-results/${{ matrix.language }}/

--- a/.github/workflows/e2e-staging-canvas.yml
+++ b/.github/workflows/e2e-staging-canvas.yml
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '20'
           cache: 'npm'
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report-staging
           path: canvas/playwright-report-staging/
@@ -125,7 +125,7 @@ jobs:
 
       - name: Upload screenshots on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-screenshots
           path: canvas/test-results/

--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -83,7 +83,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: pip

--- a/.github/workflows/runtime-pin-compat.yml
+++ b/.github/workflows/runtime-pin-compat.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/runtime-prbuild-compat.yml
+++ b/.github/workflows/runtime-prbuild-compat.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
           cache: pip

--- a/.github/workflows/secret-pattern-drift.yml
+++ b/.github/workflows/secret-pattern-drift.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
 

--- a/.github/workflows/test-ops-scripts.yml
+++ b/.github/workflows/test-ops-scripts.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
       - name: Run unittest


### PR DESCRIPTION
## Summary

Consolidates the 4 dependabot action-major PRs that were held back from the 2026-04-28 batch (#2235) for individual review. Research below confirms each is safe for our specific usage.

## Bumps

| Action | From | To | Closes |
|---|---|---|---|
| \`github/codeql-action\` | v3 | v4.35.2 | #2228 |
| \`actions/setup-node\` | v4 | v6.4.0 | #2218 |
| \`actions/upload-artifact\` | v4 | v7.0.1 | #2216 |
| \`actions/setup-python\` | v5 | v6.2.0 | #2214 |

## Why each is safe

### \`setup-node\` v4 → v6
Every call site explicitly pins \`node-version\` (\`'20'\` in e2e-staging-canvas, \`'22'\` in ci.yml). The bump cannot shift the actual Node version we use — v5 changed default behavior, but pinned consumers are unaffected.

### \`setup-python\` v5 → v6
Same reasoning. Every call pins \`python-version: '3.11'\`. v6's new default Python 3.13 doesn't apply when consumer overrides.

### \`codeql-action\` v3 → v4.35.2
Used as \`init\`/\`autobuild\`/\`analyze\` sub-actions in \`codeql.yml\` only. v4 bundles a newer CodeQL CLI; ubuntu-latest auto-updates the CLI so functional behavior is unchanged. The deprecated \`CODEQL_ACTION_CLEANUP_TRAP_CACHES\` env var noted in the v4.35.2 changelog is undocumented and we don't set it.

### \`upload-artifact\` v4 → v7.0.1
v6 introduced Node.js 24 runtime requiring Actions Runner ≥ 2.327.1. **All our upload-artifact users (\`codeql.yml\`, \`e2e-staging-canvas.yml\`) run on \`ubuntu-latest\` (GitHub-hosted)**, which auto-updates the runner agent. Self-hosted runners are NOT used for these jobs.

## Convention

All bumps preserve SHA pinning per the org convention (\`chore(security): pin Actions to SHAs\`, 2026-04-28). The \`# vX.Y.Z\` comment alongside each SHA lets reviewers verify the pin without resolving the hash.

## Test plan

- [ ] CI runs all touched workflows with the new SHAs
- [ ] If CodeQL passes on this PR, it's also a live verification of v4.35.2 behavior
- [ ] If e2e-staging-canvas (Playwright) passes, that validates upload-artifact v7 on hosted runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)