### PR TITLE
fix(workspace): in-container heartbeat persists platform_inbound_secret

### DIFF
--- a/workspace/heartbeat.py
+++ b/workspace/heartbeat.py
@@ -91,6 +91,46 @@ def _runtime_metadata_payload() -> dict:
 
 logger = logging.getLogger(__name__)
 
+
+def _persist_inbound_secret_from_heartbeat(resp) -> None:
+    """Persist ``platform_inbound_secret`` from a heartbeat response, if any.
+
+    The platform's heartbeat handler (workspace-server PR #2421) returns
+    the secret on every beat — mirrors /registry/register so a workspace
+    whose secret was lazy-healed on the platform side picks it up within
+    one heartbeat tick instead of requiring a runtime restart.
+
+    Without this delivery path the chat-upload code path's "secret was
+    just minted, will pick up on next heartbeat" 503 message is a lie
+    and the workspace stays 401-forever until the operator restarts the
+    runtime. Caught 2026-04-30 on the hongmingwang tenant — the
+    standalone wrapper (mcp_cli.py) got the same change in #2421 but
+    the in-container heartbeat (this file) was missed in the first
+    pass.
+
+    Failure is non-fatal: if the body isn't JSON, doesn't carry the
+    field, or the disk write fails, the next heartbeat retries. This
+    matches the cold-start register flow in main.py:319-323.
+    """
+    try:
+        body = resp.json()
+    except Exception:
+        return
+    if not isinstance(body, dict):
+        return
+    secret = body.get("platform_inbound_secret")
+    if not secret:
+        return
+    try:
+        from platform_inbound_auth import save_inbound_secret
+
+        save_inbound_secret(secret)
+    except Exception as exc:
+        logger.warning(
+            "heartbeat: persist inbound secret failed: %s", exc
+        )
+
+
 HEARTBEAT_INTERVAL = 30  # seconds
 MAX_CONSECUTIVE_FAILURES = 10
 MAX_SEEN_DELEGATION_IDS = 200
@@ -172,7 +212,7 @@ class HeartbeatLoop:
                         # runtime_state to flip status → degraded.
                         body.update(_runtime_state_payload())
                         body.update(_runtime_metadata_payload())
