### PR TITLE
fix(boot): always start health-sweep goroutine — SaaS tenants need it for external-runtime liveness

### DIFF
--- a/workspace-server/cmd/server/main.go
+++ b/workspace-server/cmd/server/main.go
@@ -223,13 +223,24 @@ func main() {
 		registry.StartLivenessMonitor(c, onWorkspaceOffline)
 	})
 
-	// Proactive container health sweep — detects dead containers faster than Redis TTL.
-	// Checks all "online" workspaces against Docker every 15 seconds.
-	if prov != nil {
-		go supervised.RunWithRecover(ctx, "health-sweep", func(c context.Context) {
-			registry.StartHealthSweep(c, prov, 15*time.Second, onWorkspaceOffline)
-		})
-	}
+	// Proactive health sweep — two passes per tick:
+	//   1. Docker-side: checks "online" workspaces against the local Docker
+	//      daemon (only runs when prov is non-nil, i.e. self-hosted mode).
+	//   2. Remote-side: scans runtime='external' rows whose last_heartbeat_at
+	//      is past REMOTE_LIVENESS_STALE_AFTER and flips them to
+	//      awaiting_agent. Runs regardless of provisioner mode — SaaS
+	//      tenants need this even though they don't run Docker locally,
+	//      because external-runtime workspaces are operator-managed and
+	//      the platform-side liveness sweep is the only thing that
+	//      transitions them off 'online' when the operator's CLI dies.
+	//
+	// Pre-2026-04-30 this goroutine was gated on prov != nil, which silently
+	// disabled the remote-side sweep on every SaaS tenant. The function in
+	// healthsweep.go has always handled nil checker correctly; only the
+	// orchestration was wrong. See #2392's CI failure for the trace.
+	go supervised.RunWithRecover(ctx, "health-sweep", func(c context.Context) {
+		registry.StartHealthSweep(c, prov, 15*time.Second, onWorkspaceOffline)
+	})
 
 	// Orphan-container reconcile sweep — finds running containers
 	// whose workspace row is already status='removed' and stops


### PR DESCRIPTION
## Summary

The `if prov != nil` gate at `cmd/server/main.go:228` silently disabled the entire health-sweep goroutine on every SaaS tenant. Drop the gate — `StartHealthSweep` has always handled nil checker correctly.

## Root cause

\`\`\`go
// Pre-fix
if prov != nil {
    go supervised.RunWithRecover(ctx, \"health-sweep\", func(c context.Context) {
        registry.StartHealthSweep(c, prov, 15*time.Second, onWorkspaceOffline)
    })
}
\`\`\`

In SaaS mode (\`MOLECULE_ORG_ID != \"\"\`), \`cmd/server/main.go:135-155\` initializes \`cpProv\` (the control-plane provisioner) but leaves \`prov\` (the local Docker provisioner) as \`nil\` — tenants don't run their workspaces locally; CP does the EC2 dance. The gate above prevented the goroutine from ever starting on SaaS deployments.

\`StartHealthSweep\` runs two passes per tick (\`internal/registry/healthsweep.go:50-71\`):
1. **Docker-side** (\`sweepOnlineWorkspaces\`) — internally gated on \`checker != nil\`, so safe to skip when \`prov == nil\`.
2. **Remote-side** (\`sweepStaleRemoteWorkspaces\`) — runs unconditionally; this is the one SaaS tenants need to flip stale runtime='external' workspaces from 'online' back to 'awaiting_agent'.

So removing the outer gate leaves Docker-side correctly skipped on SaaS while remote-side actually runs.

## Production impact (pre-fix)

Every external-runtime workspace on SaaS staging that lost its agent stayed \`online\` indefinitely. Caught by [#2392](https://github.com/Molecule-AI/molecule-core/pull/2392) failing at step 6: *\"After 180s with no heartbeat, expected status=awaiting_agent, got online — migration 046 likely not applied OR sweep not running.\"* Migration 046 IS applied (step 4 confirms); sweep wasn't running was the actual cause.

The class-companions:
- [#2388](https://github.com/Molecule-AI/molecule-core/pull/2388) — drift gate caught migration side
- [#2382](https://github.com/Molecule-AI/molecule-core/pull/2382) — SQL writes fixed
- This PR — orchestration gate fixed
- [#2392](https://github.com/Molecule-AI/molecule-core/pull/2392) — E2E coverage that catches the next class regression

## Test coverage

Already in place: \`internal/registry/healthsweep_test.go::TestStartHealthSweep_NilCheckerRunsRemoteSweep\` (lines 273-302) explicitly asserts the remote sweep fires with a nil Docker checker. No new tests needed.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` green (full platform suite passes)
- [ ] Merge to staging
- [ ] Wait for redeploy-tenants-on-staging to roll the image
- [ ] Re-run #2392's E2E (\`E2E Staging External Runtime\`); expect step 6 to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)