### PR TITLE
test(provision): pin PARENT_ID env injection contract in prepareProvisionContext

### DIFF
--- a/workspace-server/internal/handlers/workspace_provision_shared_test.go
+++ b/workspace-server/internal/handlers/workspace_provision_shared_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/Molecule-AI/molecule-monorepo/platform/internal/models"
 	"github.com/Molecule-AI/molecule-monorepo/platform/internal/provisioner"
 )
 
@@ -224,3 +225,69 @@ func TestMintWorkspaceSecrets_PersistsInboundSecretInSaaSMode(t *testing.T) {
 		t.Errorf("SaaS mode should not inject .auth_token into cfg.ConfigFiles (no Docker volume) — got entry")
 	}
 }
+
+// TestPrepareProvisionContext_ParentIDInjection pins the PARENT_ID env
+// contract added in #2367: when payload.ParentID is set (currently only
+// TeamHandler.Expand populates it), prepareProvisionContext MUST
+// surface it as envVars["PARENT_ID"] so workspace/coordinator.py can
+// read it on startup. Pre-fix #2367 the env was set inline in
+// TeamHandler.Expand on cfg.EnvVars; the refactor moved it into the
+// shared prepare so any future provision path with a parent_id
+// inherits it automatically.
+func TestPrepareProvisionContext_ParentIDInjection(t *testing.T) {
+	cases := []struct {
+		name       string
+		parentID   *string
+		expectKey  bool
+		expectVal  string
+	}{
+		{
+			name:      "parentID nil → no PARENT_ID env",
+			parentID:  nil,
+			expectKey: false,
+		},
+		{
+			name:      "parentID empty string → no PARENT_ID env",
+			parentID:  ptrStr(""),
+			expectKey: false,
+		},
+		{
+			name:      "parentID set → PARENT_ID env populated",
+			parentID:  ptrStr("ws-parent-123"),
+			expectKey: true,
+			expectVal: "ws-parent-123",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := setupTestDB(t)
+			// loadWorkspaceSecrets queries: empty rows + empty rows = clean prep.
+			mock.ExpectQuery(`SELECT key, encrypted_value, encryption_version FROM global_secrets`).
+				WillReturnRows(sqlmock.NewRows([]string{"key", "encrypted_value", "encryption_version"}))
+			mock.ExpectQuery(`SELECT key, encrypted_value, encryption_version FROM workspace_secrets`).
+				WithArgs("ws-child").
+				WillReturnRows(sqlmock.NewRows([]string{"key", "encrypted_value", "encryption_version"}))
+
+			handler := NewWorkspaceHandler(&captureBroadcaster{}, nil, "http://localhost:8080", t.TempDir())
+			payload := models.CreateWorkspacePayload{
+				Name:     "child",
+				Tier:     1,
+				ParentID: tc.parentID,
+			}
+			prepared, abort := handler.prepareProvisionContext(context.Background(), "ws-child", "/nonexistent", nil, payload, false)
+			if abort != nil {
+				t.Fatalf("unexpected abort: %s", abort.Msg)
+			}
+			val, present := prepared.EnvVars["PARENT_ID"]
+			if present != tc.expectKey {
+				t.Errorf("PARENT_ID present=%v, want %v (env=%v)", present, tc.expectKey, prepared.EnvVars)
+			}
+			if tc.expectKey && val != tc.expectVal {
+				t.Errorf("PARENT_ID=%q, want %q", val, tc.expectVal)
+			}
+		})
+	}
+}
+
+func ptrStr(s string) *string { return &s }


### PR DESCRIPTION
Follow-up to #2367 / #2368.

## Summary

PR #2368 moved \`PARENT_ID\` env injection from inline \`TeamHandler.Expand\` into the shared \`prepareProvisionContext\` (sourced from \`payload.ParentID\`). Behavioral test was missing — a regression that:

- dropped the injection
- inverted the nil-check
- leaked an empty \`PARENT_ID=\"\"\` into env (workspace/coordinator.py treats empty as no-parent, but a stray empty key is still confusing)

would not fail any existing test. \`workspace/coordinator.py\` reads \`PARENT_ID\` on startup to track parent-child relationships, so the breakage would surface only at runtime when team-expanded children failed to register with the parent.

## Changes

\`TestPrepareProvisionContext_ParentIDInjection\` with three sub-cases:

- nil ParentID → no \`PARENT_ID\` env
- empty-string ParentID → no \`PARENT_ID\` env (don't pollute)
- set ParentID → \`PARENT_ID\` env equals value

## Test plan

- [x] All 3 sub-cases pass
- [x] Full module green: \`go test ./...\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)