### PR TITLE
ci: add concurrency block to redeploy-tenants-on-main for parity

### DIFF
--- a/.github/workflows/redeploy-tenants-on-main.yml
+++ b/.github/workflows/redeploy-tenants-on-main.yml
@@ -64,6 +64,20 @@ permissions:
   # No write scopes needed — the workflow hits an external CP endpoint,
   # not the GitHub API.
 
+# Serialize redeploys so two rapid main pushes' redeploys don't overlap
+# and cause confusing per-tenant SSM state. Without this, GitHub's
+# implicit workflow_run queueing would *probably* serialize them, but
+# the explicit block makes the invariant defensible. Mirrors the
+# concurrency block on redeploy-tenants-on-staging.yml for shape parity.
+#
+# cancel-in-progress: false → aborting a half-rolled-out fleet would
+# leave tenants stuck on whatever image they happened to be on when
+# cancelled. Better to finish the in-flight rollout before starting
+# the next one.
+concurrency:
+  group: redeploy-tenants-on-main
+  cancel-in-progress: false
+
 jobs:
   redeploy:
     # Skip the auto-trigger if publish-workspace-server-image didn't


### PR DESCRIPTION
Parity with #2337's redeploy-tenants-on-staging.yml. The new staging redeploy got explicit serialization; the existing main redeploy didn't. Picked up as a #2337 review finding (architecture finding 1).

\`\`\`yaml
concurrency:
  group: redeploy-tenants-on-main
  cancel-in-progress: false
\`\`\`

Pre-fix relied on GitHub's implicit \`workflow_run\` queueing — "probably fine" but not defensible. Explicit > implicit for load-bearing pipeline behavior.

\`cancel-in-progress: false\` consistent with the staging variant: aborting a half-rolled-out fleet would leave tenants stuck on whatever image they happened to be on when cancelled.

No behavior change in the common case. Matters only when two main pushes land within seconds AND the first redeploy is still mid-rollout — currently rare; will become slightly more common once #2335's staging-publish feeds main more frequently via auto-promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)