### PR TITLE
docs(scripts): rename /heartbeat-history → /activity in README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,7 +9,7 @@ There are three related scripts; pick the right one:
 
 | Script | Purpose | Targets |
 |---|---|---|
-| `measure-coordinator-task-bounds.sh` | **Canonical** v1 harness for the RFC #2251 / Issue 4 reproduction. Provisions a PM coordinator + Researcher child via `claude-code-default` + `langgraph` templates, sends a synthesis-heavy A2A kickoff, observes elapsed time + heartbeat trace. | OSS-shape platform — localhost or any `/workspaces`-shaped endpoint. Has tenant/admin-token guards for non-localhost runs. |
+| `measure-coordinator-task-bounds.sh` | **Canonical** v1 harness for the RFC #2251 / Issue 4 reproduction. Provisions a PM coordinator + Researcher child via `claude-code-default` + `langgraph` templates, sends a synthesis-heavy A2A kickoff, observes elapsed time + activity trace. | OSS-shape platform — localhost or any `/workspaces`-shaped endpoint. Has tenant/admin-token guards for non-localhost runs. |
 | `measure-coordinator-task-bounds-runner.sh` | Generalised runner for the same measurement contract but with **arbitrary template + secret + model combinations** (Hermes/MiniMax, etc.). Useful for cross-runtime variants without modifying the canonical harness. | Same as above (local or SaaS via `MODE=saas`). |
 | `measure-coordinator-task-bounds.sh` (in [molecule-controlplane](https://github.com/Molecule-AI/molecule-controlplane)) | **Production-shape** variant that bootstraps a real staging tenant via `POST /cp/admin/orgs`, then runs the same measurement against `<slug>.staging.moleculesai.app`. | Staging controlplane only — refuses to run against production. |
 
@@ -29,12 +29,14 @@ and the cross-repo design rationale.
   hints; no silenced curl. ADMIN_TOKEN expiring mid-run surfaces as a
   structured event rather than a silent leak.
 
-### Heartbeat trace caveat
+### Activity trace caveat
 
-If `heartbeat_trace.raw == "<endpoint_unavailable>"`, the per-workspace
-`/heartbeat-history` endpoint isn't wired on the target build — the
-bound measurement is INCONCLUSIVE on the platform-ceiling question.
-Either wire the endpoint or replace with the equivalent Datadog query.
+If `activity_trace.raw == "<endpoint_unavailable>"`, the per-workspace
+`/activity` endpoint isn't wired on the target build — the bound
+measurement is INCONCLUSIVE on the platform-ceiling question. Either
+wire the endpoint or replace with the equivalent Datadog query. Note
+that `/activity` accepts a `since_secs` query parameter; see the
+endpoint handler for the supported range.
 
 ## Other scripts
 


### PR DESCRIPTION
## Summary
- Updates scripts/README.md to match the rename in #2265 (`/workspaces/:id/heartbeat-history` → `/workspaces/:id/activity`, event `heartbeat_trace` → `activity_trace`)
- Adds a brief note about `since_secs` query parameter

## Test plan
- [x] `grep -nE 'heartbeat' scripts/README.md` returns nothing
- [x] CI green

Closes #2270

🤖 Generated with [Claude Code](https://claude.com/claude-code)