### PR TITLE
fix(tenant-guard): allowlist /buildinfo so redeploy verifier can reach it

### DIFF
--- a/workspace-server/internal/middleware/tenant_guard.go
+++ b/workspace-server/internal/middleware/tenant_guard.go
@@ -53,6 +53,7 @@ const tenantOrgIDHeader = "X-Molecule-Org-Id"
 // here only bypasses the cross-org routing check, not auth.
 var tenantGuardAllowlist = map[string]struct{}{
 	"/health":             {},
+	"/buildinfo":          {},
 	"/metrics":            {},
 	"/registry/register":  {},
 	"/registry/heartbeat": {},

--- a/workspace-server/internal/middleware/tenant_guard_test.go
+++ b/workspace-server/internal/middleware/tenant_guard_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// helper: build a router with TenantGuard configured to `orgID` and two
-// representative routes — a regular API route and two allowlisted ones.
+// helper: build a router with TenantGuard configured to `orgID` and a
+// representative API route plus the public allowlisted ones (/health,
+// /buildinfo, /metrics).
 func newGuardedRouter(orgID string) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(TenantGuardWithOrgID(orgID))
 	r.GET("/health", func(c *gin.Context) { c.String(200, "ok") })
+	r.GET("/buildinfo", func(c *gin.Context) { c.String(200, "buildinfo") })
 	r.GET("/metrics", func(c *gin.Context) { c.String(200, "metrics") })
 	r.GET("/workspaces", func(c *gin.Context) { c.String(200, "workspaces") })
 	return r
@@ -71,10 +73,14 @@ func TestTenantGuard_MissingHeaderIs404(t *testing.T) {
 }
 
 // Allowlisted paths bypass the guard even in tenant mode — required for health
-// probes (Fly Machines checks) and Prometheus scrape.
+// probes (Fly Machines checks), Prometheus scrape, and the redeploy-fleet
+// /buildinfo verification step. /buildinfo without an org header used to
+// 404-via-NoRoute → canvas (HTML), which made the redeploy verifier think
+// every tenant was stale even when the binary was current. Pin this so a
+// future allowlist edit can't silently regress that check.
 func TestTenantGuard_AllowlistBypassesCheck(t *testing.T) {
 	r := newGuardedRouter("org-abc")
-	for _, path := range []string{"/health", "/metrics"} {
+	for _, path := range []string{"/health", "/buildinfo", "/metrics"} {
 		w := doRequest(r, path, "") // no header
 		if w.Code != 200 {
 			t.Errorf("%s: allowlisted path should return 200 without header, got %d", path, w.Code)


### PR DESCRIPTION
## Summary

The `/buildinfo` route added in #2398 to verify each tenant runs the published SHA was 404'd by TenantGuard on every production tenant — the allowlist had `/health`, `/metrics`, `/registry/register`, `/registry/heartbeat`, but not `/buildinfo`. The redeploy workflows curl `/buildinfo` from a CI runner with no `X-Molecule-Org-Id` header, TenantGuard 404'd them, gin's NoRoute proxied to canvas, canvas returned its HTML 404 page, jq read empty `git_sha`, and the verifier silently soft-warned every tenant as **unreachable** — which the workflow doesn't fail on.

Externally reproducible right now (pre-fix):

```
$ curl -i https://hongmingwang.moleculesai.app/buildinfo
HTTP/2 404
content-type: text/html; charset=utf-8
…<!DOCTYPE html>…<title>404: This page could not be found.</title>…

$ curl -i https://hongmingwang.moleculesai.app/health
HTTP/2 200
content-type: application/json; charset=utf-8
{"status":"ok"}
```

Same router, same middleware chain, same binary. The only difference: `/health` is in `tenantGuardAllowlist`, `/buildinfo` wasn't.

## Why this is safe

`internal/buildinfo/buildinfo.go` already declares this route public by design:

> Public is intentional: it's a build identifier, not operational state. The same string is already published as `org.opencontainers.image.revision` on the container image, so no new info is exposed.

The allowlist edit just makes the route reachable on tenant containers (where `MOLECULE_ORG_ID` is set). Self-hosted deploys are unchanged — the guard is a no-op there.

## Regression pin

`TestTenantGuard_AllowlistBypassesCheck` now asserts `/buildinfo` returns 200 without an org header alongside `/health` and `/metrics`. A future allowlist edit can't silently regress the verifier again.

## Impact

- redeploy-tenants-on-main `Verify each tenant /buildinfo matches published SHA` step has been silently soft-warning every tenant as unreachable since #2398 merged. After this lands, stale tenants will show up as **STALE** (hard-fail) rather than **UNREACHABLE** (soft-warn) — which is the behavior #2398 intended.
- Same applies to redeploy-tenants-on-staging.
- `scripts/ops/check-prod-versions.sh` (one-shot ops check, separate PR) will start returning real SHAs for tenant surfaces.

## Test plan

- [x] `go test ./internal/middleware/... -run TenantGuard` passes (12/12)
- [x] `TestTenantGuard_AllowlistBypassesCheck` now covers `/buildinfo`
- [ ] After staging promotion, curl `https://<staging-tenant>.staging.moleculesai.app/buildinfo` returns `{"git_sha":"<sha>"}` (expected: HTTP 200 JSON)
- [ ] Next redeploy-tenants-on-staging run shows actual per-tenant SHAs in the verifier table instead of "unreachable" rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)