### PR TITLE
fix(restart): clear running flag on panic in cycle()

### DIFF
--- a/workspace-server/internal/handlers/workspace_restart.go
+++ b/workspace-server/internal/handlers/workspace_restart.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"time"
@@ -352,6 +353,27 @@ func coalesceRestart(workspaceID string, cycle func()) {
 	state.running = true
 	state.mu.Unlock()
 
+	// Always clear running on exit — including panic — so a panicking
+	// cycle (e.g. a future provisionWorkspace nil-deref) doesn't leave
+	// the workspace permanently locked out of restarts.
+	//
+	// recover()-and-DON'T-re-raise on purpose: this runs in a goroutine
+	// (callers are `go h.RestartByID(...)`); an unrecovered panic in a
+	// goroutine crashes the whole platform process, taking down every
+	// workspace served by this binary because of one bug in cycle for
+	// one workspace. Log the panic with stack trace for debuggability,
+	// then recover and let the goroutine exit cleanly. The next restart
+	// request for this workspace will see running=false and proceed.
+	defer func() {
+		state.mu.Lock()
+		state.running = false
+		state.mu.Unlock()
+		if r := recover(); r != nil {
+			log.Printf("Auto-restart: %s — cycle panicked, restart-state cleared: %v\n%s",
+				workspaceID, r, debug.Stack())
+		}
+	}()
+
 	// Drain pending requests. Each iteration re-loads workspace_secrets
 	// inside provisionWorkspace, so any writes that committed since the
 	// last cycle are picked up. Continues until no pending request was
@@ -359,9 +381,8 @@ func coalesceRestart(workspaceID string, cycle func()) {
 	for {
 		state.mu.Lock()
 		if !state.pending {
-			state.running = false
 			state.mu.Unlock()
-			return
+			return // defer clears running
 		}
 		state.pending = false
 		state.mu.Unlock()

--- a/workspace-server/internal/handlers/workspace_restart_coalesce_test.go
+++ b/workspace-server/internal/handlers/workspace_restart_coalesce_test.go
@@ -183,6 +183,43 @@ func TestCoalesceRestart_StateClearedAfterDrain(t *testing.T) {
 	}
 }
 
+// TestCoalesceRestart_PanicInCycleClearsState defends against a
+// regression of the sticky-running deadlock: if cycle() panics, the
+// running flag MUST be cleared so a follow-up RestartByID for the
+// same workspace can still acquire the gate. Without the deferred
+// state-clear + recover, a single panic would permanently lock a
+// workspace out of all future restarts until process restart.
+//
+// Also asserts the panic is RECOVERED (not re-raised): callers are
+// `go h.RestartByID(...)` from HTTP handlers, and an unrecovered
+// goroutine panic in Go takes down the whole process. Crashing the
+// platform for every tenant because one workspace's cycle panicked
+// is the wrong availability tradeoff. The panic message + stack
+// trace are still logged for debuggability.
+func TestCoalesceRestart_PanicInCycleClearsState(t *testing.T) {
+	const wsID = "test-coalesce-panic-recovery"
+	resetRestartStatesFor(wsID)
+
+	// First call's cycle panics. coalesceRestart's defer must swallow
+	// the panic so this test caller doesn't see it propagate up — that
+	// matches what the real production caller (`go h.RestartByID(...)`)
+	// gets: the goroutine survives, no process crash.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("panic should NOT propagate out of coalesceRestart (would crash the platform process from a goroutine), got: %v", r)
+		}
+	}()
+	coalesceRestart(wsID, func() { panic("simulated cycle failure") })
+
+	// Second call must run a fresh cycle. If running stayed true after
+	// the panic, this call would early-return without invoking cycle.
+	var ran atomic.Bool
+	coalesceRestart(wsID, func() { ran.Store(true) })
+	if !ran.Load() {
+		t.Error("post-panic restart was blocked — running flag leaked, workspace permanently locked out")
+	}
+}
+
 // TestCoalesceRestart_DifferentWorkspacesDoNotSerialize verifies the
 // per-workspace state map: an in-flight restart for ws A must not
 // block restarts for ws B. Important for performance — without this,


### PR DESCRIPTION
## Summary

Follow-up to #2266. Self-review caught a regression I introduced in #2266: if `cycle()` panics, the loop never reaches `state.running = false`. The flag stays true forever, the early-return guard at the top of `coalesceRestart` fires for every subsequent call, and that workspace is permanently locked out of restarts until process restart.

## Fix

Defer the state-clear so it always runs on exit, including panic. Recover (and **don't** re-raise) so the panic doesn't propagate to the goroutine boundary and crash the platform process — `RestartByID` is always called via \`go h.RestartByID(...)\` from HTTP handlers, and an unrecovered goroutine panic in Go terminates the program. Crashing the platform for every tenant because one workspace's cycle panicked is the wrong availability tradeoff. The panic message + full stack trace via \`runtime/debug.Stack()\` are still logged for debuggability.

```go
defer func() {
    state.mu.Lock()
    state.running = false
    state.mu.Unlock()
    if r := recover(); r != nil {
        log.Printf("Auto-restart: %s — cycle panicked, restart-state cleared: %v\n%s",
            workspaceID, r, debug.Stack())
    }
}()
```

## Test plan

`TestCoalesceRestart_PanicInCycleClearsState`:

1. First call's cycle panics. \`coalesceRestart\`'s defer must swallow the panic — assert no panic propagates out (would crash the platform process from a goroutine in production).
2. Second call must run a fresh cycle (proves running was cleared).

All 7 tests pass with \`-race -count=10\`.

## Self-review history

- Initial commit (now landed via #2266): pending-flag coalescing, no panic guard.
- Self-review caught: panic in cycle leaves running=true forever → workspace permanently locked out.
- First panic-recovery attempt (in this branch's draft): re-raised the panic after recover, arguing "silent recovery would mask real bugs."
- Second self-review caught: re-raise crashes the whole platform process because the caller is a goroutine. Switched to log-with-stack-and-suppress.

This is the surfaced-correctly version.

## Linked

- #2266 (the original coalescing fix this is tightening)
- molecule-core#2256 (the original RFC #2251 V1.0 measurement context)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>