### PR TITLE
fix(ci): dispatch publish chain after auto-promote merge (#2357)

### DIFF
--- a/.github/workflows/auto-promote-staging.yml
+++ b/.github/workflows/auto-promote-staging.yml
@@ -240,3 +240,67 @@ jobs:
             echo
             echo "Merge queue lands the PR once required gates are green; no human action needed unless gates fail."
           } >> "$GITHUB_STEP_SUMMARY"
+
+          # Hand the PR number to the next step so we can dispatch the
+          # tenant-redeploy chain after the merge queue lands the merge.
+          echo "promote_pr_num=${PR_NUM}" >> "$GITHUB_OUTPUT"
+        id: promote_pr
+
+      - name: Wait for promote merge, then dispatch publish + redeploy (#2357)
+        # GITHUB_TOKEN-initiated merges suppress downstream `push` events
+        # (https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow).
+        # Result: when the merge queue lands the promote PR, the resulting
+        # main-branch push DOES NOT fire publish-workspace-server-image,
+        # so canary-verify and redeploy-tenants-on-main never run and
+        # tenants stay on stale code (issue #2357).
+        #
+        # Workaround: poll for the merge to land, then explicitly
+        # `gh workflow run` publish-workspace-server-image. workflow_dispatch
+        # is the documented exception to the GITHUB_TOKEN suppression rule —
+        # dispatch DOES create a new workflow run. canary-verify chains via
+        # workflow_run (no branch filter) and redeploys to fleet via the
+        # existing chain.
+        #
+        # Long-term fix: switch the auto-merge call above to a GitHub App
+        # token (actions/create-github-app-token) and remove this polling
+        # tail step. Tracked in #2357.
+        if: steps.promote_pr.outputs.promote_pr_num != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUM: ${{ steps.promote_pr.outputs.promote_pr_num }}
+        run: |
+          # Poll for merge — max 30 min (60 × 30s). The merge queue
+          # typically lands within 5-10 min when gates are green.
+          MERGED=""
+          for _ in $(seq 1 60); do
+            MERGED=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergedAt --jq '.mergedAt // ""')
+            if [ -n "$MERGED" ] && [ "$MERGED" != "null" ]; then
+              echo "::notice::Promote PR #${PR_NUM} merged at ${MERGED}"
+              break
+            fi
+            sleep 30
+          done
+
+          if [ -z "$MERGED" ] || [ "$MERGED" = "null" ]; then
+            echo "::warning::Promote PR #${PR_NUM} didn't merge within 30min — skipping deploy dispatch (manually run \`gh workflow run redeploy-tenants-on-main.yml\` once it lands)."
+            exit 0
+          fi
+
+          # Dispatch publish on main. workflow_dispatch via GITHUB_TOKEN
+          # IS allowed to create new workflow runs (per the linked docs).
+          # publish completes → canary-verify chains via workflow_run →
+          # redeploy-tenants-on-main chains via workflow_run + branches:[main].
+          if gh workflow run publish-workspace-server-image.yml \
+              --repo "$REPO" --ref main 2>&1; then
+            echo "::notice::Dispatched publish-workspace-server-image on ref=main — canary-verify and redeploy-tenants-on-main will chain via workflow_run."
+            {
+              echo "## 🚀 Tenant redeploy chain dispatched"
+              echo
+              echo "- publish-workspace-server-image (workflow_dispatch on \`main\`)"
+              echo "- canary-verify will chain on completion"
+              echo "- redeploy-tenants-on-main will chain on canary green"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Failed to dispatch publish-workspace-server-image. Run manually: gh workflow run publish-workspace-server-image.yml --ref main"
+          fi


### PR DESCRIPTION
## Summary

- After the auto-promote staging → main PR is enqueued for auto-merge, poll until it lands and then explicitly `gh workflow run publish-workspace-server-image.yml --ref main`.
- Works around the documented GITHUB_TOKEN suppression rule: events created by `GITHUB_TOKEN` (like our `gh pr merge --auto`) do NOT trigger downstream `push`/`pull_request` workflows. `workflow_dispatch` is the documented exception.
- Restores the publish → canary-verify → redeploy-tenants-on-main chain so tenants get fresh images automatically after a green staging promotion.

## Background — issue #2357

Concrete repro from this morning:

1. PR #2354 (`feat(activity): since_id cursor`) merged to staging, all gates green.
2. `auto-promote-staging.yml` opened PR #<promote> staging → main and called `gh pr merge --auto --merge` with GITHUB_TOKEN.
3. Merge queue landed it. Main commit \`b5bde039\` exists.
4. **Zero workflows fired on that main push.** No publish-workspace-server-image, no canary-verify, no redeploy-tenants-on-main.
5. User's tenant on the live `*.staging.moleculesai.app` (running `main`) kept returning \`{\"error\":\"invalid request body\"}\` because it was running pre-PR-1 code. Manual `gh workflow run redeploy-tenants-on-main.yml` was needed to push tenants forward.

[GitHub docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN, with the exception of workflow_dispatch and repository_dispatch, will not create a new workflow run.

So the `gh pr merge --auto --merge` → merge → main-push chain is silently dropped. canary-verify (\`workflow_run: publish-workspace-server-image, completed\`) never fires, and the tenant fleet stays stale.

## What this PR does

- Captures \`promote_pr_num\` as a step output.
- Adds a tail step that:
  - Polls \`gh pr view --json mergedAt\` for up to 30 min (60 × 30s).
  - When merged, calls \`gh workflow run publish-workspace-server-image.yml --ref main\`.
  - If the PR doesn't merge in 30 min, warns and exits 0 — operator can dispatch manually.
- \`workflow_dispatch\` IS allowed under GITHUB_TOKEN per the docs exception, so this triggers a real run. publish completes → canary-verify chains via \`workflow_run\` → \`redeploy-tenants-on-main\` chains via \`workflow_run\` + branches:[main].

## Why not amend the merge call to use a GitHub App token instead?

That's the long-term fix — App-token-initiated merges DO fire downstream workflows naturally, no polling tail needed. But it requires:
- New GitHub App + secrets plumbing (\`actions/create-github-app-token\`).
- Permissions audit (App needs PR write + contents write).
- Org-admin coordination.

That's a separate, larger PR. This dispatch-chain shim restores the deploy chain TODAY without new secrets and is documented inline as an interim measure.

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(...)\"` — YAML parses cleanly.
- [ ] CI on this PR (auto-promote-staging.yml is itself a workflow file but only runs on main pushes / workflow_run triggers, so this PR doesn't self-test — verification is on the next staging→main promotion).
- [ ] After merge to staging + promotion to main: confirm publish-workspace-server-image fires automatically on the post-merge run, with no manual dispatch.
- [ ] Confirm canary-verify + redeploy-tenants-on-main chain on workflow_run as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)