### PR TITLE
feat(a2a): per-queue-id status endpoint + per-message TTL (RFC #2331 Tier 1)

### DIFF
--- a/workspace-server/internal/handlers/a2a_proxy_helpers.go
+++ b/workspace-server/internal/handlers/a2a_proxy_helpers.go
@@ -97,8 +97,16 @@ func (h *WorkspaceHandler) handleA2ADispatchError(ctx context.Context, workspace
 		}
 
 		idempotencyKey := extractIdempotencyKey(body)
+		// Honor params.expires_in_seconds when the caller specifies one. Zero
+		// (the unset default) → expiresAt = nil → infinite TTL preserved by
+		// DequeueNext. RFC #2331 Tier 1.
+		var expiresAt *time.Time
+		if secs := extractExpiresInSeconds(body); secs > 0 {
+			t := time.Now().Add(time.Duration(secs) * time.Second)
+			expiresAt = &t
+		}
 		if qid, depth, qerr := EnqueueA2A(
-			ctx, workspaceID, callerID, PriorityTask, body, a2aMethod, idempotencyKey,
+			ctx, workspaceID, callerID, PriorityTask, body, a2aMethod, idempotencyKey, expiresAt,
 		); qerr == nil {
 			log.Printf("ProxyA2A: target %s busy — enqueued as %s (depth=%d)", workspaceID, qid, depth)
 			respBody, _ := json.Marshal(gin.H{

--- a/workspace-server/internal/handlers/a2a_queue.go
+++ b/workspace-server/internal/handlers/a2a_queue.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
 )
@@ -37,6 +38,33 @@ func extractIdempotencyKey(body []byte) string {
 		return ""
 	}
 	return envelope.Params.Message.MessageID
+}
+
+// extractExpiresInSeconds pulls params.expires_in_seconds out of an A2A
+// JSON-RPC body and returns it as a positive integer. A zero return means
+// "no caller-specified TTL" — caller should leave expires_at NULL on the
+// queue row, preserving today's infinite-TTL behaviour (the
+// DropStaleQueueItems admin sweeper still drops entries past the
+// platform-default age). Negative values and parse errors collapse to 0.
+//
+// Why params-level (not metadata): expires_in_seconds is a delivery
+// directive, not a peer-to-peer message attribute. Putting it under
+// `params` keeps it adjacent to other delivery hints (priority,
+// idempotency) and out of `params.message.metadata` which the receiving
+// agent can read.
+func extractExpiresInSeconds(body []byte) int {
+	var envelope struct {
+		Params struct {
+			ExpiresInSeconds int `json:"expires_in_seconds"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return 0
+	}
+	if envelope.Params.ExpiresInSeconds < 0 {
+		return 0
+	}
+	return envelope.Params.ExpiresInSeconds
 }
 
 const (
@@ -70,6 +98,7 @@ func EnqueueA2A(
 	priority int,
 	body []byte,
 	method, idempotencyKey string,
+	expiresAt *time.Time,
 ) (id string, depth int, err error) {
 	var keyArg interface{}
 	if idempotencyKey != "" {
@@ -83,6 +112,13 @@ func EnqueueA2A(
 	if method != "" {
 		methodArg = method
 	}
+	// expiresAtArg stays NULL when caller didn't specify a TTL. DequeueNext's
+	// `expires_at IS NULL OR expires_at > now()` filter then preserves today's
+	// infinite-TTL semantics for un-flagged messages.
+	var expiresAtArg interface{}
+	if expiresAt != nil {
+		expiresAtArg = *expiresAt
+	}
 
 	// INSERT ... ON CONFLICT DO NOTHING RETURNING id. The conflict target
 	// must reference the partial unique INDEX columns + WHERE clause directly
@@ -91,13 +127,13 @@ func EnqueueA2A(
 	// then look up the existing row's id so the caller always receives a
 	// valid queue entry reference.
 	err = db.DB.QueryRowContext(ctx, `
-		INSERT INTO a2a_queue (workspace_id, caller_id, priority, body, method, idempotency_key)
-		VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+		INSERT INTO a2a_queue (workspace_id, caller_id, priority, body, method, idempotency_key, expires_at)
+		VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
 		ON CONFLICT (workspace_id, idempotency_key)
 			WHERE idempotency_key IS NOT NULL AND status IN ('queued','dispatched')
 			DO NOTHING
 		RETURNING id
-	`, workspaceID, callerArg, priority, string(body), methodArg, keyArg).Scan(&id)
+	`, workspaceID, callerArg, priority, string(body), methodArg, keyArg, expiresAtArg).Scan(&id)
 
 	if errors.Is(err, sql.ErrNoRows) && idempotencyKey != "" {
 		// Conflict — look up the existing active row and use its id.

--- a/workspace-server/internal/handlers/a2a_queue_status.go
+++ b/workspace-server/internal/handlers/a2a_queue_status.go
@@ -1,0 +1,231 @@
+package handlers
+
+// a2a_queue_status.go — RFC #2331 Tier 1: public per-queue-id status endpoint.
+//
+// Closes the gap surfaced in #2329 item 5: callers receive `queue_id` in
+// the 202 enqueue response but had no public lookup endpoint. The only
+// observability path was through `check_task_status` which joins via
+// `request_body->>'delegation_id'` in `activity_logs` — works only for
+// delegation-flavored A2A. Cross-workspace peer-direct A2A had no
+// observability after enqueue.
+//
+// Auth model:
+//
+//   - The caller's workspace token must match the `caller_id` recorded
+//     on the queue row at enqueue time, OR the caller's token must be
+//     for the target workspace_id (target can see what's queued for it),
+//     OR an org-level token (canvas/admin) can see anything.
+//
+//   - 404 — not 403 — when the caller has no read access. The queue_id
+//     UUID is the access token; revealing "this queue_id exists but
+//     you can't see it" leaks the existence-of-other-callers' state.
+//
+// What the response body excludes:
+//
+//   - `body` (the original JSON-RPC request body) — could contain
+//     prompts/PII the caller's authority shouldn't include in poll-loop
+//     responses. The body is only relevant to the dispatching agent.
+//   - `caller_id` — exposes the existence of other callers.
+//
+// What it includes:
+//
+//   - status, attempts, last_error, enqueued_at, dispatched_at,
+//     completed_at, expires_at, priority — the delivery state machine
+//     observables.
+//   - response_body when status == completed — so the caller can
+//     retrieve the response without polling check_task_status.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"log"
+	"net/http"
+
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/db"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/wsauth"
+	"github.com/gin-gonic/gin"
+)
+
+// QueueStatus is the public projection of an a2a_queue row.
+type QueueStatus struct {
+	ID           string  `json:"queue_id"`
+	WorkspaceID  string  `json:"workspace_id"`
+	Status       string  `json:"status"`
+	Priority     int     `json:"priority"`
+	Attempts     int     `json:"attempts"`
+	LastError    *string `json:"last_error,omitempty"`
+	EnqueuedAt   string  `json:"enqueued_at"`
+	DispatchedAt *string `json:"dispatched_at,omitempty"`
+	CompletedAt  *string `json:"completed_at,omitempty"`
+	ExpiresAt    *string `json:"expires_at,omitempty"`
+	ResponseBody []byte  `json:"response_body,omitempty"`
+}
+
+// QueueStatusByID looks up the queue row and projects it for the public
+// endpoint. Returns ErrNoQueueRow when the row doesn't exist OR the
+// caller has no read access — collapsing the two surfaces a single 404
+// from the handler so an attacker can't probe queue_id existence.
+//
+// Access rules — caller must satisfy at least one of:
+//
+//	(a) callerID == queue.caller_id        (sender can read own enqueue)
+//	(b) callerID == queue.workspace_id     (target can read queued-for-me)
+//	(c) isAdmin == true                    (canvas/admin token)
+//
+// Internal helper; the HTTP handler enforces the auth checks before
+// calling this — by the time we get here we already know the caller
+// is authorized, so this just runs the SELECT.
+func QueueStatusByID(ctx context.Context, queueID string) (*QueueStatus, error) {
+	var qs QueueStatus
+	var lastError, dispatchedAt, completedAt, expiresAt sql.NullString
+	var responseBody []byte
+
+	// response_body lives on activity_logs (the stitched delegation row), not
+	// on a2a_queue itself. We pull both here in one round-trip via LEFT JOIN
+	// so a completed delegation surfaces its result inline — non-delegation
+	// queue rows simply won't have a matching activity_logs row and the field
+	// stays null.
+	err := db.DB.QueryRowContext(ctx, `
+		SELECT
+			q.id,
+			q.workspace_id,
+			q.status,
+			q.priority,
+			q.attempts,
+			q.last_error,
+			q.enqueued_at::text,
+			q.dispatched_at::text,
+			q.completed_at::text,
+			q.expires_at::text,
+			al.response_body::text
+		FROM a2a_queue q
+		LEFT JOIN activity_logs al
+			ON al.method = 'delegate_result'
+			AND al.target_id = q.workspace_id
+			AND al.workspace_id = q.caller_id
+			AND al.response_body->>'delegation_id' = (q.body->'params'->'message'->'metadata'->>'delegation_id')
+		WHERE q.id = $1
+	`, queueID).Scan(
+		&qs.ID, &qs.WorkspaceID, &qs.Status, &qs.Priority, &qs.Attempts,
+		&lastError, &qs.EnqueuedAt, &dispatchedAt, &completedAt, &expiresAt,
+		&responseBody,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, sql.ErrNoRows
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if lastError.Valid && lastError.String != "" {
+		s := lastError.String
+		qs.LastError = &s
+	}
+	if dispatchedAt.Valid && dispatchedAt.String != "" {
+		s := dispatchedAt.String
+		qs.DispatchedAt = &s
+	}
+	if completedAt.Valid && completedAt.String != "" {
+		s := completedAt.String
+		qs.CompletedAt = &s
+	}
+	if expiresAt.Valid && expiresAt.String != "" {
+		s := expiresAt.String
+		qs.ExpiresAt = &s
+	}
+	if len(responseBody) > 0 && qs.Status == "completed" {
+		qs.ResponseBody = responseBody
+	}
+
+	return &qs, nil
+}
+
+// queueRowAuthFields returns the (caller_id, workspace_id) of the queue row
+// for access control. Separate from QueueStatusByID so the handler can do
+// the auth check without first projecting the public response.
+func queueRowAuthFields(ctx context.Context, queueID string) (callerID, workspaceID string, err error) {
+	var callerNS, workspaceNS sql.NullString
+	err = db.DB.QueryRowContext(ctx,
+		`SELECT caller_id, workspace_id FROM a2a_queue WHERE id = $1`,
+		queueID,
+	).Scan(&callerNS, &workspaceNS)
+	if err != nil {
+		return "", "", err
+	}
+	return callerNS.String, workspaceNS.String, nil
+}
+
+// GetA2AQueueStatus handles GET /workspaces/:id/a2a/queue/:queue_id.
+//
+// The :id path param is the workspace context (matches the proxy pattern
+// /workspaces/:id/a2a). :queue_id is the row's UUID returned from the
+// 202 enqueue response.
+//
+// Auth flow:
+//
+//  1. Extract caller's workspace from bearer (org tokens grant org-wide
+//     access and short-circuit the per-row check).
+//  2. Look up queue row's (caller_id, workspace_id).
+//  3. Allow when caller's workspace == queue.caller_id OR
+//     == queue.workspace_id, OR caller has org-level access.
+//  4. Otherwise 404 (not 403) — see file-header rationale.
+func (h *WorkspaceHandler) GetA2AQueueStatus(c *gin.Context) {
+	ctx := c.Request.Context()
+	queueID := c.Param("queue_id")
+	if queueID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "queue_id required"})
+		return
+	}
+
+	// Org-level token (canvas/admin)? Bypass per-row caller match.
+	_, isOrg := c.Get("org_token_id")
+
+	// Derive caller workspace from bearer when not org-token.
+	callerWorkspace := c.GetHeader("X-Workspace-ID")
+	if !isOrg && callerWorkspace == "" {
+		if tok := wsauth.BearerTokenFromHeader(c.GetHeader("Authorization")); tok != "" {
+			if wsID, err := wsauth.WorkspaceFromToken(ctx, db.DB, tok); err == nil {
+				callerWorkspace = wsID
+			}
+		}
+	}
+	if !isOrg && callerWorkspace == "" {
+		// No identity — treat as not-found rather than 401, matching the
+		// file-header existence-non-inference policy. A 401 would tell
+		// an attacker that the queue_id at least might exist.
+		c.JSON(http.StatusNotFound, gin.H{"error": "queue item not found"})
+		return
+	}
+
+	rowCallerID, rowWorkspaceID, err := queueRowAuthFields(ctx, queueID)
+	if errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "queue item not found"})
+		return
+	}
+	if err != nil {
+		log.Printf("GetA2AQueueStatus: row lookup failed for %s: %v", queueID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed"})
+		return
+	}
+
+	// Access check.
+	if !isOrg && callerWorkspace != rowCallerID && callerWorkspace != rowWorkspaceID {
+		// Collapse to 404 — see header.
+		c.JSON(http.StatusNotFound, gin.H{"error": "queue item not found"})
+		return
+	}
+
+	status, err := QueueStatusByID(ctx, queueID)
+	if errors.Is(err, sql.ErrNoRows) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "queue item not found"})
+		return
+	}
+	if err != nil {
+		log.Printf("GetA2AQueueStatus: status fetch failed for %s: %v", queueID, err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "status fetch failed"})
+		return
+	}
+
+	c.JSON(http.StatusOK, status)
+}

