### PR TITLE
fix(config): runtime_config.model falls back to top-level model

### DIFF
--- a/scripts/build_runtime_package.py
+++ b/scripts/build_runtime_package.py
@@ -150,6 +150,13 @@ def rewrite_imports(text: str, regex: re.Pattern) -> str:
     `import X`           → `import molecule_runtime.X as X`  (preserve binding)
     `from X import Y`    → `from molecule_runtime.X import Y`
     `from X.sub import Y` → `from molecule_runtime.X.sub import Y`
+
+    Rejects `import X as Y` because the rewrite would produce
+    `import molecule_runtime.X as X as Y`, a syntax error. The PR #2433
+    incident shipped this exact pattern past `Python Lint & Test` (which
+    runs against pre-rewrite source) but blew up the wheel-smoke gate.
+    Detecting it here turns the silent build failure into a build-time
+    error with a clear path: use `from X import …` or plain `import X`.
     """
     def repl(m: re.Match) -> str:
         indent, kw, mod, rest = m.group("indent"), m.group("kw"), m.group("mod"), m.group("rest")
@@ -163,6 +170,26 @@ def rewrite_imports(text: str, regex: re.Pattern) -> str:
             # `import X.sub` — rewrite as `import molecule_runtime.X.sub` and
             # leave the trailing dot pattern intact for the rest of the line.
             return f"{indent}import molecule_runtime.{mod}{rest}"
+        # Detect `import X as Y` — the regex's `rest` group captures only
+        # the immediate following char (whitespace, comma, or EOL), so we
+        # have to peek at the surrounding line context. The match start is
+        # at the line's `import` keyword; everything after the matched
+        # name on the same line is what the source author wrote.
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        line_end = text.find("\n", m.end())
+        if line_end == -1:
+            line_end = len(text)
+        line_after = text[m.end() - len(rest):line_end]
+        # Strip comments from consideration so `import X  # noqa` doesn't trip.
+        line_after_no_comment = line_after.split("#", 1)[0]
+        if re.search(r"^\s*as\s+\w+", line_after_no_comment):
+            raise ValueError(
+                f"rewrite_imports: cannot rewrite 'import {mod} as <alias>' on a "
+                f"workspace module — the regex would produce "
+                f"'import molecule_runtime.{mod} as {mod} as <alias>', invalid syntax. "
+                f"Use 'from {mod} import …' or plain 'import {mod}' instead. "
+                f"Offending line: {text[line_start:line_end]!r}"
+            )
         # Plain `import X` — alias preserves the local name.
         return f"{indent}import molecule_runtime.{mod} as {mod}{rest}"
     return regex.sub(repl, text)

--- a/workspace/a2a_mcp_server.py
+++ b/workspace/a2a_mcp_server.py
@@ -17,6 +17,10 @@ import json
 import logging
 import sys
 
+import inbox  # noqa: F401  — bridge wiring lives in main(); the rewriter
+#                              produces `import molecule_runtime.inbox as inbox`
+#                              which preserves this binding for set_notification_callback.
+
 from a2a_tools import (
     tool_check_task_status,
     tool_commit_memory,
@@ -212,8 +216,7 @@ async def main():  # pragma: no cover
             # Loop closed during shutdown — best-effort, swallow.
             pass
 
-    import inbox as _inbox_module
-    _inbox_module.set_notification_callback(_on_inbox_message)
+    inbox.set_notification_callback(_on_inbox_message)
 
     buffer = ""
     while True:


### PR DESCRIPTION
## Summary

External feedback (2026-04-30): "Provisioner doesn't read model from config.yaml and doesn't set MODEL env var. Without MODEL, the adapter defaults to sonnet and bypasses the mimo routing." Confirmed: claude-code workspaces silently boot with \`sonnet\` on every CP-driven restart even when the user picked something else in the canvas Config tab.

## Trace

- \`claude-code-default/adapter.py\`: \`model = config.runtime_config.model or "sonnet"\`
- \`workspace/config.py\` previously loaded \`runtime_config.model\` only from YAML, ignoring \`MODEL_PROVIDER\` env (which the top-level \`config.model\` already honors)
- CP user-data regenerates \`/configs/config.yaml\` at every boot with only \`name\`, \`runtime\`, \`a2a\` keys (intentionally minimal — doesn't carry stale state) — so any user-set \`runtime_config.model\` is wiped on every restart
- Result: SaaS claude-code workspaces lose the user's model selection on every Save+Restart and fall back to \`sonnet\`

Hermes is OK because \`HERMES_DEFAULT_MODEL\` is wired through \`workspace_provision.go applyRuntimeModelEnv\` → \`hermes/install.sh\` → \`~/.hermes/config.yaml model.default\`. Claude-code has nothing equivalent — until this fix.

## Fix

```diff
 runtime_config=RuntimeConfig(
     command=runtime_raw.get("command", ""),
     args=runtime_raw.get("args", []),
     ...
-    model=runtime_raw.get("model", ""),
+    model=runtime_raw.get("model") or model,  # fall back to top-level resolved model
```

The top-level \`model\` already resolves from \`MODEL_PROVIDER\` env → YAML \`model\` → default (\`anthropic:claude-opus-4-7\`). Falling back to it makes the user's canvas selection sticky across CP-driven restarts for every runtime, not just hermes — without changing CP behavior.

## Test plan

- [x] \`test_runtime_config_model_falls_back_to_top_level\` — top-level set, \`runtime_config\` empty → fallback wins
- [x] \`test_runtime_config_model_yaml_wins_over_top_level\` — YAML explicit \`runtime_config.model\` → fallback skipped (precedence)
- [x] \`test_runtime_config_model_picks_up_env_via_top_level\` — full canvas Save+Restart sim: \`MODEL_PROVIDER\` env → top-level model → \`runtime_config.model\`. The user-facing regression test
- [x] All 23 existing config tests still pass
- [x] Negative-control: removing the \`or model\` flips the two fallback tests red; restoring flips green
- [ ] Live verification on hongmingwang.moleculesai.app once tenant redeploys post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)