### PR TITLE
docs(mcp): correct server.ts reference + flag verification gap

### DIFF
--- a/workspace/a2a_mcp_server.py
+++ b/workspace/a2a_mcp_server.py
@@ -152,16 +152,28 @@ _CHANNEL_NOTIFICATION_METHOD = "notifications/claude/channel"
 def _build_initialize_result() -> dict:
     """MCP initialize handshake result.
 
-    The ``experimental.claude/channel`` capability declaration is what
-    tells Claude Code's MCP client to route our
-    ``notifications/claude/channel`` emissions as conversation
-    interrupts (push UX). Without it the notification arrives over the
-    wire but is silently dropped instead of becoming a ``<channel>``
-    tag in the next agent turn — matching the
-    "Notification arrives but Claude Code doesn't surface it" failure
-    mode anticipated in molecule-core#2444. Mirrors the contract
-    declared by the molecule-mcp-claude-channel bun bridge
-    (server.ts:374).
+    Declares ``experimental.claude/channel`` as a *hypothesized*
+    contract for routing ``notifications/claude/channel`` emissions
+    into Claude Code as conversation interrupts (push UX). The
+    failure mode from molecule-core#2444 §2 — "notification arrives
+    over the wire but is silently dropped instead of becoming a
+    ``<channel>`` tag" — motivated this declaration.
+
+    UNVERIFIED: end-to-end push delivery has not been confirmed since
+    this capability was added. Counter-evidence: the
+    molecule-mcp-claude-channel bun bridge declares only
+    ``{ capabilities: { tools: {} } }`` (server.ts:475 — NOT line 374
+    as the original commit message claimed; line 374 is unrelated
+    poll-init code) and is reported to deliver
+    ``notifications/claude/channel`` successfully in Claude Code.
+    The MCP SDK's ``assertNotificationCapability`` also does not gate
+    custom (non-spec) notification methods on a declared capability,
+    so server-side this declaration is likely a no-op. If push UX is
+    still missing after this ships, the real fault probably lives
+    in writer.drain swallowing on closed pipes, the inbox-thread →
+    asyncio loop bridge, or initialize-ordering between the inbox
+    callback and the MCP transport — not in this handshake. Treat
+    this as belt-and-braces until verified.
     """
     return {
         "protocolVersion": "2024-11-05",


### PR DESCRIPTION
## Summary

Follow-up to PR #2461 (commit `0a87dec5`), which was merged before live verification. Two doc-only corrections to the `_build_initialize_result()` docstring in `workspace/a2a_mcp_server.py`:

- **Wrong line reference.** The original claimed "mirrors molecule-mcp-claude-channel server.ts:374". Line 374 is unrelated poll-init code. The actual capability declaration site is server.ts:475 — and crucially, the bun bridge there declares only `{ capabilities: { tools: {} } }`. No `experimental.claude/channel`. The bridge is reported to deliver `notifications/claude/channel` successfully in Claude Code anyway, which directly contradicts the "capability is required for push UX" hypothesis.
- **MCP SDK doesn't gate custom notification methods.** `@modelcontextprotocol/sdk`'s `assertNotificationCapability` has no case for `notifications/claude/channel`, so server-side, declaring the capability is almost certainly a no-op.

The capability declaration stays in place (additive, the new tests pin its presence) but the docstring is downgraded from "this is what fixes push UX" to "hypothesized, unverified, and the more likely root causes are X / Y / Z."

## Why now

The next person to debug "Claude Code receives our notification but doesn't surface it" needs to know the experimental capability is *probably not the answer*, so they pursue:
- `writer.drain()` swallowing exceptions on a closed pipe
- inbox-thread → `asyncio.run_coroutine_threadsafe` race during init
- MCP transport not yet attached when the first inbox event fires

Live verification (#2444 §2 — fresh Claude Code session on this wheel + peer A2A message, observe interrupt) remains the open hard-gate.

## Test plan

- [x] Docstring-only change; no behavior touched
- [x] Existing tests still pass (`workspace/tests/test_a2a_mcp_server.py` — 21/21)
- [ ] Required check: runtime-pin-compat green
- [ ] Required check: ci.yml green
- [ ] Required check: codeql green

🤖 Generated with [Claude Code](https://claude.com/claude-code)