### PR TITLE
fix(ci): drop --depth=1 from migration collision check fetch

### DIFF
--- a/.github/workflows/check-migration-collisions.yml
+++ b/.github/workflows/check-migration-collisions.yml
@@ -44,8 +44,15 @@ jobs:
           # gh CLI uses GH_TOKEN from env
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Make sure base ref is fetched (checkout@v4 with fetch-depth=0
-          # fetches history but not necessarily named refs in the form we
-          # expect; explicit fetch is cheap insurance).
-          git fetch origin "${{ github.event.pull_request.base.ref }}" --depth=1 || true
+          # Ensure the named base ref exists locally. checkout@v4 with
+          # fetch-depth=0 pulls full history, but the explicit fetch is
+          # cheap insurance against form-of-ref differences across runs.
+          #
+          # IMPORTANT: do NOT pass --depth=1 here. The script below uses
+          # `git diff origin/<base>...<head>` (three-dot, merge-base form),
+          # which fails with "fatal: no merge base" if the base ref is
+          # shallow. The auto-promote staging→main PR (#2361) was blocked
+          # by exactly this for ~5h on 2026-04-30 — the depth=1 fetch
+          # overwrote checkout@v4's full-history clone with a shallow tip.
+          git fetch origin "${{ github.event.pull_request.base.ref }}" || true
           python3 scripts/ops/check_migration_collisions.py


### PR DESCRIPTION
## Summary

Unblocks the staging→main auto-promote PR (#2361) which has been failing since 2026-04-30T07:17Z with:

\`\`\`
fatal: origin/main...<head>: no merge base
command failed: git diff --name-only --diff-filter=AM origin/main...<head> -- workspace-server/migrations
\`\`\`

## Root cause

\`.github/workflows/check-migration-collisions.yml\` does:

\`\`\`yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0   # ← pulls full history
- run: |
    git fetch origin main --depth=1 || true   # ← overwrites with shallow tip
    python3 scripts/ops/check_migration_collisions.py
\`\`\`

The explicit fetch with \`--depth=1\` shrinks the local main ref to a single shallow commit, destroying the ancestry that \`check_migration_collisions.py\` needs for its \`git diff origin/main...HEAD\` (three-dot, merge-base form) call.

## Impact

- Every staging→main auto-promote PR opened since this workflow landed has hit this. The CI gate fails → auto-promote workflow waits 30 min for merge → times out → skips the publish + redeploy dispatch tail.
- PR #2361 has been blocked for ~5 hours; main is still at \`6ef562ee\` (PR #2359), 27+ commits behind staging including the recent SaaS dead-agent fix (#2362) and CF-status-code follow-up (#2365).
- Production tenant fleet redeployed from staging successfully (the staging redeploy chain doesn't go through main), so this isn't a production incident — but main + the publish-image chain are blocked for any future staging-only-fix that needs to reach main.

## Fix

Drop the \`--depth=1\` flag. \`checkout@v4\` with \`fetch-depth: 0\` already pulled full history; the explicit fetch is cheap insurance for ref naming, not a perf optimization.

The comment is rewritten to call out this trap so a future maintainer doesn't reintroduce the flag.

## Test plan

- [x] yaml parses (\`python3 -c "import yaml; yaml.safe_load(...)"\` clean)
- [ ] CI green on this PR (which exercises the workflow against itself via the path filter on \`.github/workflows/check-migration-collisions.yml\`)
- [ ] After merge: PR #2361 (auto-promote staging→main) re-runs the check, goes green, merges, main fast-forwards, publish + redeploy chain dispatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)