### PR TITLE
chore(tests): drop redundant local _reset fixture from test_runtime_wedge

### DIFF
--- a/workspace/tests/test_runtime_wedge.py
+++ b/workspace/tests/test_runtime_wedge.py
@@ -5,19 +5,13 @@ to its template repo without breaking heartbeat.
 
 The behavior is identical to the prior in-executor implementation; tests
 pin the contract so the re-export shim in claude_sdk_executor.py can
-later be deleted without surprise."""
-import pytest
+later be deleted without surprise.
 
+Cross-test isolation is provided by the autouse
+`_reset_runtime_wedge_between_tests` fixture in workspace/tests/conftest.py
+— this file does not need a local reset fixture.
+"""
 import runtime_wedge
-
-
-@pytest.fixture(autouse=True)
-def _reset():
-    """Each test starts with a clean wedge state — production wedges are
-    sticky-per-process, but cross-test bleed would couple unrelated cases."""
-    runtime_wedge.reset_for_test()
-    yield
-    runtime_wedge.reset_for_test()
 
 
 class TestRuntimeWedge:


### PR DESCRIPTION
## Summary
- The autouse \`_reset_runtime_wedge_between_tests\` fixture in workspace/tests/conftest.py (added in PR #2475) covers every test in this directory.
- The local \`@pytest.fixture(autouse=True) _reset\` in test_runtime_wedge.py became dead-but-harmless — both autouse fixtures ran on every test, double-resetting via idempotent ops.
- Drop the local copy so future maintainers don't have to keep two definitions in sync.

## Why this exists

Caught during a deeper /code-review-and-quality pass on the #2475 follow-ups — the original PR landed the conftest fixture but missed the dedup of the now-redundant in-file fixture. Clean-up only — no behavior change.

## Test plan
- [x] \`pytest workspace/tests/test_runtime_wedge.py workspace/tests/test_smoke_mode.py\` → 34 passed, 2 skipped
- [x] Conftest autouse fixture continues to reset wedge state pre+post every test in workspace/tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)