### PR TITLE
docs(mcp): tagged server:NAME form in dev-channels reference

### DIFF
--- a/workspace/a2a_mcp_server.py
+++ b/workspace/a2a_mcp_server.py
@@ -178,8 +178,9 @@ def _poll_timeout_secs() -> int:
     except ValueError:
         return _DEFAULT_POLL_TIMEOUT_SECS
     # Clamp to sane bounds: 0 disables polling (push-only mode for
-    # operators who pin Claude Code with --dangerously-load-development-
-    # channels), 60s caps the per-turn stall.
+    # operators who pin Claude Code with
+    # `--dangerously-load-development-channels server:<mcp-server-name>`),
+    # 60s caps the per-turn stall.
     if value < 0:
         return _DEFAULT_POLL_TIMEOUT_SECS
     return min(value, 60)
@@ -205,8 +206,10 @@ def _build_channel_instructions() -> str:
         "Polling is disabled in this workspace "
         "(MOLECULE_MCP_POLL_TIMEOUT_SECS=0). The host is expected to "
         "deliver inbound messages via push tags only — typically "
-        "Claude Code launched with --dangerously-load-development-"
-        "channels or an allowlisted channel server name."
+        "Claude Code launched with "
+        "`--dangerously-load-development-channels server:<mcp-server-name>` "
+        "(the tag is required since Claude Code 2.1.x; bare-flag launches "
+        "are rejected) or an allowlisted channel server name."
     )
     return (
         "Inbound canvas-user and peer-agent messages have two delivery "


### PR DESCRIPTION
## Summary

Claude Code 2.1.x's \`--dangerously-load-development-channels\` takes an allowlist of tagged entries (\`server:<name>\` or \`plugin:<name>@<marketplace>\`), not a bare switch. Two strings in the wheel referenced the old bare form:

- The push-only-mode message in \`_build_channel_instructions()\` (read by every agent at \`initialize\`)
- The clamp-bounds comment in \`_poll_timeout_secs()\`

Update both to the tagged form so an agent or operator reading them lands on the right invocation. String-only edits — no behavior change.

Paired with [molecule-docs PR #110](https://github.com/Molecule-AI/docs/pull/110) which updates the operator-facing runtime-mcp.mdx the same way.

## Test plan

- [x] \`pytest workspace/tests/test_a2a_mcp_server.py\` — 33 pass
- [x] Verified the new wording matches the user-confirmed live invocation from 2026-05-01: \`claude --dangerously-load-development-channels server:molecule\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)