### PR TITLE
fix(ci): hard-fail when >50% of fleet unreachable post-redeploy

### DIFF
--- a/.github/workflows/redeploy-tenants-on-main.yml
+++ b/.github/workflows/redeploy-tenants-on-main.yml
@@ -306,6 +306,16 @@ jobs:
           if [ $UNREACHABLE_COUNT -gt 0 ]; then
             echo "::warning::$UNREACHABLE_COUNT tenant(s) unreachable post-redeploy. Likely benign teardown race — CP healthz monitor catches real outages."
           fi
+
+          # Belt-and-suspenders sanity floor: same logic as the staging
+          # variant — if MORE than half the prod fleet is unreachable,
+          # this is a real outage, not a teardown race. Hard-fail.
+          TOTAL_VERIFIED=${#SLUGS[@]}
+          if [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
+            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED tenant(s) unreachable — exceeds 50% threshold. Likely real outage, not teardown race."
+            exit 1
+          fi
+
           if [ $STALE_COUNT -gt 0 ]; then
             echo "::error::$STALE_COUNT tenant(s) returned a stale SHA. ssm_status=Success was misleading — see job summary."
             exit 1

--- a/.github/workflows/redeploy-tenants-on-main.yml
+++ b/.github/workflows/redeploy-tenants-on-main.yml
@@ -308,11 +308,12 @@ jobs:
           fi
 
           # Belt-and-suspenders sanity floor: same logic as the staging
-          # variant — if MORE than half the prod fleet is unreachable,
-          # this is a real outage, not a teardown race. Hard-fail.
+          # variant — see that file's comment for the full rationale.
+          # Floor only applies when fleet >= 4; below that, canary-verify
+          # is the actual gate.
           TOTAL_VERIFIED=${#SLUGS[@]}
-          if [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
-            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED tenant(s) unreachable — exceeds 50% threshold. Likely real outage, not teardown race."
+          if [ $TOTAL_VERIFIED -ge 4 ] && [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
+            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED tenant(s) unreachable — exceeds 50% threshold on a fleet large enough that this signals a real outage, not teardown race."
             exit 1
           fi
 

--- a/.github/workflows/redeploy-tenants-on-staging.yml
+++ b/.github/workflows/redeploy-tenants-on-staging.yml
@@ -283,6 +283,18 @@ jobs:
           if [ $UNREACHABLE_COUNT -gt 0 ]; then
             echo "::warning::$UNREACHABLE_COUNT staging tenant(s) unreachable post-redeploy. Likely benign teardown race — CP healthz monitor catches real outages."
           fi
+
+          # Belt-and-suspenders sanity floor: if MORE than half the fleet is
+          # unreachable, this isn't a teardown race — it's a real outage
+          # (e.g. the new image crashes on startup). Hard-fail. Canary-verify
+          # would catch this on the canary tenant first; this guard is a
+          # fallback for canary-skip dispatches and same-batch races.
+          TOTAL_VERIFIED=${#SLUGS[@]}
+          if [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
+            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED staging tenant(s) unreachable — exceeds 50% threshold. Likely real outage, not teardown race."
+            exit 1
+          fi
+
           if [ $STALE_COUNT -gt 0 ]; then
             echo "::error::$STALE_COUNT staging tenant(s) returned a stale SHA. ssm_status=Success was misleading — see job summary."
             exit 1

--- a/.github/workflows/redeploy-tenants-on-staging.yml
+++ b/.github/workflows/redeploy-tenants-on-staging.yml
@@ -285,13 +285,20 @@ jobs:
           fi
 
           # Belt-and-suspenders sanity floor: if MORE than half the fleet is
-          # unreachable, this isn't a teardown race — it's a real outage
-          # (e.g. the new image crashes on startup). Hard-fail. Canary-verify
-          # would catch this on the canary tenant first; this guard is a
-          # fallback for canary-skip dispatches and same-batch races.
+          # unreachable AND the fleet is large enough that "half down" is
+          # statistically meaningful, this is a real outage (e.g. new image
+          # crashes on startup), not a teardown race. Hard-fail.
+          #
+          # Floor only applies when TOTAL_VERIFIED >= 4 — below that, the
+          # canary-verify step is the actual gate for "all tenants down"
+          # detection (it runs against the canary first and aborts the
+          # rollout if the canary fails to come up). Without the >=4 gate,
+          # a 1-tenant fleet (e.g. a single ephemeral e2e-* tenant on a
+          # quiet staging push) would re-flake on the exact teardown-race
+          # condition #2402 fixed: 1 of 1 unreachable = 100% > 50% → fail.
           TOTAL_VERIFIED=${#SLUGS[@]}
-          if [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
-            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED staging tenant(s) unreachable — exceeds 50% threshold. Likely real outage, not teardown race."
+          if [ $TOTAL_VERIFIED -ge 4 ] && [ $UNREACHABLE_COUNT -gt $((TOTAL_VERIFIED / 2)) ]; then
+            echo "::error::$UNREACHABLE_COUNT of $TOTAL_VERIFIED staging tenant(s) unreachable — exceeds 50% threshold on a fleet large enough that this signals a real outage, not teardown race."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Follow-up to #2402 addressing the **Optional/Consider** suggestion in the review on that PR — adds a sanity floor on top of the unreachable-soft-warn:

> if MORE than half the fleet is unreachable, this isn't a teardown race — it's a real outage (e.g. the new image crashes on startup). Hard-fail.

#2402 was merged before I got to this; opening as a separate small PR.

## Why

The unreachable-soft-warn from #2402 fixed the e2e-* teardown-race flake. But it left a residual gap: if the new image crashes on startup, every tenant ends up unreachable and the soft-warn alone would let that ship as a green deploy. Canary-verify catches it on the canary tenant first, but this guard is a fallback for canary-skip dispatches and same-batch races.

50% threshold is comfortably above the typical e2e-* teardown rate (5-10/hour, ~1 ephemeral tenant per batch) but below any plausible real-outage scenario.

## How

- Add a 50%-floor check after the soft-warn in both `redeploy-tenants-on-{staging,main}.yml`.
- Hard-fail with a clear `::error::` message that distinguishes "real outage" from "teardown race".

## Test plan

- [x] YAML validates (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [ ] Merge to staging
- [ ] Watch a real redeploy chain — expect identical behavior in the typical case (1 e2e-* unreachable, soft-warn pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)