### PR TITLE
docs(readme): fix clone + deploy URLs after molecule-core rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@
   <a href="./docs/agent-runtime/workspace-runtime.md"><strong>Workspace Runtime</strong></a>
 </p>
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/Molecule-AI/molecule-core)
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Molecule-AI/molecule-core)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/Molecule-AI/molecule-monorepo)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Molecule-AI/molecule-monorepo)
 
 </div>
 
@@ -249,8 +249,8 @@ Workspace Runtime (Python image with adapters)
 ## Quick Start
 
 ```bash
-git clone https://github.com/Molecule-AI/molecule-core.git
-cd molecule-core
+git clone https://github.com/Molecule-AI/molecule-monorepo.git
+cd molecule-monorepo
 
 cp .env.example .env
 # Defaults boot the stack locally out of the box. See .env.example for


### PR DESCRIPTION
## Summary

The repo was renamed from `molecule-core` to `molecule-monorepo`. README still pointed to the old URL in four places, which would 404 the Railway/Render deploy buttons (template URLs aren't resolved through GitHub redirects on those hosts) and silently mislead anyone copy-pasting the Quick Start clone command.

## URLs changed

All four refs are about cloning/deploying THIS repo (canvas + workspace runtime monorepo). None are about orchestration/control plane, so all four go to `molecule-monorepo` (not `molecule-controlplane`).

| Line | Before | After |
|---|---|---|
| 42 | `railway.app/new/template?template=https://github.com/Molecule-AI/molecule-core` | `…/Molecule-AI/molecule-monorepo` |
| 43 | `render.com/deploy?repo=https://github.com/Molecule-AI/molecule-core` | `…/Molecule-AI/molecule-monorepo` |
| 252 | `git clone https://github.com/Molecule-AI/molecule-core.git` | `git clone https://github.com/Molecule-AI/molecule-monorepo.git` |
| 253 | `cd molecule-core` | `cd molecule-monorepo` |

## Why not molecule-controlplane?

The Quick Start clone bootstraps the Canvas (Next.js) + workspace-server (Go) + workspace runtime (Python) stack — all of which live in this repo. `molecule-controlplane` is the new primary repo for orchestration as of the 2026-04-27 handover, but it isn't what the deploy buttons or local-dev clone are pointing at. Out of scope for this PR.

## Out of scope

Other potentially stale things in the README (e.g. references to "what ships in main" given the controlplane handover) are intentionally not touched here. Separate PR if needed.

## Test plan

- [ ] Click Deploy on Railway button on the rendered staging README — resolves to molecule-monorepo template
- [ ] Click Deploy to Render button — resolves to molecule-monorepo
- [ ] Copy-paste Quick Start clone command — clones successfully