### PR TITLE
fix(workspace_crud) + feat(activity): restartStates leak (#2269) + since_secs param (#2268)

### DIFF
--- a/workspace-server/internal/handlers/activity.go
+++ b/workspace-server/internal/handlers/activity.go
@@ -23,12 +23,22 @@ func NewActivityHandler(b *events.Broadcaster) *ActivityHandler {
 	return &ActivityHandler{broadcaster: b}
 }
 
-// List handles GET /workspaces/:id/activity?type=&limit=
+// List handles GET /workspaces/:id/activity?type=&source=&limit=&since_secs=
+//
+// since_secs filters to activity_logs.created_at >= NOW() - INTERVAL '$N seconds'.
+// Optional, additive — callers that don't pass it get today's behavior (the
+// most-recent N events regardless of time). The harness runner
+// (scripts/measure-coordinator-task-bounds-runner.sh) uses this to scope a
+// trace to a specific test window; RFC #2251 §V1.0 step 6 also depends on it.
+// Capped at 30 days (2_592_000s) — anything older has typically been paged
+// out anyway, and a defensive ceiling keeps a paranoid client from triggering
+// a full-table scan via since_secs=99999999999. Closes #2268.
 func (h *ActivityHandler) List(c *gin.Context) {
 	workspaceID := c.Param("id")
 	activityType := c.Query("type")
 	source := c.Query("source") // "canvas" = source_id IS NULL, "agent" = source_id IS NOT NULL
 	limitStr := c.DefaultQuery("limit", "100")
+	sinceSecsStr := c.Query("since_secs")
 
 	limit := 100
 	if n, err := strconv.Atoi(limitStr); err == nil && n > 0 {
@@ -36,6 +46,23 @@ func (h *ActivityHandler) List(c *gin.Context) {
 		if limit > 500 {
 			limit = 500
 		}
+	}
+
+	// Parse since_secs. Reject negative or non-integer values rather than
+	// silently ignoring them — a typoed param shouldn't be lost as
+	// most-recent-100, that's exactly the bug this fixes.
+	var sinceSecs int
+	if sinceSecsStr != "" {
+		n, err := strconv.Atoi(sinceSecsStr)
+		if err != nil || n <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "since_secs must be a positive integer"})
+			return
+		}
+		const maxSinceSecs = 30 * 24 * 60 * 60 // 30 days
+		if n > maxSinceSecs {
+			n = maxSinceSecs
+		}
+		sinceSecs = n
 	}
 
 	// Build query with optional filters
@@ -57,6 +84,15 @@ func (h *ActivityHandler) List(c *gin.Context) {
 	} else if source != "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "source must be 'canvas' or 'agent'"})
 		return
+	}
+	if sinceSecs > 0 {
+		// Use a parameterized interval so the value is bound, not
+		// interpolated into the SQL string. `make_interval(secs => $N)`
+		// avoids the lib/pq quirk where INTERVAL '$N seconds' won't
+		// substitute a placeholder inside the literal.
+		query += fmt.Sprintf(" AND created_at >= NOW() - make_interval(secs => $%d)", argIdx)
+		args = append(args, sinceSecs)
+		argIdx++
 	}
 
 	query += fmt.Sprintf(" ORDER BY created_at DESC LIMIT $%d", argIdx)