--- a/workspace-server/internal/handlers/a2a_queue_status_test.go
+++ b/workspace-server/internal/handlers/a2a_queue_status_test.go
@@ -1,0 +1,60 @@
+package handlers
+
+import (
+	"testing"
+)
+
+// TestExtractExpiresInSeconds covers the JSON parser used at enqueue time
+// to honor a caller-specified TTL. Zero return = "no TTL" — caller leaves
+// expires_at NULL on the queue row.
+func TestExtractExpiresInSeconds(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "absent",
+			body: `{"params":{"message":{"messageId":"x"}}}`,
+			want: 0,
+		},
+		{
+			name: "positive",
+			body: `{"params":{"expires_in_seconds":300,"message":{"messageId":"x"}}}`,
+			want: 300,
+		},
+		{
+			name: "zero",
+			body: `{"params":{"expires_in_seconds":0,"message":{"messageId":"x"}}}`,
+			want: 0,
+		},
+		{
+			name: "negative coerced to zero",
+			body: `{"params":{"expires_in_seconds":-30,"message":{"messageId":"x"}}}`,
+			want: 0,
+		},
+		{
+			name: "invalid JSON returns zero",
+			body: `not json`,
+			want: 0,
+		},
+		{
+			name: "wrong type silently zero (json.Unmarshal returns err on type mismatch)",
+			body: `{"params":{"expires_in_seconds":"not-a-number"}}`,
+			want: 0,
+		},
+		{
+			name: "params absent entirely",
+			body: `{}`,
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractExpiresInSeconds([]byte(tc.body))
+			if got != tc.want {
+				t.Errorf("extractExpiresInSeconds(%q) = %d, want %d", tc.body, got, tc.want)
+			}
+		})
+	}
+}

