### PR TITLE
chore(gitattributes): pin LF on snapshot golden files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,11 @@ workspace/entrypoint.sh text eol=lf
 # but keep LF for consistency across platforms.
 Dockerfile text eol=lf
 *.dockerfile text eol=lf
+
+# Snapshot golden files — workspace/tests/snapshots/*.txt is consumed by
+# byte-exact comparisons in test_platform_tools.py. A Windows contributor
+# with auto-CRLF=true would otherwise convert \n → \r\n on checkout, the
+# snapshot tests would fail mysteriously locally / pass in CI (or vice
+# versa), and the regen instructions in the test-file header would
+# produce LF files that disagree with the working-copy CRLF versions.
+workspace/tests/snapshots/*.txt text eol=lf


### PR DESCRIPTION
## Summary

Self-review follow-up on #2258 (just merged).

The byte-exact snapshot comparisons in `test_platform_tools.py` would fail mysteriously on a Windows contributor's machine with `core.autocrlf=true` — checkout would convert LF → CRLF, the test would fail locally with no useful diagnostic, and the regen instructions in the test-file header would produce LF files that disagree with the working-copy CRLF versions.

Pin `workspace/tests/snapshots/*.txt` to `text eol=lf` so this can't happen. All three current snapshots are already LF (verified with `file`); the attribute ensures it stays that way.

## Test plan

- [x] `file workspace/tests/snapshots/*.txt` confirms all three are ASCII/UTF-8 text (LF)
- [x] `.gitattributes` matches the pattern style used for other LF-pinned files in this repo (`*.sh`, `*.py`, `Dockerfile`)

Refs: #2258 review.