### PR TITLE
fix(harness): cleanup_failed event + drop misleading exit_code capture

### DIFF
--- a/scripts/measure-coordinator-task-bounds.sh
+++ b/scripts/measure-coordinator-task-bounds.sh
@@ -153,18 +153,31 @@ PM_ID=""
 CHILD_ID=""
 
 cleanup() {
-  local exit_code=$?
+  # `trap` ignores function return values, so don't capture/return $?
+  # — that would only mislead a future reader. Disable -e inside cleanup
+  # so a single curl failure doesn't abort the loop and leave the other
+  # workspace orphaned.
   set +e
   if [ "$KEEP_WORKSPACES" = "1" ]; then
     emit "cleanup_skipped" "{\"reason\":\"KEEP_WORKSPACES=1\",\"pm_id\":\"$PM_ID\",\"child_id\":\"$CHILD_ID\"}"
-    return $exit_code
+    return
   fi
   for id in "$CHILD_ID" "$PM_ID"; do
     [ -z "$id" ] && continue
-    api -X DELETE "$PLATFORM/workspaces/$id" >/dev/null 2>&1
-    emit "cleanup_deleted" "{\"workspace_id\":\"$id\"}"
+    # Capture HTTP status separately from response body so a 401/403/5xx
+    # surfaces as a `cleanup_failed` event instead of a silent leak. The
+    # operator can then re-run cleanup-rogue-workspaces.sh with fresh
+    # credentials. ADMIN_TOKEN expiry mid-run is the realistic failure
+    # mode here; without this we'd swallow it under `>/dev/null 2>&1`.
+    code=$(api -o /dev/null -w '%{http_code}' -X DELETE "$PLATFORM/workspaces/$id" 2>/dev/null || echo "curl_err")
+    if [ "$code" = "200" ] || [ "$code" = "204" ] || [ "$code" = "404" ]; then
+      # 404 = already gone (race with a concurrent operator). Treat as
+      # success since the post-condition (workspace absent) holds.
+      emit "cleanup_deleted" "{\"workspace_id\":\"$id\",\"http_code\":\"$code\"}"
+    else
+      emit "cleanup_failed" "{\"workspace_id\":\"$id\",\"http_code\":\"$code\",\"hint\":\"workspace may be leaked — re-run cleanup-rogue-workspaces.sh\"}"
+    fi
   done
-  return $exit_code
 }
 trap cleanup EXIT INT TERM
 


### PR DESCRIPTION
## Summary

Two self-review fixes on top of #2257 (harness hardening, just merged):

### 1. Drop misleading `local exit_code=$?` from `cleanup()`

`trap`-handler return values are ignored by bash, so capturing `$?` and returning it only misled a future reader into thinking exit-code preservation was happening. Removed the capture and the `return $exit_code` lines.

### 2. Surface cleanup failures as a structured event

The previous `api -X DELETE ... >/dev/null 2>&1` swallowed every failure mode — including the realistic one (ADMIN_TOKEN expiring mid-run). When that happens, the workspace is leaked and there is no signal in the JSON event log.

Replaced with an `-w '%{http_code}'` capture:
- `200` / `204` → `cleanup_deleted` event with the HTTP code
- `404` → `cleanup_deleted` (post-condition holds — workspace absent — possibly a concurrent operator)
- anything else → `cleanup_failed` event with a remediation hint pointing at `cleanup-rogue-workspaces.sh`

## Test plan

- [x] `bash -n` passes
- [x] `DRY_RUN=1` exits cleanly (cleanup runs but emits `cleanup_skipped` because IDs are still empty)
- [x] No behaviour change on the success path; only failure-path observability improves

Refs: #2257 review.