### PR TITLE
feat(canvas): add /api/buildinfo for version parity with tenant

### DIFF
--- a/canvas/src/app/api/buildinfo/__tests__/route.test.ts
+++ b/canvas/src/app/api/buildinfo/__tests__/route.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Canvas /api/buildinfo — version-display endpoint mirroring
+ * workspace-server's /buildinfo. Lets `curl <url>/api/buildinfo`
+ * confirm which git SHA is live on a canvas deployment.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { GET } from "../route";
+
+const ENV_KEYS = ["VERCEL_GIT_COMMIT_SHA", "VERCEL_GIT_COMMIT_REF", "VERCEL_ENV"];
+
+describe("GET /api/buildinfo", () => {
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    saved = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("returns dev sentinel when Vercel env vars are unset", async () => {
+    const res = await GET();
+    const body = await res.json();
+    expect(body).toEqual({ git_sha: "dev", git_ref: "", vercel_env: "local" });
+  });
+
+  it("reports the SHA Vercel injected at build time", async () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "abc1234567890";
+    process.env.VERCEL_GIT_COMMIT_REF = "main";
+    process.env.VERCEL_ENV = "production";
+    const res = await GET();
+    const body = await res.json();
+    expect(body.git_sha).toBe("abc1234567890");
+    expect(body.git_ref).toBe("main");
+    expect(body.vercel_env).toBe("production");
+  });
+
+  it("returns 200 status and JSON content type", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+  });
+});

--- a/canvas/src/app/api/buildinfo/route.ts
+++ b/canvas/src/app/api/buildinfo/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+// Mirror of workspace-server's GET /buildinfo (PR #2398). Lets a developer
+// confirm which git SHA is live on a canvas deployment with the same
+// `curl <url>/buildinfo` flow they use against tenant workspaces.
+//
+// Vercel injects VERCEL_GIT_COMMIT_SHA / _REF / VERCEL_ENV at build time
+// from the deploying commit; outside Vercel (local `next dev`, harness)
+// these are unset and the endpoint reports `git_sha: "dev"`. Same sentinel
+// the workspace-server uses pre-ldflags-injection so both surfaces speak
+// the same vocabulary.
+export async function GET() {
+  return NextResponse.json({
+    git_sha: process.env.VERCEL_GIT_COMMIT_SHA ?? "dev",
+    git_ref: process.env.VERCEL_GIT_COMMIT_REF ?? "",
+    vercel_env: process.env.VERCEL_ENV ?? "local",
+  });
+}


### PR DESCRIPTION
## Summary

- Adds canvas \`/api/buildinfo\` route handler returning \`{git_sha, git_ref, vercel_env}\`
- Mirrors workspace-server's \`/buildinfo\` (PR #2398) so debugging "is this the deployed code?" uses the same flow on both surfaces

## Why

The user asked: "how can I make sure one tenant workspace or canvas is up to date? do we have version display on production? which is easier for debugging?"

Tenant has it (PR #2398, gated by redeploy-tenants verify-step). Canvas had nothing — debugging required reading Vercel's UI or \`x-vercel-id\` (deployment id, not git SHA).

After this PR, both surfaces share the same \`curl <url>/buildinfo\` flow:
\`\`\`
curl https://<slug>.moleculesai.app/buildinfo
# → {"git_sha":"dea306d2..."}

curl https://canvas.moleculesai.app/api/buildinfo
# → {"git_sha":"7ada4a4d...","git_ref":"main","vercel_env":"production"}
\`\`\`

## Sentinel

When Vercel env vars are unset (local \`next dev\`, harness), the endpoint returns \`{git_sha: "dev", git_ref: "", vercel_env: "local"}\`. Same \`"dev"\` sentinel workspace-server uses pre-ldflags-injection — both speak the same vocabulary for "this is not a deployed build."

## Test plan

- [x] vitest: 3 tests pass (dev-fallback, Vercel-injected SHA, JSON content type)
- [x] tsc --noEmit clean
- [ ] Verify on Vercel preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)