### PR TITLE
docs(CONTRIBUTING): add 'What goes where' section for content routing (#2060)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,29 @@ cp .env.example .env
 
 See `CLAUDE.md` for a full list of environment variables and their purposes.
 
+## What goes where (content vs code)
+
+This repo is scoped to **code** (canvas, workspace, workspace-server, related
+infra). Public content (blog posts, marketing copy, OG images, SEO briefs,
+DevRel demos) lives in [`Molecule-AI/docs`](https://github.com/Molecule-AI/docs).
+The `Block forbidden paths` CI gate fails any PR that writes to `marketing/`
+or other removed paths — open against `Molecule-AI/docs` instead.
+
+| Content type | Target |
+|---|---|
+| Blog posts | `Molecule-AI/docs` → `content/blog/<YYYY-MM-DD-slug>/` |
+| Doc pages | `Molecule-AI/docs` → `content/docs/` |
+| Marketing copy / PMM positioning | `Molecule-AI/docs` → `marketing/` |
+| OG images, visual assets | `Molecule-AI/docs` → `app/` or `marketing/` |
+| SEO briefs | `Molecule-AI/docs` → `marketing/` |
+| DevRel demos (runnable code) | Standalone repo under `Molecule-AI/`, OR embedded in `Molecule-AI/docs` |
+| Launch checklists, internal tracking | GitHub Issues — **not** committed files |
+| Engineering docs (`docs/adr/`, `docs/architecture/`, `docs/incidents/`) | This repo (internal, not published) |
+| Live product pages (e.g. `canvas/src/app/pricing/page.tsx`) | This repo (these are app code, not marketing copy) |
+
+If a PR fails the `Block forbidden paths` check, the contents belong in
+`Molecule-AI/docs`. No CI drag, no Canvas E2E, content lands in minutes.
+
 ## Development Workflow
 
 ### Branch Naming


### PR DESCRIPTION
## Summary
Adds a prominent **What goes where** section to CONTRIBUTING.md documenting that public content (blog, marketing, OG images, SEO briefs, DevRel demos) belongs in `Molecule-AI/docs`, not molecule-core. Routing cheat-sheet table from #2060 included verbatim.

## Why
The `Block forbidden paths` CI gate already enforces the policy — but the rule is currently only discoverable by failing CI. This puts the routing in CONTRIBUTING.md so human + agent contributors learn before opening the wrong PR. Per #2060: 11 content PRs were silently blocked + closed over 48h.

## Test plan
- [x] CONTRIBUTING.md renders correctly (markdown table)
- [x] Section sits between Getting Started and Development Workflow — discoverable on first read
- [ ] Confirm `Block forbidden paths` CI continues to pass on this PR (the new content is under `CONTRIBUTING.md`, not `marketing/` — should be fine)

Closes #2060

🤖 Generated with [Claude Code](https://claude.com/claude-code)