### PR TITLE
test(arch): codify 4 module boundaries as architecture tests (#2344)

### DIFF
--- a/workspace-server/internal/db/architecture_test.go
+++ b/workspace-server/internal/db/architecture_test.go
@@ -1,0 +1,63 @@
+package db_test
+
+// Architecture test (#2344): db is a leaf — DB pool + migrations + raw
+// SQL helpers, no business-logic dependencies. The DB layer must be
+// testable with sqlmock in isolation. If db starts importing handlers
+// or provisioner, every db unit test would need to bring up that
+// subsystem, and the layering becomes circular.
+//
+// If this test fails: you put business logic in the db package. Move
+// it to a higher-tier package that imports db, not the reverse.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const moduleInternalPrefix = "github.com/Molecule-AI/molecule-monorepo/platform/internal/"
+
+func TestDBHasNoInternalDependencies(t *testing.T) {
+	t.Parallel()
+	for path, file := range listImports(t, ".") {
+		if strings.HasPrefix(path, moduleInternalPrefix) {
+			t.Errorf(
+				"db must not import other internal packages "+
+					"(found %q in %s) — db is the foundation layer and a "+
+					"reverse dep creates a cycle (everything imports db). "+
+					"See workspace-server/internal/db/architecture_test.go.",
+				path, file,
+			)
+		}
+	}
+}
+
+func listImports(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[string]string)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			path := strings.Trim(imp.Path.Value, "\"")
+			if _, seen := out[path]; !seen {
+				out[path] = name
+			}
+		}
+	}
+	return out
+}

--- a/workspace-server/internal/models/architecture_test.go
+++ b/workspace-server/internal/models/architecture_test.go
@@ -1,0 +1,63 @@
+package models_test
+
+// Architecture test (#2344): models is a leaf — it carries pure type
+// definitions and must not import any other internal/* package. Almost
+// every package in workspace-server depends on models; if models grew a
+// reverse dep, the import graph would cycle.
+//
+// If this test fails: you put behavior inside models. Move the behavior
+// to whichever package actually owns it (handlers, provisioner, db, …)
+// and have *that* package import models, not the reverse.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const moduleInternalPrefix = "github.com/Molecule-AI/molecule-monorepo/platform/internal/"
+
+func TestModelsHasNoInternalDependencies(t *testing.T) {
+	t.Parallel()
+	for path, file := range listImports(t, ".") {
+		if strings.HasPrefix(path, moduleInternalPrefix) {
+			t.Errorf(
+				"models must not import other internal packages "+
+					"(found %q in %s) — models is the pure-types leaf and any "+
+					"reverse dep creates an import cycle since most packages "+
+					"depend on models. See workspace-server/internal/models/architecture_test.go.",
+				path, file,
+			)
+		}
+	}
+}
+
+func listImports(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[string]string)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			path := strings.Trim(imp.Path.Value, "\"")
+			if _, seen := out[path]; !seen {
+				out[path] = name
+			}
+		}
+	}
+	return out
+}

--- a/workspace-server/internal/provisioner/architecture_test.go
+++ b/workspace-server/internal/provisioner/architecture_test.go
@@ -1,0 +1,80 @@
+package provisioner_test
+
+// Architecture test (#2344): provisioner is below handlers/router in
+// the layer hierarchy. handlers wires provisioner into HTTP routes;
+// the reverse direction (provisioner reaching back into handlers or
+// the router) creates a cycle and tangles infra-orchestration with
+// transport.
+//
+// Note: provisioner CURRENTLY imports db (for the runtime-image
+// lookup). That's a known coupling — see PR #2276 review thread on
+// where image resolution should live. The narrower rule we enforce
+// here is "no upward import to handlers/router," which is the harder
+// rule to keep clean.
+//
+// If this test fails: you reached "up" the stack. Pass whatever you
+// need from handlers down through a constructor parameter or a
+// function-typed callback instead of importing the package directly.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const moduleInternalPrefix = "github.com/Molecule-AI/molecule-monorepo/platform/internal/"
+
+var provisionerForbiddenImports = []string{
+	moduleInternalPrefix + "handlers",
+	moduleInternalPrefix + "router",
+}
+
+func TestProvisionerDoesNotImportUpstreamLayers(t *testing.T) {
+	t.Parallel()
+	imports := listImports(t, ".")
+	for path, file := range imports {
+		for _, forbidden := range provisionerForbiddenImports {
+			if path == forbidden || strings.HasPrefix(path, forbidden+"/") {
+				t.Errorf(
+					"provisioner must not import %q (found in %s) — "+
+						"provisioner sits below handlers/router in the layer "+
+						"hierarchy and a reverse dep creates a cycle. Pass "+
+						"what you need down via constructor params or "+
+						"function-typed callbacks. See workspace-server/internal/"+
+						"provisioner/architecture_test.go.",
+					path, file,
+				)
+			}
+		}
+	}
+}
+
+func listImports(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[string]string)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			path := strings.Trim(imp.Path.Value, "\"")
+			if _, seen := out[path]; !seen {
+				out[path] = name
+			}
+		}
+	}
+	return out
+}

