### PR TITLE
fix(pre-commit): add go build gate for staged Go changes (#1770)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -95,7 +95,39 @@ if [ -n "$STAGED_GO" ]; then
 fi
 
 # ──────────────────────────────────────────────────────────
-# 5. Secrets: No tokens/keys in staged files
+# 5. Go: build check — catches bot-generated structurally-invalid Go (#1770)
+# ──────────────────────────────────────────────────────────
+#
+# Background: bot agents have produced syntactically-broken Go that the
+# patch tool happily applied (e.g. PR #1769 commit 66ea0b64 — function
+# declaration nested inside another function's body). Compilation failed,
+# staging Platform(Go) was red for hours. CI catches this AT PR-time but
+# by then the malformed commit is already shared.
+#
+# Pre-commit guard: when ANY .go file in workspace-server/ is staged, run
+# `go build ./...` from workspace-server. If it fails, reject the commit.
+# Cost: ~5-10s on a warm cache; acceptable for the class of bug it
+# catches. Skip when go isn't available (CI runners that need to bypass).
+
+if [ -n "$STAGED_GO" ]; then
+  if command -v go >/dev/null 2>&1; then
+    if ! (cd workspace-server && go build ./... >/tmp/precommit-go-build.log 2>&1); then
+      echo "❌ GO BUILD FAILED — staged Go changes don't compile (workspace-server/)."
+      echo "   Output:"
+      sed 's/^/     /' /tmp/precommit-go-build.log | head -20
+      echo "   Fix the build error before committing. See #1770 for context."
+      ERRORS=$((ERRORS + 1))
+    fi
+  else
+    # Bots and CI runners may bypass when go isn't installed — surface a
+    # warning so the absence is visible, but don't block. Humans hit this
+    # only if they didn't run setup.sh.
+    echo "⚠️  go not installed — skipping go-build pre-commit check (#1770)"
+  fi
+fi
+
+# ──────────────────────────────────────────────────────────
+# 6. Secrets: No tokens/keys in staged files
 # ──────────────────────────────────────────────────────────
 
 ALL_STAGED=$(git diff --cached --name-only --diff-filter=ACM || true)


### PR DESCRIPTION
## Summary
Adds a `go build ./...` check to `.githooks/pre-commit` that runs whenever a `.go` file in `workspace-server/` is staged. Rejects the commit if the build fails.

## Why
Per #1770: bot agents have produced syntactically-broken Go that the patch tool applied (PR #1769 nested a function declaration inside another function's body). Staging Platform(Go) was red for hours; every Go PR targeting staging during that window failed CI through no fault of its own.

This is the **pre-commit guard** half of the three guards proposed in #1770. Skip-with-warning when `go` isn't installed (so CI runners and bots without go bypass cleanly).

## Test plan
- [x] `bash -n .githooks/pre-commit` — shell syntax valid
- [x] `cd workspace-server && go build ./...` on current main — passes (no false positive)
- [ ] Manual: introduce a syntax error to a staged Go file, attempt commit, confirm rejection
- [ ] Manual: verify cost on a warm cache (~5-10s expected)

## What this PR does NOT do
- **Branch-protection: make `Platform (Go)` a required check on staging** — admin action, needs your settings change. Currently the job runs but isn't required, so a Lead override could still merge a red PR.
- **SHARED_RULES clarification** — process change, lives in some other doc/repo.

These are tracked in #1770 as separate guards; this PR closes only the pre-commit guard half. The issue stays open for the other two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)