### PR TITLE
fix(mcp): friendly fail-fast when stdio isn't pipe-compatible

### DIFF
--- a/workspace/a2a_mcp_server.py
+++ b/workspace/a2a_mcp_server.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import os
+import stat
 import sys
 from typing import Callable
 
@@ -393,6 +394,52 @@ def _build_channel_notification(msg: dict) -> dict:
 
 # --- MCP Server (JSON-RPC over stdio) ---
 
+
+def _assert_stdio_is_pipe_compatible(
+    stdin_fd: int = 0, stdout_fd: int = 1
+) -> None:
+    """Fail fast with a friendly message when stdio isn't pipe-compatible.
+
+    asyncio.connect_read_pipe / connect_write_pipe accept only pipes,
+    sockets, and character devices. When molecule-mcp is launched with
+    stdout redirected to a regular file (CI smoke tests, ad-hoc local
+    debugging that captures output), the asyncio call later raises
+    ``ValueError: Pipe transport is only for pipes, sockets and character
+    devices`` from inside the event loop — surfaced to the operator as a
+    confusing traceback. Detect early and exit cleanly with guidance
+    instead. See molecule-ai-workspace-runtime#61.
+    """
+    for name, fd in (("stdin", stdin_fd), ("stdout", stdout_fd)):
+        try:
+            mode = os.fstat(fd).st_mode
+        except OSError as exc:
+            print(
+                f"molecule-mcp: cannot stat {name} (fd={fd}): {exc}.\n"
+                f"  This MCP server expects bidirectional pipe stdio. Launch it from\n"
+                f"  an MCP-aware client (Claude Code, Cursor, etc.) — not detached\n"
+                f"  from a terminal or with stdio closed.",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        if not (
+            stat.S_ISFIFO(mode) or stat.S_ISSOCK(mode) or stat.S_ISCHR(mode)
+        ):
+            print(
+                f"molecule-mcp: {name} (fd={fd}) is a regular file, not a pipe,\n"
+                f"  socket, or character device — asyncio's stdio transport rejects\n"
+                f"  it with `ValueError: Pipe transport is only for pipes, sockets\n"
+                f"  and character devices`. Common causes:\n"
+                f"      molecule-mcp > out.txt           # stdout → regular file (fails)\n"
+                f"      molecule-mcp < input.json        # stdin  → regular file (fails)\n"
+                f"  Launch molecule-mcp from an MCP-aware client (Claude Code, Cursor,\n"
+                f"  hermes, OpenCode, etc.) so stdio is wired to a pipe pair, or use\n"
+                f"  `tee`/process substitution if you need to capture output:\n"
+                f"      molecule-mcp 2>&1 | tee out.txt  # stdout stays a pipe",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+
+
 async def main():  # pragma: no cover
     """Run MCP server on stdio — reads JSON-RPC requests, writes responses."""
     reader = asyncio.StreamReader()
@@ -496,6 +543,7 @@ def cli_main() -> None:  # pragma: no cover
     break every external-runtime operator's MCP install — the 0.1.16
     ``main_sync`` rename incident is the cautionary precedent.
     """
+    _assert_stdio_is_pipe_compatible()
     asyncio.run(main())
 
 

--- a/workspace/tests/test_a2a_mcp_server.py
+++ b/workspace/tests/test_a2a_mcp_server.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import json
+import os
 
 from unittest.mock import AsyncMock, patch
 
@@ -716,6 +717,104 @@ def test_inbox_bridge_swallows_closed_loop_runtime_error():
         "method": "",
         "created_at": "",
     })
+
+
+class TestStdioPipeAssertion:
+    """Pin _assert_stdio_is_pipe_compatible — the friendly fail-fast guard
+    that turns asyncio's `ValueError: Pipe transport is only for pipes,
+    sockets and character devices` into a clear operator message + exit 2.
+    See molecule-ai-workspace-runtime#61.
+    """
+
+    def test_pipe_pair_passes_silently(self):
+        """Happy path — both fds are pipes (the production launch shape
+        from any MCP client). Should return None without printing or
+        exiting."""
+        import a2a_mcp_server
+
+        r, w = os.pipe()
+        try:
+            # No exit, no stderr noise. We don't capture stderr here
+            # because pipe path should produce zero output.
+            a2a_mcp_server._assert_stdio_is_pipe_compatible(stdin_fd=r, stdout_fd=w)
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_regular_file_stdout_exits_with_friendly_message(
+        self, tmp_path, capsys
+    ):
+        """Reproducer for runtime#61: stdout redirected to a regular file.
+        Pre-fix this would surface upstream as
+        `ValueError: Pipe transport is only for pipes...`. Post-fix we
+        exit with code 2 and a stderr message that names the symptom +
+        fix."""
+        import a2a_mcp_server
+
+        # stdin = pipe (so we isolate the stdout failure path);
+        # stdout = regular file (the bug condition).
+        r, _w = os.pipe()
+        regular = tmp_path / "captured.log"
+        f = open(regular, "wb")
+        try:
+            with pytest.raises(SystemExit) as excinfo:
+                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                    stdin_fd=r, stdout_fd=f.fileno()
+                )
+            assert excinfo.value.code == 2
+            err = capsys.readouterr().err
+            # Names the failing stream + the asyncio constraint that
+            # would otherwise crash. Don't pin the exact wording — the
+            # asserts pin the operator-recoverable signal only.
+            assert "stdout" in err
+            assert "regular file" in err
+            assert "pipe" in err
+        finally:
+            f.close()
+            os.close(r)
+
+    def test_regular_file_stdin_exits_with_friendly_message(
+        self, tmp_path, capsys
+    ):
+        """Symmetric case — stdin redirected from a regular file. Same
+        asyncio constraint applies via connect_read_pipe."""
+        import a2a_mcp_server
+
+        regular = tmp_path / "input.json"
+        regular.write_bytes(b'{"jsonrpc":"2.0","id":1,"method":"initialize"}\n')
+        f = open(regular, "rb")
+        _r, w = os.pipe()
+        try:
+            with pytest.raises(SystemExit) as excinfo:
+                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                    stdin_fd=f.fileno(), stdout_fd=w
+                )
+            assert excinfo.value.code == 2
+            err = capsys.readouterr().err
+            assert "stdin" in err
+            assert "regular file" in err
+        finally:
+            f.close()
+            os.close(w)
+
+    def test_closed_fd_exits_with_stat_error(self, capsys):
+        """If stdio is closed (rare but seen in detached daemonized
+        contexts), os.fstat raises OSError. We catch it and exit 2 with
+        a guidance message instead of letting the traceback escape."""
+        import a2a_mcp_server
+
+        r, w = os.pipe()
+        os.close(w)  # Now `w` is a stale fd — fstat will fail.
+        try:
+            with pytest.raises(SystemExit) as excinfo:
+                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                    stdin_fd=r, stdout_fd=w
+                )
+            assert excinfo.value.code == 2
+            err = capsys.readouterr().err
+            assert "cannot stat stdout" in err
+        finally:
+            os.close(r)
 
 
 def _readable(fd: int) -> bool:

--- a/workspace/tests/test_a2a_mcp_server.py
+++ b/workspace/tests/test_a2a_mcp_server.py
@@ -730,13 +730,13 @@ class TestStdioPipeAssertion:
         """Happy path — both fds are pipes (the production launch shape
         from any MCP client). Should return None without printing or
         exiting."""
-        import a2a_mcp_server
+        from a2a_mcp_server import _assert_stdio_is_pipe_compatible
 
         r, w = os.pipe()
         try:
             # No exit, no stderr noise. We don't capture stderr here
             # because pipe path should produce zero output.
-            a2a_mcp_server._assert_stdio_is_pipe_compatible(stdin_fd=r, stdout_fd=w)
+            _assert_stdio_is_pipe_compatible(stdin_fd=r, stdout_fd=w)
         finally:
             os.close(r)
             os.close(w)
@@ -749,7 +749,7 @@ class TestStdioPipeAssertion:
         `ValueError: Pipe transport is only for pipes...`. Post-fix we
         exit with code 2 and a stderr message that names the symptom +
         fix."""
-        import a2a_mcp_server
+        from a2a_mcp_server import _assert_stdio_is_pipe_compatible
 
         # stdin = pipe (so we isolate the stdout failure path);
         # stdout = regular file (the bug condition).
@@ -758,7 +758,7 @@ class TestStdioPipeAssertion:
         f = open(regular, "wb")
         try:
             with pytest.raises(SystemExit) as excinfo:
-                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                _assert_stdio_is_pipe_compatible(
                     stdin_fd=r, stdout_fd=f.fileno()
                 )
             assert excinfo.value.code == 2
@@ -778,7 +778,7 @@ class TestStdioPipeAssertion:
     ):
         """Symmetric case — stdin redirected from a regular file. Same
         asyncio constraint applies via connect_read_pipe."""
-        import a2a_mcp_server
+        from a2a_mcp_server import _assert_stdio_is_pipe_compatible
 
         regular = tmp_path / "input.json"
         regular.write_bytes(b'{"jsonrpc":"2.0","id":1,"method":"initialize"}\n')
@@ -786,7 +786,7 @@ class TestStdioPipeAssertion:
         _r, w = os.pipe()
         try:
             with pytest.raises(SystemExit) as excinfo:
-                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                _assert_stdio_is_pipe_compatible(
                     stdin_fd=f.fileno(), stdout_fd=w
                 )
             assert excinfo.value.code == 2
@@ -801,13 +801,13 @@ class TestStdioPipeAssertion:
         """If stdio is closed (rare but seen in detached daemonized
         contexts), os.fstat raises OSError. We catch it and exit 2 with
         a guidance message instead of letting the traceback escape."""
-        import a2a_mcp_server
+        from a2a_mcp_server import _assert_stdio_is_pipe_compatible
 
         r, w = os.pipe()
         os.close(w)  # Now `w` is a stale fd — fstat will fail.
         try:
             with pytest.raises(SystemExit) as excinfo:
-                a2a_mcp_server._assert_stdio_is_pipe_compatible(
+                _assert_stdio_is_pipe_compatible(
                     stdin_fd=r, stdout_fd=w
                 )
             assert excinfo.value.code == 2


### PR DESCRIPTION
## Summary

External feedback on [molecule-ai-workspace-runtime#61](https://github.com/Molecule-AI/molecule-ai-workspace-runtime/issues/61): when `molecule-mcp` is launched with stdout redirected to a regular file (CI smoke-tests, ad-hoc local debugging that captures output), the async stdio loop crashes with an opaque traceback:

```
ValueError: Pipe transport is only for pipes, sockets and character devices
```

`asyncio.connect_read_pipe` / `connect_write_pipe` only accept pipe / socket / char-device file descriptors; a regular file fd silently fails the transport check after the event loop is already running. The user sees a multi-frame traceback with no actionable guidance.

## Fix

Add a synchronous `_assert_stdio_is_pipe_compatible()` helper that runs before `asyncio.run(main())` in `cli_main()`:

- Calls `os.fstat()` on fd 0 and fd 1, checks `stat.S_ISFIFO/S_ISSOCK/S_ISCHR` mode bits.
- If either fd is a regular file, prints a stderr message that names the failing stream + the asyncio constraint + the two common causes (`> file`, `< file`) + a working alternative (`tee`), then exits with code 2.
- If `os.fstat` itself raises `OSError` (closed/stale fd — rare but seen in detached daemonized contexts), same exit behavior with a stat-error message.

The async `main()` body is unchanged; the guard sits in the sync entry point so wheel-smoke and production launches both flow through it.

## Why this approach over a raw-fd fallback

The issue suggested either friendly-error or fall back to `os.fdopen(1, 'wb', buffering=0)`. The fallback only helps the *output* path — the *input* path has the same constraint via `connect_read_pipe`, and a one-way fallback can't actually serve JSON-RPC, so the fallback would just postpone the crash. Friendly-error is honest about the constraint and gives operators an actionable next step.

## Tests

`TestStdioPipeAssertion` (4 new tests, all in `tests/test_a2a_mcp_server.py`):

- `test_pipe_pair_passes_silently` — happy path, both fds are pipes (production launch shape from any MCP client). Returns `None`, prints nothing.
- `test_regular_file_stdout_exits_with_friendly_message` — reproducer for runtime#61. Asserts `SystemExit(2)` and that the stderr names \"stdout\" + \"regular file\" + \"pipe\".
- `test_regular_file_stdin_exits_with_friendly_message` — symmetric case for the read path.
- `test_closed_fd_exits_with_stat_error` — closed-fd corner case. Asserts \"cannot stat stdout\" appears on stderr.

**Mutation-verified:** with the prod helper stashed out, all 4 tests fail (`AttributeError: module 'a2a_mcp_server' has no attribute '_assert_stdio_is_pipe_compatible'`). 37/37 pass with the helper restored.

## Test plan

- [x] `WORKSPACE_ID=test-ws PLATFORM_URL=http://localhost MOLECULE_WORKSPACE_TOKEN=t pytest tests/test_a2a_mcp_server.py` → 37 passed
- [x] Mutation test — fix removed → 4 fail; fix restored → 4 pass
- [ ] CI on this branch
- [ ] Manual smoke: `molecule-mcp > out.txt` exits with the friendly message instead of the asyncio traceback

Closes Molecule-AI/molecule-ai-workspace-runtime#61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)