--- a/workspace-server/internal/router/router.go
+++ b/workspace-server/internal/router/router.go
@@ -144,6 +144,13 @@ func Setup(hub *ws.Hub, broadcaster *events.Broadcaster, prov *provisioner.Provi
 	// A2A proxy — registered outside the auth group; already enforces CanCommunicate access control.
 	r.POST("/workspaces/:id/a2a", wh.ProxyA2A)
 
+	// A2A queue status lookup (RFC #2331 Tier 1) — registered outside the
+	// workspace auth group because the row's caller_id may be a DIFFERENT
+	// workspace than :id. The handler runs its own access check (caller
+	// must match queue.caller_id OR queue.workspace_id, OR hold an
+	// org-level token). Existence-non-inferring 404 on auth failure.
+	r.GET("/workspaces/:id/a2a/queue/:queue_id", wh.GetA2AQueueStatus)
+
 	// Auth-gated workspace sub-routes — ALL /workspaces/:id/* paths except /a2a.
 	// Fix A (Cycle 5): single WorkspaceAuth middleware blocks C2-C5, C7-C9, C12, C13
 	// by requiring a valid bearer token for any workspace that has one on file.


### PR DESCRIPTION
## Summary

Closes the observability gap from #2329 item 5: callers received \`queue_id\` in 202 responses but had no public lookup. Only \`check_task_status\` worked (delegation-flavored A2A only — joins via \`request_body->>'delegation_id'\`). Peer-direct A2A had zero observability after enqueue.

Implements **Tier 1 of RFC #2331**. No schema migration — \`expires_at\` already exists (migration 042); previously dead infrastructure with no caller path.

## Changes

| Change | File |
|---|---|
| \`extractExpiresInSeconds(body)\` parser | \`a2a_queue.go\` |
| \`EnqueueA2A\` signature gains \`expiresAt *time.Time\` | \`a2a_queue.go\` |
| Proxy callsite computes expiresAt + passes it through | \`a2a_proxy_helpers.go\` |
| New \`QueueStatusByID\` + \`GetA2AQueueStatus\` handler | \`a2a_queue_status.go\` (new) |
| \`GET /workspaces/:id/a2a/queue/:queue_id\` route | \`router.go\` |
| 7-case parser tests | \`a2a_queue_status_test.go\` (new) |

## Auth model

- Workspace token: caller's workspace must match \`queue.caller_id\` OR \`queue.workspace_id\`
- Org-level token (canvas/admin): bypass per-row check
- 404 — not 403 — on auth failure (existence-non-inferring; the \`queue_id\` UUID is the access token)

## What's NOT in this PR

- Drain semantics (heartbeat-driven dispatch) — unchanged
- Native-session bypass — unchanged (claude-agent-sdk, hermes still skip the queue)
- Cross-workspace peer-direct stitch — Tier 2
- Webhook callback — Tier 2
- Reconciler-track refactor — Tier 3

## Verification

- \`go build\` clean
- \`go vet\` clean
- \`go test ./internal/handlers/\` full suite passes
- 7-case unit test on \`extractExpiresInSeconds\` covering absent / positive / zero / negative / invalid-JSON / wrong-type / empty-params
- \`grep EnqueueA2A\` confirmed only one production caller; signature change isolated

## Closes

#2331 (Tier 1) — leave issue open for Tier 2/3 tracking.

Refs #2329 item 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)