### PR TITLE
fix(ci): hard-fail publish-runtime cascade on push when token missing

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -419,9 +419,32 @@ jobs:
           RUNTIME_VERSION: ${{ needs.publish.outputs.version }}
         run: |
           set +e   # don't abort on a single repo failure — collect them all
+          # Schedule-vs-dispatch behaviour split (hardened 2026-04-28
+          # after the sweep-cf-orphans soft-skip incident — same class
+          # of bug):
+          #
+          # The earlier "skipping cascade. templates will pick up the
+          # new version on their own next rebuild" message was wrong —
+          # templates only build on this dispatch trigger; without it
+          # they stay pinned to whatever runtime version they last saw.
+          # A silent skip here means "PyPI is current, templates are
+          # not" and the gap is invisible until someone notices a
+          # template still on the old version weeks later.
+          #
+          #   - push                → exit 1 (red CI surfaces the gap)
+          #   - workflow_dispatch   → exit 0 with a warning (operator
+          #                           ran this ad-hoc; let them rerun
+          #                           after fixing the secret)
           if [ -z "$DISPATCH_TOKEN" ]; then
-            echo "::warning::TEMPLATE_DISPATCH_TOKEN secret not set — skipping cascade. PyPI was published; templates will pick up the new version on their own next rebuild."
-            exit 0
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "::warning::TEMPLATE_DISPATCH_TOKEN secret not set — skipping cascade."
+              echo "::warning::set it at Settings → Secrets and Variables → Actions, then rerun. Templates will stay on the prior runtime version until either this token is set or each template is rebuilt manually."
+              exit 0
+            fi
+            echo "::error::TEMPLATE_DISPATCH_TOKEN secret missing — cascade cannot fan out."
+            echo "::error::PyPI was published, but the 8 template repos will NOT pick up the new version until this token is restored and a republish dispatches the cascade."
+            echo "::error::set it at Settings → Secrets and Variables → Actions; then re-trigger publish-runtime via workflow_dispatch."
+            exit 1
           fi
           VERSION="$RUNTIME_VERSION"
           if [ -z "$VERSION" ]; then


### PR DESCRIPTION
## Summary

- Mirror the sweep-cf-orphans hardening (#2248) on publish-runtime's `TEMPLATE_DISPATCH_TOKEN` gate.
- Push trigger → hard-fail. workflow_dispatch keeps soft-skip for operator override.
- Replaces the misleading "templates will pick up the new version on their own next rebuild" message — they won't; templates only build on this dispatch.

## Why

The previous behaviour silently exits 0 when the token is missing, with a warning claiming templates will catch up. That's wrong: the 8 workspace-template repos only rebuild on this `repository_dispatch` fanout. Without the dispatch they stay pinned to whatever runtime version they last saw. Same class of bug as the CF orphan leak fixed in #2248 — silent green run masks a real "PyPI current, templates not" gap that's invisible until someone audits manually.

## Behaviour matrix

| Trigger | Token present | Token missing |
|---|---|---|
| `push` (workspace/runtime/** changes) | cascade fans out | exit 1 with 3 `::error::` lines |
| `workflow_dispatch` | cascade fans out | exit 0 with `::warning::`, operator can rerun |

The error message now also names the operational consequence concretely so future operators see the actionable line.

## Test plan

- [x] `python3 -c 'import yaml; yaml.safe_load(open(...))'` parses clean
- [x] Existing cascade fan-out logic untouched (only the secret-missing branch changed)
- [ ] Next runtime publish (push trigger) succeeds with token present — same behaviour as today
- [ ] If a future rotation drops the secret, the next push will fail loudly within one CI run instead of silently skipping for an unknown duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)