### PR TITLE
fix(ci): close gaps in auto-promote dispatch tail (#2358 follow-up)

### DIFF
--- a/.github/workflows/auto-promote-staging.yml
+++ b/.github/workflows/auto-promote-staging.yml
@@ -76,6 +76,27 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # actions: write is needed by the post-merge dispatch tail step
+  # (#2358 / #2357) — `gh workflow run publish-workspace-server-image.yml`
+  # POSTs to /actions/workflows/.../dispatches which requires this scope.
+  # Without it the call 403s and the publish/canary/redeploy chain still
+  # doesn't run on staging→main promotions, undoing #2358.
+  actions: write
+
+# Serialize auto-promote runs. Multiple staging gate completions can land
+# in quick succession (CI + E2E + CodeQL all finish within seconds of
+# each other on a green PR) — without this, two parallel runs both:
+#   1. Open / re-use the same promote PR.
+#   2. Both call `gh pr merge --auto` (idempotent — fine).
+#   3. Both poll for the same mergedAt and both `gh workflow run` publish
+#      → 2× redundant publish builds racing for the same `:staging-latest`
+#      retag, and 2× canary-verify chains.
+# cancel-in-progress: false because we don't want a brand-new run to kill
+# a polling-tail that's about to dispatch — the polling tail's 30 min cap
+# is the right backstop, not workflow-level cancel.
+concurrency:
+  group: auto-promote-staging
+  cancel-in-progress: false
 
 jobs:
   check-all-gates-green:
@@ -271,19 +292,29 @@ jobs:
           PR_NUM: ${{ steps.promote_pr.outputs.promote_pr_num }}
         run: |
           # Poll for merge — max 30 min (60 × 30s). The merge queue
-          # typically lands within 5-10 min when gates are green.
+          # typically lands within 5-10 min when gates are green. Break
+          # early if the PR is closed without merging (operator action,
+          # gates flipped red post-approval, branch-protection rejection)
+          # so we don't tie up a runner for the full 30 min on a dead PR.
           MERGED=""
+          STATE=""
           for _ in $(seq 1 60); do
-            MERGED=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergedAt --jq '.mergedAt // ""')
+            VIEW=$(gh pr view "$PR_NUM" --repo "$REPO" --json mergedAt,state)
+            MERGED=$(echo "$VIEW" | jq -r '.mergedAt // ""')
+            STATE=$(echo "$VIEW" | jq -r '.state // ""')
             if [ -n "$MERGED" ] && [ "$MERGED" != "null" ]; then
               echo "::notice::Promote PR #${PR_NUM} merged at ${MERGED}"
               break
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "::warning::Promote PR #${PR_NUM} was closed without merging — skipping deploy dispatch."
+              exit 0
             fi
             sleep 30
           done
 
           if [ -z "$MERGED" ] || [ "$MERGED" = "null" ]; then
-            echo "::warning::Promote PR #${PR_NUM} didn't merge within 30min — skipping deploy dispatch (manually run \`gh workflow run redeploy-tenants-on-main.yml\` once it lands)."
+            echo "::warning::Promote PR #${PR_NUM} didn't merge within 30min — skipping deploy dispatch (manually run \`gh workflow run publish-workspace-server-image.yml --ref main\` once it lands)."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

Independent five-axis review of the merged #2358 fix surfaced three gaps the original self-review missed. All three only manifest on the first real staging→main promotion through the new tail step, so they would silently re-introduce the deploy-chain bug #2357 was supposed to fix.

## The gaps

1. **`actions: write` permission missing on the `promote` job.** `gh workflow run` POSTs to `/repos/.../actions/workflows/.../dispatches` which requires `actions: write`. The job had only `contents: write` + `pull-requests: write`. Result: dispatch call 403s on every run, publish chain still doesn't fire. **Fix: add `actions: write`.**

2. **No workflow-level `concurrency` block.** Four required gates (CI + E2E Staging Canvas + E2E API Smoke + CodeQL) all complete within seconds of each other on a green staging push, firing four parallel `workflow_run` events. All four reach the dispatch tail, all four observe the same `mergedAt`, all four call `gh workflow run` → 2-4× redundant publish builds racing for the same `:staging-latest` retag plus 2-4× canary-verify chains. **Fix: `concurrency.group: auto-promote-staging, cancel-in-progress: false`.** (False because cancelling a polling tail that's about to dispatch re-introduces the original bug.)

3. **PR closed-without-merge ties up a runner for 30 min.** If the merge queue rejects the promote PR (gates flip red post-approval), or an operator closes it, `mergedAt` stays null forever and the polling loop wastes 60 × 30s. **Fix: read `state` in the same `gh pr view` call, break early on `STATE=CLOSED`.**

## Why this is its own PR

The original #2358 was load-bearing for restoring the deploy chain — landing it as small as possible was right. This follow-up hardens it before the next staging→main promotion actually exercises it. The two PRs as a stack: #2358 establishes the dispatch mechanism; this PR closes the gaps that would silently break it.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — valid.
- [x] Independent reviewer reproduced and verified each finding against the workflow file.
- [ ] Real verification on the next staging→main promotion (workflow only fires on `workflow_run` of staging gates → can't unit-test).

## Acknowledgement

The original #2358 was self-approved by an AI agent in under 60s of "five-axis review." That review was inadequate — the three gaps above are exactly the kind of thing a real reviewer would catch on first read. Filing this is the corrective. Future merge: pair with the same independent-review pattern on the first attempt, not as cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)