### PR TITLE
ci(canvas): wire vitest --coverage into CI for baseline observability (#1815)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,8 +193,24 @@ jobs:
           node-version: '22'
       - run: rm -f package-lock.json && npm install
       - run: npm run build
-      - name: Run tests
-        run: npx vitest run
+      - name: Run tests with coverage
+        # Coverage instrumentation is configured in canvas/vitest.config.ts
+        # (provider: v8, reporters: text + html + json-summary). Step 2 of
+        # #1815 — wires coverage into CI so we get a baseline visible on
+        # every PR. No threshold gate yet; thresholds dial in (Step 3, also
+        # tracked in #1815) after the team sees what current coverage is.
+        # Per the inline comment in vitest.config.ts: "first land
+        # observability so we can see the baseline, then dial in
+        # thresholds + a hard gate" — this PR ships the observability half.
+        run: npx vitest run --coverage
+      - name: Upload coverage summary as artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: canvas-coverage-${{ github.run_id }}
+          path: canvas/coverage/
+          retention-days: 7
+          if-no-files-found: warn
 
   # MCP Server + SDK removed from CI — now in standalone repos:
   # - github.com/Molecule-AI/molecule-mcp-server (npm CI)


### PR DESCRIPTION
## Summary
Step 2 of #1815. Replaces `npx vitest run` with `npx vitest run --coverage` in the `canvas-build` job and uploads the coverage report (HTML + json-summary) as a 7-day artifact. No threshold gate yet — Step 3.

## Why staged
The inline comment in `canvas/vitest.config.ts` (already shipped under Step 1) explicitly defers thresholds because a blind 70% gate would either fail CI immediately or force an ad-hoc exclude list that papers over real gaps. This PR ships the observability so the team can see the baseline before dialing in thresholds.

## Test plan
- [x] `python3 -c 'import yaml; yaml.safe_load(open("..."))'` — yaml valid
- [ ] CI passes on this PR (vitest still runs the same 900 tests; coverage is additive)
- [ ] Coverage artifact appears under Actions → run → canvas-coverage-`<run_id>`
- [ ] No threshold failures (vitest.config.ts has none set)

## Follow-up
Step 3 (set thresholds + flip to a hard gate) becomes a fresh issue once baseline numbers are visible. Issue body proposed lines:70 / functions:70 / branches:65 / statements:70; the actual values may need adjustment.

Closes the Step-2 portion of #1815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)