--- a/workspace-server/internal/wsauth/architecture_test.go
+++ b/workspace-server/internal/wsauth/architecture_test.go
@@ -1,0 +1,68 @@
+package wsauth_test
+
+// Architecture test (#2344): wsauth is a leaf package — it must not import
+// any other internal/* package. The auth layer is below business logic;
+// importing handlers, db, or any cousin package would force every wsauth
+// test to spin up that subsystem, defeating the unit-test boundary that
+// makes the auth code reviewable.
+//
+// If this test fails: you added an import that crosses a layer. Either
+// move the dependency the other direction (consumer wires wsauth into
+// itself), accept the boundary by inlining what you need, or — if the
+// new coupling is genuinely correct — explicitly update this test with
+// the new allowed import + a comment explaining why.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const moduleInternalPrefix = "github.com/Molecule-AI/molecule-monorepo/platform/internal/"
+
+func TestWsauthHasNoInternalDependencies(t *testing.T) {
+	t.Parallel()
+	for path, file := range listImports(t, ".") {
+		if strings.HasPrefix(path, moduleInternalPrefix) {
+			t.Errorf(
+				"wsauth must not import other internal packages "+
+					"(found %q in %s) — wsauth is the auth leaf and must stay "+
+					"unit-testable without spinning up other subsystems. "+
+					"See workspace-server/internal/wsauth/architecture_test.go for context.",
+				path, file,
+			)
+		}
+	}
+}
+
+// listImports returns import-path → first-file-where-seen for non-test
+// .go files in dir. Used by every architecture_test.go in this tree.
+func listImports(t *testing.T, dir string) map[string]string {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	out := make(map[string]string)
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(dir, name), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for _, imp := range f.Imports {
+			path := strings.Trim(imp.Path.Value, "\"")
+			if _, seen := out[path]; !seen {
+				out[path] = name
+			}
+		}
+	}
+	return out
+}


### PR DESCRIPTION
Closes #2344. Hard gate #4 of 4 in the hard-gates roadmap.

## What this gate catches

Module boundaries that exist in tribal knowledge but aren't enforced today. A new contributor (or AI agent) can land an import that crosses a layer, and code review is the only thing standing between that and gradual rot.

## Boundaries codified

One `architecture_test.go` per package, each one parsing the package's `.go` files via `go/parser` (stdlib only — no `x/tools` dep) and asserting forbidden imports don't appear:

| Test | Rule |
|---|---|
| `TestWsauthHasNoInternalDependencies` | wsauth is the auth leaf — no internal/* deps |
| `TestModelsHasNoInternalDependencies` | models is the pure-types leaf — no internal/* deps |
| `TestDBHasNoInternalDependencies` | db is the foundation layer — no internal/* deps |
| `TestProvisionerDoesNotImportUpstreamLayers` | provisioner doesn't import handlers/router (cycle prevention) |

Failure messages name the rule, the offending file, and the *why* behind the boundary, so the diff author can either fix the import direction or — if the new coupling is genuinely correct — explicitly update the test with the allowed import + a new comment.

## Deviation from the issue

The issue proposed 4 boundaries, but two of them don't match reality today:

- `provisioner` no `db` import — **violated**. `cp_provisioner.go:15` imports `db` for the runtime-image lookup (landed in PR #2276 review thread).
- `handlers` no direct docker — **violated**. 5 handlers hold `*docker.Client` fields directly (terminal, plugins, bundle, templates, admin_workspace_images).

I picked the 4 boundaries that **actually hold on current main** and meet the issue's acceptance criterion ("All 4 pass on current main"). The first two are aspirational and would need a refactor before they could be codified — happy to file a follow-up for that if you want.

## Hand test

Injected a deliberate violation (`wsauth` import of `orgtoken`):

```
--- FAIL: TestWsauthHasNoInternalDependencies (0.00s)
    architecture_test.go:30: wsauth must not import other internal packages
    (found ".../internal/orgtoken" in handtest_violation.go) — wsauth is the
    auth leaf and must stay unit-testable without spinning up other subsystems.
```

Gate fires red with the rule message before merge.

## Test plan
- [x] All 4 architecture tests pass on current main
- [x] Hand-test: deliberate violation injected → gate fires red with intent message
- [ ] CI green on staging branch protection