### PR TITLE
fix: resolve git/gh from PATH instead of hardcoded /usr/local/bin (closes #2289)

### DIFF
--- a/workspace/executor_helpers.py
+++ b/workspace/executor_helpers.py
@@ -26,6 +26,7 @@ import logging
 import mimetypes
 import os
 import re
+import shutil
 import subprocess
 import uuid as _uuid
 from pathlib import Path
@@ -513,9 +514,16 @@ def sanitize_agent_error(
 # Auto-push hook — push unpushed commits and open PR after task completion
 # ========================================================================
 
-# Git/gh wrappers at /usr/local/bin have GH_TOKEN baked in.
-_GIT = "/usr/local/bin/git"
-_GH = "/usr/local/bin/gh"
+# Resolve git/gh from PATH so the runtime works regardless of which
+# image the workspace is on. Some templates ship a /usr/local/bin/{git,gh}
+# wrapper with GH_TOKEN baked in (preferred — picks up auth automatically);
+# other templates have plain /usr/bin/git installed by apt. Hardcoding
+# /usr/local/bin/git crashed every auto-push attempt on the latter image
+# class with `FileNotFoundError: '/usr/local/bin/git'` (issue #2289).
+# `shutil.which` finds the wrapper first if it's earlier in PATH, so the
+# GH_TOKEN injection still wins where it exists.
+_GIT = shutil.which("git") or "/usr/bin/git"
+_GH = shutil.which("gh") or "/usr/bin/gh"
 _PROTECTED_BRANCHES = frozenset({"staging", "main", "master"})
 
 


### PR DESCRIPTION
## Summary

Closes #2289. \`workspace/executor_helpers.py\` hardcoded \`_GIT = \"/usr/local/bin/git\"\`. The current claude-code template image has git at \`/usr/bin/git\` with no wrapper at \`/usr/local/bin/\`, so every auto-push attempt crashed with \`FileNotFoundError\`.

## Fix

\`shutil.which(\"git\")\` walks PATH in order:
- Wrapper-equipped images (where \`/usr/local/bin/git\` exists with GH_TOKEN baked in) → resolve to the wrapper, **GH_TOKEN injection preserved**.
- Bare-apt images → resolve to \`/usr/bin/git\`, **auto-push no longer crashes**.

\`gh\` gets the same treatment for symmetry.

## Test plan

- [x] \`python -m py_compile\` clean.
- [x] Verified \`shutil.which(\"git\")\` returns a real path on dev (\`/usr/bin/git\`).
- [ ] End-to-end (post-cascade): auto-push from a claude-code workspace lands the commit on staging without FileNotFoundError.

## Linked

- Issue #2289 (filed by team this session).
- Related: #2277 (template repo drift) — once the canonical Dockerfile lint exists, the missing \`/usr/local/bin/git\` wrapper would have been caught at template-image build time.

🤖 Auto-resolved by the molecule-core issue cron (job 6cb95f70). Per the cron's auto-resolve criteria: small scope, single file, no schema/auth/security implications, behavior is strictly additive.