-                        await client.post(
+                        resp = await client.post(
                             f"{self.platform_url}/registry/heartbeat",
                             json=body,
                             headers=auth_headers(),
@@ -180,6 +220,16 @@ class HeartbeatLoop:
                         self.error_count = 0
                         self.request_count = 0
                         self._consecutive_failures = 0
+                        # 2026-04-30: persist the platform_inbound_secret
+                        # if the heartbeat response carries one. Mirrors
+                        # the cold-start register flow in main.py:319-323
+                        # and closes the recovery path for workspaces
+                        # whose secret was lazy-healed on the platform
+                        # side after register-time. Without this, the
+                        # workspace stays 401-forever on chat upload
+                        # until restart. See workspace-server PR #2421
+                        # for the server-side delivery change.
+                        _persist_inbound_secret_from_heartbeat(resp)
                     except Exception as e:
                         self._consecutive_failures += 1
                         # Issue #1877: if heartbeat 401'd, re-read the token from disk
@@ -202,13 +252,14 @@ class HeartbeatLoop:
                                     "uptime_seconds": int(time.time() - self.start_time),
                                 }
                                 retry_body.update(_runtime_state_payload())
-                                await client.post(
+                                retry_resp = await client.post(
                                     f"{self.platform_url}/registry/heartbeat",
                                     json=retry_body,
                                     headers=auth_headers(),
                                 )
                                 self._consecutive_failures = 0
                                 self.request_count += 1
+                                _persist_inbound_secret_from_heartbeat(retry_resp)
                             except Exception:
                                 # Retry also failed — fall through to the normal
                                 # failure tracking below.

--- a/workspace/tests/test_heartbeat.py
+++ b/workspace/tests/test_heartbeat.py
@@ -355,3 +355,149 @@ def test_on_done_restarts_loop():
     mock_create.assert_called_once()
     # New task should have done callback
     mock_new_task.add_done_callback.assert_called_once()
+
+
+# ============== In-container heartbeat persists platform_inbound_secret (2026-04-30) ==============
+# Pairs with workspace-server PR #2421's heartbeat-delivers-secret change.
+# The standalone wrapper (mcp_cli.py) got persistence in #2421; the
+# in-container heartbeat (heartbeat.py) was missed and the symptom
+# returned: hongmingwang Claude Code agent stayed 401-forever on chat
+# upload because the workspace's runtime never picked up the lazy-healed
+# secret without a restart.
+
+import heartbeat as heartbeat_mod  # noqa: E402
+
+
+def test_persist_inbound_secret_happy_path(monkeypatch):
+    """200 with platform_inbound_secret in body → save_inbound_secret called."""
+
+    class FakeResp:
+        def json(self):
+            return {"status": "ok", "platform_inbound_secret": "fresh-secret"}
+
+    saved: list[str] = []
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", saved.append)
+
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+
+    assert saved == ["fresh-secret"]
+
+
+def test_persist_inbound_secret_skips_when_absent(monkeypatch):
+    class FakeResp:
+        def json(self):
+            return {"status": "ok"}
+
+    saved: list[str] = []
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", saved.append)
+
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+    assert saved == []
+
+
+def test_persist_inbound_secret_skips_on_empty(monkeypatch):
+    class FakeResp:
+        def json(self):
+            return {"status": "ok", "platform_inbound_secret": ""}
+
+    saved: list[str] = []
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", saved.append)
+
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+    assert saved == []
+
+
+def test_persist_inbound_secret_swallows_non_json(monkeypatch):
+    class FakeResp:
+        def json(self):
+            raise ValueError("not json")
+
+    saved: list[str] = []
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", saved.append)
+
+    # Must not raise
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+    assert saved == []
+
+
+def test_persist_inbound_secret_handles_non_dict(monkeypatch):
+    class FakeResp:
+        def json(self):
+            return ["unexpected", "list"]
+
+    saved: list[str] = []
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", saved.append)
+
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+    assert saved == []
+
+
+def test_persist_inbound_secret_swallows_save_oserror(monkeypatch):
+    class FakeResp:
+        def json(self):
+            return {"platform_inbound_secret": "x"}
+
+    def boom(_secret):
+        raise OSError("disk full")
+
+    import platform_inbound_auth
+
+    monkeypatch.setattr(platform_inbound_auth, "save_inbound_secret", boom)
+
+    # Heartbeat liveness > secret persistence — must not raise.
+    heartbeat_mod._persist_inbound_secret_from_heartbeat(FakeResp())
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_persists_secret_from_response(monkeypatch):
+    """End-to-end: in-container _loop persists secret when the heartbeat
+    response carries platform_inbound_secret."""
+    saved: list[str] = []
+
+    def fake_persist(resp):
+        try:
+            body = resp.json()
+        except Exception:
+            return
+        if isinstance(body, dict) and body.get("platform_inbound_secret"):
+            saved.append(body["platform_inbound_secret"])
+
+    monkeypatch.setattr(
+        heartbeat_mod,
+        "_persist_inbound_secret_from_heartbeat",
+        fake_persist,
+    )
+
+    hb = HeartbeatLoop("http://platform:8080", "ws-abc")
+
+    mock_response = MagicMock()
+    mock_response.json = MagicMock(
+        return_value={"status": "ok", "platform_inbound_secret": "from-heartbeat"}
+    )
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("heartbeat.httpx.AsyncClient", return_value=mock_client):
+        task = asyncio.create_task(hb._loop())
+        await asyncio.sleep(0.05)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert saved == ["from-heartbeat"], (
+        "in-container heartbeat must persist platform_inbound_secret from 200 response"
+    )


### PR DESCRIPTION
## Summary

**Follow-up to PR #2421** which delivered the secret on the wire but only patched the standalone `mcp_cli.py` heartbeat client. The in-container heartbeat at `workspace/heartbeat.py` — the path every workspace EC2 actually runs — was missed.

## Symptom (post-#2421 deploy)

After PR #2421 shipped to production, hongmingwang's Claude Code agent **still 401-failed** on chat upload. Server-side delivery worked, but the in-container `_loop` discards `await client.post(...)`'s response, so the freshly-minted secret never landed on disk.

Screenshot from user reproducing the bug: `Upload failed: upload failed: 401 {"error":"unauthorized"}` on `hongmingwang.moleculesai.app/buildinfo` SHA `ce7698ef` (the merge commit that included #2421).

## Changes

`workspace/heartbeat.py`:
- `_loop` now captures the response from both the primary POST and the 401-retry POST.
- New `_persist_inbound_secret_from_heartbeat(resp)` helper mirrors the one added to `mcp_cli.py` in #2421: parses JSON, validates dict + non-empty string, calls `platform_inbound_auth.save_inbound_secret`.
- All error paths swallowed (non-JSON, non-dict, empty, save OSError) — heartbeat liveness contract trumps secret persistence.

## Tests

`workspace/tests/test_heartbeat.py` (+7 tests, all passing alongside the existing 16):
- Happy path — secret in body persists
- Absent secret — no save call
- Empty string — no save call
- Non-JSON body — swallowed, no save call
- Non-dict body (list) — swallowed, no save call
- `save_inbound_secret` raises OSError — swallowed, no crash
- End-to-end `_loop` invokes persist with secret from response

## Test plan

- [x] `pytest workspace/tests/test_heartbeat.py` — 23/23 green
- [ ] After deploy: `hongmingwang.moleculesai.app` chat upload stops 401-ing within ≤30s of redeploy (heartbeat cadence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)