### PR TITLE
fix(e2e-canvas): kill teardown race that poisons concurrent runs (unblocks staging→main #2264)

### DIFF
--- a/.github/workflows/e2e-staging-canvas.yml
+++ b/.github/workflows/e2e-staging-canvas.yml
@@ -153,43 +153,39 @@ jobs:
           path: canvas/test-results/
           retention-days: 14
 
-      # Safety-net teardown mirrors the bash-harness workflow — if
-      # globalTeardown didn't run (worker crash, runner cancel), this
-      # step sweeps any e2e-canvas-* org tagged with today's date.
+      # Safety-net teardown — fires only when Playwright's globalTeardown
+      # didn't (worker crash, runner cancel). Reads the slug from
+      # canvas/.playwright-staging-state.json (written by staging-setup
+      # as its first action, before any CP call) and deletes only that
+      # slug.
+      #
+      # Earlier versions of this step pattern-swept `e2e-canvas-<today>-*`
+      # orgs to compensate for setup-crash-before-state-file-write. That
+      # over-aggressive cleanup raced concurrent canvas-E2E runs and
+      # poisoned each other's tenants — observed 2026-04-30 when three
+      # real-test runs killed each other mid-test, surfacing as
+      # `getaddrinfo ENOTFOUND` once CP had cleaned up the just-deleted
+      # DNS record. Pattern-sweep removed; setup now writes the state
+      # file before any CP work, so the slug is always recoverable.
       - name: Teardown safety net
         if: always() && needs.detect-changes.outputs.canvas == 'true'
         env:
           ADMIN_TOKEN: ${{ secrets.MOLECULE_STAGING_ADMIN_TOKEN }}
         run: |
           set +e
-          # Midnight-UTC rollover guard: a single-date filter misses
-          # orgs created on the prior UTC day when the run crosses
-          # midnight (incident 2026-04-26 23:46Z → 2026-04-27 00:12Z:
-          # slug `e2e-canvas-20260426-1u8nz3` survived because the
-          # safety-net step ran on the 27th, computed `today=20260427`,
-          # and the filter `e2e-canvas-20260427-` never matched). Sweep
-          # both today AND yesterday's dates so a cross-midnight run
-          # still cleans up its own slug.
-          orgs=$(curl -sS "$MOLECULE_CP_URL/cp/admin/orgs" \
-            -H "Authorization: Bearer $ADMIN_TOKEN" 2>/dev/null \
-            | python3 -c "
-          import json, sys, datetime
-          d = json.load(sys.stdin)
-          today = datetime.date.today()
-          yesterday = today - datetime.timedelta(days=1)
-          prefixes = (
-              f'e2e-canvas-{today.strftime(\"%Y%m%d\")}-',
-              f'e2e-canvas-{yesterday.strftime(\"%Y%m%d\")}-',
-          )
-          candidates = [o['slug'] for o in d.get('orgs', [])
-                        if any(o.get('slug','').startswith(p) for p in prefixes)
-                        and o.get('status') not in ('purged',)]
-          print('\n'.join(candidates))
-          " 2>/dev/null)
-          for slug in $orgs; do
-            curl -sS -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
-              -H "Authorization: Bearer $ADMIN_TOKEN" \
-              -H "Content-Type: application/json" \
-              -d "{\"confirm\":\"$slug\"}" >/dev/null || true
-          done
+          STATE_FILE=".playwright-staging-state.json"
+          if [ ! -f "$STATE_FILE" ]; then
+            echo "::notice::No state file at canvas/$STATE_FILE — Playwright globalTeardown handled it (or setup never ran)."
+            exit 0
+          fi
+          slug=$(python3 -c "import json; print(json.load(open('$STATE_FILE')).get('slug',''))")
+          if [ -z "$slug" ]; then
+            echo "::warning::State file present but slug missing; nothing to clean up."
+            exit 0
+          fi
+          echo "Deleting orphan tenant: $slug"
+          curl -sS -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
+            -H "Authorization: Bearer $ADMIN_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"confirm\":\"$slug\"}" >/dev/null || true
           exit 0

--- a/canvas/e2e/staging-setup.ts
+++ b/canvas/e2e/staging-setup.ts
@@ -111,6 +111,20 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   const adminAuth = { Authorization: `Bearer ${ADMIN_TOKEN}` };
   console.log(`[staging-setup] Using slug=${slug}`);
 
+  // Write the state file FIRST, before any CP call. Teardown (both
+  // Playwright globalTeardown and the workflow safety-net) reads this
+  // file to identify the slug it must clean up. If we wait until the
+  // end of setup to write it (the previous behavior), a crash during
+  // any of steps 1-6 leaves the org orphaned in CP with no record on
+  // disk — forcing the workflow safety-net into a pattern-sweep over
+  // every `e2e-canvas-<date>-*` org, which races with concurrent
+  // canvas-E2E runs and deletes their live tenants. Race observed
+  // 2026-04-30 on PR #2264 staging→main: three real-test runs killed
+  // each other's tenants mid-test, surfacing as `getaddrinfo ENOTFOUND`
+  // when CP cleaned up the just-deleted DNS record.
+  const stateFile = join(process.cwd(), ".playwright-staging-state.json");
+  writeFileSync(stateFile, JSON.stringify({ slug }, null, 2));
+
   // 1. Create org via admin endpoint — no WorkOS session needed
   const create = await jsonFetch(`${CP_URL}/cp/admin/orgs`, {
     method: "POST",
@@ -245,8 +259,8 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
   );
   console.log(`[staging-setup] Workspace online`);
 
-  // 7. Hand state off to tests + teardown
-  const stateFile = join(process.cwd(), ".playwright-staging-state.json");
+  // 7. Hand state off to tests + teardown — overwrite the slug-only
+  // bootstrap state with the full state spec tests need.
   writeFileSync(
     stateFile,
     JSON.stringify({ slug, tenantURL, workspaceId, tenantToken }, null, 2),

--- a/canvas/e2e/staging-teardown.ts
+++ b/canvas/e2e/staging-teardown.ts
@@ -24,7 +24,11 @@ export default async function globalTeardown(): Promise<void> {
 
   const stateFile = join(process.cwd(), ".playwright-staging-state.json");
   if (!existsSync(stateFile)) {
-    console.warn("[staging-teardown] no state file — setup must have failed before org create; nothing to tear down");
+    // staging-setup writes this file as its first action, before any
+    // CP call. Missing here means setup never ran (CANVAS_E2E_STAGING
+    // unset, or ran in a different cwd) — there's no slug we created
+    // that needs cleaning up.
+    console.warn("[staging-teardown] no state file — nothing to tear down");
     return;
   }
 


### PR DESCRIPTION
## Summary

The canvas-E2E teardown safety net was pattern-sweeping every \`e2e-canvas-<today>-*\` org as compensation for setup-crash-before-state-file-write. That sweep raced concurrent canvas-E2E runs and deleted their live tenants mid-test — surfacing as \`getaddrinfo ENOTFOUND\` once CP cleaned up the just-deleted DNS record.

Fix: write the state file as setup's **first action**, before any CP call. Teardown always has the slug, so the workflow safety-net can read it and delete only that slug.

## Root cause

| When | Old behavior | New behavior |
|---|---|---|
| Crash before slug generation | No state file → safety-net pattern-sweeps everyone's tenants | No state file → safety-net no-ops (no orphan to clean) |
| Crash during steps 1-6 (org created, but workspace-online never resolved) | No state file → safety-net pattern-sweeps everyone's tenants | State file has slug → safety-net deletes only that slug |
| Setup completes successfully | State file has full state → globalTeardown deletes own slug | Same — state file just gets overwritten with full state at step 7 |

## Race observed

PR #2264 staging→main, 2026-04-30. Three real-test canvas-E2E runs killed each other mid-test. Timeline (each row = a peer's teardown nuking the row below it):

| Time | Run | Result | What killed it |
|---|---|---|---|
| 00:30:06 | PR (real, 12min) | ✓ — finishes ~00:42, runs teardown | — |
| 00:36:08 | push (real, 7.8min) | ✗ fail at **00:43:57** | 00:30 PR's teardown |
| 00:36:10 | PR (real, 20min) | ✓ — finishes ~00:56, runs teardown | — |
| 00:50:01 | push (real, 8.3min) | ✗ fail at **00:58:16** | 00:36 PR's teardown |
| 00:50:04 | PR (real, 21min) | ✓ — finishes ~01:11, runs teardown | — |
| 00:50:18 | PR rerun (real, 24min) | ✗ fail at **01:14:25** | 00:50:04 PR's teardown |

Every failure is within ~2 min of a peer's teardown firing. Not a CloudFlare DNS bug, not a sweep-cf-orphans bug — both verified clean.

## Files changed

- \`canvas/e2e/staging-setup.ts\`: write state file right after \`makeSlug()\`; promote to full state at step 7 (overwrite)
- \`canvas/e2e/staging-teardown.ts\`: comment update — missing state file genuinely means nothing to clean now
- \`.github/workflows/e2e-staging-canvas.yml\`: replace pattern-sweep with state-file lookup; delete only the recorded slug

## Test plan

- [ ] CI passes on this PR (path filter SHOULD trigger real run since canvas/e2e/ changed)
- [ ] After merge, verify PR #2264 staging→main can advance — Canvas tabs E2E should no longer self-poison
- [ ] Teardown still cleans up successfully on a normal happy-path run
- [ ] Teardown still cleans up the orphan when staging-setup crashes mid-flight (e.g., on a workspace-online timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)