### PR TITLE
ci: no-op shadow for Canvas (Next.js) required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,26 @@ jobs:
             exit 1
           fi
 
+  # Path-filter no-op shadow for Canvas (Next.js).
+  #
+  # Branch protection on staging requires a "Canvas (Next.js)" check.
+  # When a PR doesn't touch canvas/** paths, the real canvas-build job
+  # below is skipped via `if:`, and GitHub reports its conclusion as
+  # SKIPPED — which branch protection treats as not-passed → merge
+  # BLOCKED on every workspace-server-only or migration-only PR.
+  #
+  # Pattern (per durable feedback memory: branch_protection_check_name_parity):
+  # split into a real job + a no-op shadow that share the same `name:`.
+  # Exactly one runs per PR; both report the same check context, and at
+  # least one always reports SUCCESS, satisfying the required check.
+  canvas-build-noop:
+    name: Canvas (Next.js)
+    needs: changes
+    if: needs.changes.outputs.canvas != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No canvas/** changes in this PR — Canvas (Next.js) skip is intentional, satisfying required-check via this no-op."
+
   canvas-build:
     name: Canvas (Next.js)
     needs: changes


### PR DESCRIPTION
## Summary

Branch protection on \`staging\` requires \`Canvas (Next.js)\` to pass. The \`canvas-build\` job uses \`if: needs.changes.outputs.canvas == 'true'\`, so PRs that don't touch \`canvas/**\` skip it — GitHub reports SKIPPED, which branch protection treats as **not-passed → merge BLOCKED**.

This is the documented \`branch_protection_check_name_parity\` pattern: split into real-job + no-op shadow that share the same \`name:\`. Exactly one runs per PR; both report the same check context.

## Concrete blocker that surfaced this

PR #2314 (RFC #2312 PR-B) sat APPROVED + CI-green + up-to-date for half an hour with \`mergeStateStatus: BLOCKED\`. GraphQL trace via the \`isRequired\` field on each check found a single SKIPPED \`Canvas (Next.js)\` blocking. The rest of the RFC #2312 stack (PR-F #2319, etc.) would have hit the same wall.

## Changes

- \`.github/workflows/ci.yml\`: added \`canvas-build-noop\` job sharing \`name: Canvas (Next.js)\` with the real \`canvas-build\` job. Triggered when \`needs.changes.outputs.canvas != 'true'\` (the inverse of the real job's gate). Single \`echo\` step.

## Test plan

- [x] \`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))\"\` passes
- [x] No-op runs only when canvas paths unchanged; real job runs only when changed; mutually exclusive
- [ ] After merge: queue PR #2314 and confirm Canvas (Next.js) reports SUCCESS via the no-op path → BLOCKED clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)