--- a/workspace-server/internal/handlers/activity_since_secs_test.go
+++ b/workspace-server/internal/handlers/activity_since_secs_test.go
@@ -1,0 +1,163 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+)
+
+// Tests for the since_secs query parameter on GET /workspaces/:id/activity.
+// Closes #2268 — the harness runner was passing this param and it was
+// silently ignored, capping the trace at most-recent-100 events. The new
+// shape: parse since_secs, add a parameterised `created_at >= NOW() -
+// make_interval(secs => $N)` clause, cap at 30 days, reject invalid input
+// with 400.
+
+const activityCols = `id, workspace_id, activity_type, source_id, target_id, method, ` +
+	`summary, request_body, response_body, tool_trace, duration_ms, status, error_detail, created_at`
+
+func newActivityRows() *sqlmock.Rows {
+	cols := []string{
+		"id", "workspace_id", "activity_type", "source_id", "target_id", "method",
+		"summary", "request_body", "response_body", "tool_trace", "duration_ms", "status", "error_detail", "created_at",
+	}
+	return sqlmock.NewRows(cols).
+		AddRow("act-1", "ws-1", "a2a_send", nil, nil, nil,
+			"sent", nil, nil, nil, nil, "ok", nil,
+			time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC))
+}
+
+// TestActivityHandler_SinceSecs_Accepted verifies that a valid since_secs
+// query param adds the make_interval clause to the SQL with the parsed
+// value as a bound parameter — exactly what the runner needs to scope a
+// trace to a test window.
+func TestActivityHandler_SinceSecs_Accepted(t *testing.T) {
+	mock := setupTestDB(t)
+
+	mock.ExpectQuery("SELECT id, workspace_id, activity_type").
+		WithArgs("ws-1", 600, 100). // workspaceID, since_secs, limit
+		WillReturnRows(newActivityRows())
+
+	broadcaster := newTestBroadcaster()
+	handler := NewActivityHandler(broadcaster)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+	c.Request = httptest.NewRequest("GET", "/workspaces/ws-1/activity?since_secs=600", nil)
+
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestActivityHandler_SinceSecs_ClampedAt30Days verifies the defensive
+// ceiling so a paranoid client can't trigger a multi-month full-table
+// scan via since_secs=999999999.
+func TestActivityHandler_SinceSecs_ClampedAt30Days(t *testing.T) {
+	mock := setupTestDB(t)
+
+	const cap30Days = 30 * 24 * 60 * 60
+	mock.ExpectQuery("SELECT id, workspace_id, activity_type").
+		WithArgs("ws-1", cap30Days, 100).
+		WillReturnRows(newActivityRows())
+
+	broadcaster := newTestBroadcaster()
+	handler := NewActivityHandler(broadcaster)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+	c.Request = httptest.NewRequest("GET", "/workspaces/ws-1/activity?since_secs=999999999", nil)
+
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}
+
+// TestActivityHandler_SinceSecs_InvalidRejected covers the loud-fail path:
+// a typoed param (non-int, zero, negative) returns 400 instead of being
+// silently dropped — that's the bug this whole feature is fixing.
+func TestActivityHandler_SinceSecs_InvalidRejected(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+	}{
+		{"non-integer", "abc"},
+		{"zero", "0"},
+		{"negative", "-1"},
+		{"hex-prefix", "0x10"},
+		{"float", "60.5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// No DB call expected; bad input must be caught before the query.
+			setupTestDB(t)
+			broadcaster := newTestBroadcaster()
+			handler := NewActivityHandler(broadcaster)
+
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+			c.Request = httptest.NewRequest("GET",
+				"/workspaces/ws-1/activity?since_secs="+tc.val, nil)
+
+			handler.List(c)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for %q, got %d: %s", tc.val, w.Code, w.Body.String())
+			}
+			var resp map[string]string
+			_ = json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["error"] == "" {
+				t.Errorf("expected error message in response body for %q", tc.val)
+			}
+		})
+	}
+}
+
+// TestActivityHandler_SinceSecs_Omitted verifies backward compat — callers
+// that don't pass since_secs see the original behavior (no extra WHERE
+// clause, just workspace_id + limit).
+func TestActivityHandler_SinceSecs_Omitted(t *testing.T) {
+	mock := setupTestDB(t)
+
+	// Only workspace_id + limit; the query must NOT include the
+	// make_interval clause. sqlmock's WithArgs is strict on count, so a
+	// since_secs leak would surface as "expected 2 args, got 3".
+	mock.ExpectQuery("SELECT id, workspace_id, activity_type").
+		WithArgs("ws-1", 100).
+		WillReturnRows(newActivityRows())
+
+	broadcaster := newTestBroadcaster()
+	handler := NewActivityHandler(broadcaster)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Params = gin.Params{{Key: "id", Value: "ws-1"}}
+	c.Request = httptest.NewRequest("GET", "/workspaces/ws-1/activity", nil)
+
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet sqlmock expectations: %v", err)
+	}
+}

--- a/workspace-server/internal/handlers/workspace_crud.go
+++ b/workspace-server/internal/handlers/workspace_crud.go
@@ -441,6 +441,12 @@ func (h *WorkspaceHandler) Delete(c *gin.Context) {
 	for _, descID := range descendantIDs {
 		stopAndRemove(descID)
 		db.ClearWorkspaceKeys(cleanupCtx, descID)
+		// #2269: drop the per-workspace restartState entry so it
+		// doesn't accumulate across the platform's lifetime. The
+		// LoadOrStore that creates the entry (workspace_restart.go)
+		// has no companion remove path; without this Delete, every
+		// short-lived workspace leaks ~16 bytes forever.
+		restartStates.Delete(descID)
 		// Detach broadcaster ctx for the same reason as the cleanup
 		// above — RecordAndBroadcast does an INSERT INTO
 		// structure_events + Redis Publish. If the canvas hangs up,
@@ -453,6 +459,7 @@ func (h *WorkspaceHandler) Delete(c *gin.Context) {
 
 	stopAndRemove(id)
 	db.ClearWorkspaceKeys(cleanupCtx, id)
+	restartStates.Delete(id) // #2269: same as descendants above
 
 	h.broadcaster.RecordAndBroadcast(cleanupCtx, "WORKSPACE_REMOVED", id, map[string]interface{}{
 		"cascade_deleted": len(descendantIDs),


### PR DESCRIPTION
Bundles two small, independent workspace-server fixes that surfaced from PR #2266 and #2265 reviews.

## Commits

### `fix(workspace_crud): drop restartStates entries on workspace delete (#2269)`
Pre-existing leak in the per-workspace `sync.Map`. ~16 bytes per workspace ever created, unbounded over process lifetime. Adds `restartStates.Delete(wsID)` after the existing per-ID cleanup loop in `WorkspaceHandler.Delete`. `sync.Map.Delete` is safe on absent keys.

### `feat(activity): accept ?since_secs= for time-window filtering (#2268)`
The harness runner was passing this param and getting silently ignored — most-recent-100 regardless of window. Adds parsing with parameterized SQL (`make_interval(secs => $N)`), 30-day cap, and 400 on invalid input. **Loud-fail on typo** is intentional: silent drop is the bug being fixed.

## Test plan
- [x] `go vet ./...` + `go build ./...` clean
- [x] Full handlers test suite green
- [x] 4 new tests cover since_secs (accepted / clamped-at-30d / invalid-rejected w/ 5 sub-cases / omitted)
- [ ] Manual: `curl /workspaces/<id>/activity?since_secs=600` against staging, verify only events from last 10 min returned

## Why bundled
Both are small, independent, surfaced from review. Splitting into two PRs would over-fragment for review and they share no code paths. Each commit is self-contained so reverting one doesn't touch the other.

Closes #2269
Closes #2268

🤖 Generated with [Claude Code](https://claude.com/claude-code)