### PR TITLE
feat(harness): coordinator phase-boundary instrumentation for RFC #2251

### DIFF
--- a/workspace/builtin_tools/delegation.py
+++ b/workspace/builtin_tools/delegation.py
@@ -515,4 +515,14 @@ async def check_task_status(
     elif delegation.status == DelegationStatus.FAILED:
         result["error"] = delegation.error
 
+    # RFC #2251 V1.0 reproduction-harness instrumentation. Every poll of
+    # check_task_status emits a phase=check_status line so the harness
+    # operator can tell whether a coordinator stuck for 8 minutes was
+    # polling-children-the-whole-time vs synthesizing-after-children-done.
+    # `grep rfc2251_phase=check_status` in the workspace's container log
+    # gives the polling pattern. Strip when V1.0 ships.
+    logger.info(
+        "rfc2251_phase=check_status task_id=%s peer=%s status=%s",
+        task_id, delegation.workspace_id, delegation.status.value,
+    )
     return result

--- a/workspace/coordinator.py
+++ b/workspace/coordinator.py
@@ -120,23 +120,56 @@ async def route_task_to_team(
         task: The task description to route.
         preferred_member_id: Optional — directly delegate to this member.
     """
+    import time
     from builtin_tools.delegation import delegate_task_async as delegate
 
+    # RFC #2251 V1.0 reproduction-harness instrumentation. Phase-tagged log
+    # lines correlate with scripts/measure-coordinator-task-bounds.sh's
+    # external timing trace, so an operator running the harness against
+    # staging can answer "what phase was the coordinator in at minute 7?".
+    # `grep rfc2251_phase` on the workspace's container logs is the query.
+    # Strip when V1.0 ships and the phase data lands in the structured
+    # heartbeat payload instead.
+    _phase_t0 = time.monotonic()
+    logger.info(
+        "rfc2251_phase=route_start task_chars=%d preferred_member_id=%s",
+        len(task), preferred_member_id or "none",
+    )
+
     children = await get_children()
+    logger.info(
+        "rfc2251_phase=children_fetched count=%d elapsed_ms=%d",
+        len(children), int((time.monotonic() - _phase_t0) * 1000),
+    )
+
     decision = build_team_routing_payload(
         children,
         task=task,
         preferred_member_id=preferred_member_id,
     )
+    logger.info(
+        "rfc2251_phase=routing_decided action=%s elapsed_ms=%d",
+        decision.get("action", "unknown"), int((time.monotonic() - _phase_t0) * 1000),
+    )
 
     if decision.get("action") == "delegate_to_preferred_member":
         # Async delegation — returns immediately with task_id
+        target = decision["preferred_member_id"]
+        logger.info(
+            "rfc2251_phase=delegate_invoked target=%s elapsed_ms=%d",
+            target, int((time.monotonic() - _phase_t0) * 1000),
+        )
         result = await delegate.ainvoke(
-            {
-                "workspace_id": decision["preferred_member_id"],
-                "task": task,
-            }
+            {"workspace_id": target, "task": task}
+        )
+        logger.info(
+            "rfc2251_phase=delegate_returned target=%s task_id=%s elapsed_ms=%d",
+            target, result.get("task_id", "n/a"), int((time.monotonic() - _phase_t0) * 1000),
         )
         return result
 
+    logger.info(
+        "rfc2251_phase=route_returning_decision_only elapsed_ms=%d",
+        int((time.monotonic() - _phase_t0) * 1000),
+    )
     return decision


### PR DESCRIPTION
## Summary

Pre-V1.0 gate #2 of the RFC at #2251 — the in-process companion to the existing \`scripts/measure-coordinator-task-bounds.sh\` external harness. Adds structured \`rfc2251_phase=...\` log lines at deterministic phase boundaries inside \`route_task_to_team\` and \`check_task_status\` so the harness operator can answer **"the coordinator response took 7 minutes — was it stuck delegating, polling children, or synthesizing?"** by greping the workspace container log.

## What's instrumented

Every phase boundary emits one log line with the phase name + elapsed_ms-from-route_start. Phases:

| Phase | Where | What it tells you |
|---|---|---|
| \`route_start\` | enter route_task_to_team | task arrived |
| \`children_fetched\` | after get_children() returns | platform discovery latency |
| \`routing_decided\` | after build_team_routing_payload | routing cost (CPU only, no I/O) |
| \`delegate_invoked\` | just before delegate_task_async.ainvoke | A2A send latency starts |
| \`delegate_returned\` | after delegate_task_async returns | A2A send latency ends |
| \`check_status\` | every check_task_status poll | one line per poll — polling cadence + last status seen |
| \`route_returning_decision_only\` | fall-through | non-delegation path |

The **synthesis phase** (between last \`check_status: completed\` and the final A2A response) is NOT instrumented here because it's agent-driven (no deterministic Python boundary). Operators infer:
\`\`\`
synthesis_secs = total_a2a_response_secs − max(check_status timestamp)
\`\`\`

## Why no enforcement

This is reproduction-harness scaffolding. **Adds zero behavior**. The \`logger.info\` calls flow into the existing workspace log stream — no new infrastructure, no per-task DB writes, no metric emission yet. When V1.0 ships and per-task phase data lands in the structured heartbeat payload, these lines get stripped (commit message documents this for the future cleanup).

## Tests

- \`pytest workspace/tests/test_coordinator_routing.py\` — 27 pass
- \`pytest workspace/tests/test_delegation.py\` — pass
- Full workspace suite: 1232 pass, 2 xfailed (pre-existing)

## How operators use it

After this PR merges + a redeploy of any coordinator workspace:

1. Run \`bash scripts/measure-coordinator-task-bounds.sh\` (already in staging) — kicks off a synthesis-heavy task against a real coordinator.
2. While it runs, tail the coordinator workspace's container log:
   \`\`\`
   railway logs --service controlplane | grep "rfc2251_phase="
   \`\`\`
3. Compute per-phase deltas from the elapsed_ms field. The phase the coordinator was last seen in before the harness's external timeout fires = the answer to "is Issue 4 a synthesis bug or a delegation bug?"

## Refs

- RFC: #2251
- Harness: \`scripts/measure-coordinator-task-bounds.sh\` (shipped earlier)
- V1.0 gate: this is deliverable #2 of the four pre-V1.0 gates listed in the RFC
- The other three gates (Issue 4 reproduction RUN, p99 measurement, per-adapter cancellation matrix) remain blocked on staging access / production data / adapter team time

🤖 Generated with [Claude Code](https://claude.com/claude-code)