### PR TITLE
fix(ci): handle empty E2E lookup in auto-promote-on-e2e gate

### DIFF
--- a/.github/workflows/auto-promote-on-e2e.yml
+++ b/.github/workflows/auto-promote-on-e2e.yml
@@ -155,6 +155,20 @@ jobs:
           fi
 
           # Upstream is publish-workspace-server-image. Check E2E state.
+          # The jq filter must defend against TWO empty cases that gh
+          # CLI emits indistinguishably:
+          #   1. gh exits non-zero (network blip, auth issue) → handled
+          #      by the `|| echo "none/none"` fallback below.
+          #   2. gh exits zero but returns `[]` (no E2E run on this
+          #      main SHA — the common case for canvas-only / cmd-only
+          #      / sweep-only changes whose paths don't trigger E2E).
+          #      Without `(.[0] // {})`, jq sees `null` and emits
+          #      "null/none" — which the case statement below has no
+          #      branch for, so it falls into *) → exit 1.
+          # Surfaced 2026-04-30 the first time the App-token chain
+          # (#2389) actually fired auto-promote-on-e2e from a publish
+          # upstream — every prior run was E2E-upstream which
+          # short-circuits before this gate.
           RESULT=$(gh run list \
             --repo "$REPO" \
             --workflow e2e-staging-saas.yml \
@@ -162,7 +176,7 @@ jobs:
             --commit "$SHA" \
             --limit 1 \
             --json status,conclusion \
-            --jq '.[0] | "\(.status)/\(.conclusion // "none")"' \
+            --jq '(.[0] // {}) | "\(.status // "none")/\(.conclusion // "none")"' \
             2>/dev/null || echo "none/none")
 
           echo "E2E Staging SaaS for ${SHA:0:7}: $RESULT"


### PR DESCRIPTION
## Bug

When \`gh run list\` returns \`[]\` (no E2E run on the main SHA — the common case for canvas-only / cmd-only / sweep-only changes whose paths don't trigger E2E), the jq expression at line 165 evaluates \`.[0]\` as \`null\`, and \`"\\(null)/\\(null // "none")"\` interpolates as \`"null/none"\`. The case statement has no \`null/none)\` branch, so it falls into \`*)\` → \`exit 1\` → auto-promote-on-e2e fails → \`:latest\` doesn't retag to the new SHA → tenants pulling \`:latest\` get the **old** image.

## Why now

Surfaced 2026-04-30 17:00Z as the first observable consequence of PR #2389 (App-token dispatch fix). Every prior auto-promote-on-e2e run was triggered by E2E completion — the \"Upstream is E2E itself\" short-circuit at line 151 fired before ever reaching the broken gate. #2389 made publish-image's completion event correctly fire workflow_run listeners, and auto-promote-on-e2e is one of them. The very first publish-upstream run hit the latent jq bug.

## Fix

\`.[0]\` → \`(.[0] // {})\` so the empty-array case becomes \`none/none\` (the documented \"E2E paths-filtered out for this SHA — proceed\" branch) instead of the unhandled \`null/none\`. Also defaulting \`.status\` for the same defensive reason.

## Verification

Three input shapes verified locally:

| Input | jq output |
|---|---|
| \`[]\` (no E2E run) | \`\"none/none\"\` ✓ → proceeds with notice \"E2E paths-filtered out\" |
| \`[{status:completed,conclusion:success}]\` | \`\"completed/success\"\` ✓ → proceeds |
| \`[{status:in_progress,conclusion:null}]\` | \`\"in_progress/none\"\` ✓ → defers to E2E completion |

Outer \`|| echo \"none/none\"\` fallback retained for non-zero gh CLI exits (network/auth failures).

## Impact retroactive

Today's main SHA \`26fecb90\` (PR #2391's merge) had \`:latest\` NOT retagged because of this bug. The redeploy-tenants-on-main run that chained successfully via #2389 used the previous \`:latest\` digest. Once this fix lands, the next main bump will retag correctly. The current main SHA will eventually be retagged via the next publish chain or a manual \`gh workflow run auto-promote-on-e2e.yml --field sha=26fecb902fb6e77d30940702379c039a96ea0812\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)