### PR TITLE
docs(internal): refresh workspace-runtime-package + backends parity + workspace-terminal dead link

### DIFF
--- a/docs/architecture/backends.md
+++ b/docs/architecture/backends.md
@@ -2,7 +2,7 @@
 
 **Status:** living document — update when you ship a feature that touches one backend.
 **Owner:** workspace-server + controlplane teams.
-**Last audit:** 2026-04-23 (Claude agent, PR #TBD).
+**Last audit:** 2026-05-02 (Claude agent, PR #TBD).
 
 ## Why this exists
 
@@ -37,6 +37,12 @@ This document is the canonical matrix. If you are landing a workspace-facing fea
 | **A2A proxy** | | | | |
 | Forward | `a2a_proxy.go` | `127.0.0.1:<port>` | EC2 private IP inside tenant VPC | ✅ parity |
 | Liveness | `a2a_proxy_helpers.go` | `provisioner.IsRunning()` | `cpProv.IsRunning()` (DB-backed) | ✅ parity |
+| Channel envelope enrichment (peer_name / peer_role / agent_card_url) | `a2a_proxy.go` + workspace-runtime channel emitter (PR #2471) | inbox row carries enriched fields | inbox row carries enriched fields | ✅ parity as of 2026-05-02 |
+| **MCP tools (a2a)** | | | | |
+| `chat_history` — fetch prior turns with a peer | `mcp_server.go` + workspace-runtime `a2a_mcp` (PR #2474) | runtime-served, backend-agnostic | runtime-served, backend-agnostic | ✅ parity as of 2026-05-02 |
+| **Activity API** | | | | |
+| `before_ts` paging on `/workspaces/:id/activity` | `activity.go` (PR #2476) | DB-driven | DB-driven | ✅ parity as of 2026-05-02 |
+| `peer_id` filter on `/workspaces/:id/activity` | `activity.go` (PR #2472) | DB-driven | DB-driven | ✅ parity as of 2026-05-02 |
 | **Config / template injection** | | | | |
 | Template copy at provision | `provisioner.go:553-648` | host walk → tar → `CopyToContainer(/configs)` | CP user-data bakes template into bootstrap script | ⚠️ divergent — sync (docker) vs async (EC2) |
 | Runtime config hot-reload | `templates.go` + handlers | no hot-reload — restart required | no hot-reload — restart required | ✅ parity (both require restart; acceptable) |
@@ -45,6 +51,9 @@ This document is the canonical matrix. If you are landing a workspace-facing fea
 | **Bootstrap signals** | | | | |
 | Ready detection | registry `/registry/register` | container heartbeat | tenant heartbeat + boot-event phone-home (CP `bootevents` table + `wait_platform_health=ok`) | ✅ parity as of molecule-controlplane#235 |
 | Console / log output | `workspace_bootstrap.go` | `docker logs` | `ec2:GetConsoleOutput` via CP proxy | 🟡 ec2-only (docker has `docker logs` directly; no unified API) |
+| `runtime_wedge` post-`execute()` smoke gate | workspace-runtime `smoke_mode.py` (PRs #2473 + #2475) | runtime-served, surfaces SDK-init wedges to wheel-smoke + container start | runtime-served, surfaces SDK-init wedges to wheel-smoke + container start | ✅ parity as of 2026-05-02 |
+| **Test infrastructure** | | | | |
+| Canvas-E2E `.playwright-staging-state.json` written before any CP call | `tools/e2e-staging-setup` (PR #2327, 2026-04-30) | n/a — staging-only safety net | required so workflow safety-net can find slug; pattern-sweeping by date prefix poisons concurrent runs | ✅ enforced (staging E2E) |
 | **Orphan cleanup** | | | | |
 | Detect + terminate stale | `healthsweep.go` + CP `DeprovisionInstance` | Docker daemon scan | CP OrgID-tag cascade (molecule-controlplane#234) | ✅ parity as of 2026-04-23 |
 | **Health / budget / schedules** | | | | |

--- a/docs/infra/workspace-terminal.md
+++ b/docs/infra/workspace-terminal.md
@@ -16,7 +16,11 @@ workspace container running on it) over an [EC2 Instance Connect
 Endpoint](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-connect-setup-ec2-instance-connect-endpoint.html).
 End users see a terminal; no direct public SSH ingress is required.
 
-Tracking: [molecule-core#1528](https://github.com/Molecule-AI/molecule-core/issues/1528) (resolved 2026-04-22).
+Tracking: originally `molecule-core#1528` (resolved 2026-04-22). The
+`molecule-core` repo has since been renamed to `molecule-monorepo` and no
+longer accepts new issues under the old name; future terminal work is
+tracked in `molecule-monorepo` issues (workspace-server scope) and in
+`molecule-controlplane` issues for the EIC / per-tenant SG path.
 
 ## Where things are
 

--- a/docs/workspace-runtime-package.md
+++ b/docs/workspace-runtime-package.md
@@ -17,6 +17,29 @@ distinct from the PyPI package) is no longer the source-of-truth and should
 be treated as a publish artifact only. It can be archived or used as a
 read-only mirror.
 
+## Where to make changes
+
+**All runtime edits land in `molecule-monorepo/workspace/`. Period.**
+
+The GitHub repo `Molecule-AI/molecule-ai-workspace-runtime` is **mirror-only**.
+It exists so external consumers (template repos, downstream operators) have a
+git-cloneable artifact that mirrors the PyPI wheel — nothing more.
+
+- **Direct PRs against `molecule-ai-workspace-runtime` are auto-rejected by
+  the `mirror-guard` CI check.** The check fails any push that did not come
+  from the publish pipeline. There is no opt-out — file the change against
+  `molecule-monorepo/workspace/` instead.
+- **The mirror + the PyPI wheel both auto-regenerate on every push to
+  `staging`** via `.github/workflows/publish-runtime.yml` (which calls
+  `scripts/build_runtime_package.py`, builds wheel + sdist, smoke-imports,
+  uploads to PyPI via Trusted Publisher, and force-pushes the rewritten tree
+  to the mirror repo). You never touch the mirror by hand.
+
+If you have an old local clone of the mirror and try to push a fix to it
+directly, expect a CI failure with a message pointing you here. Re-open the
+change against `molecule-monorepo/workspace/` and let the publish workflow
+do the rest.
+
 ## Why this shape
 
 The 8 workspace template repos (claude-code, langgraph, hermes, etc.) each


### PR DESCRIPTION
Three-file internal-docs refresh. No code, tests, workflows, or other docs touched.

## docs/workspace-runtime-package.md

Add an explicit "Where to make changes" section that documents the
mirror-only policy on `Molecule-AI/molecule-ai-workspace-runtime`:

- Direct PRs against the mirror are auto-rejected by `mirror-guard` CI.
- All edits land in `molecule-monorepo/workspace/`.
- The mirror repo and the PyPI wheel both auto-regenerate on every
  push to `staging` via `.github/workflows/publish-runtime.yml`.

This had been folk-knowledge until now; the existing prose mentioned
the mirror is a publish artifact but did not call out the CI rejection
or the staging-push trigger that operators need to know about.

## docs/infra/workspace-terminal.md

The line under "What this feature is" pointed at
`molecule-core#1528`. The `molecule-core` repo has been renamed to
`molecule-monorepo` (handover 2026-04-27) and no longer accepts new
issues under the old name. Replace the dead reference with a
forward-pointer to monorepo issues (workspace-server scope) and
molecule-controlplane issues (EIC / per-tenant SG path).

## docs/architecture/backends.md

Bump the audit date from 2026-04-23 to 2026-05-02 and add six rows
covering features merged 2026-04-30 → 2026-05-02. Existing rows
untouched, existing format preserved:

- Channel envelope enrichment (peer_name / peer_role / agent_card_url)
  — PR #2471
- chat_history MCP tool — PR #2474
- /activity before_ts paging — PR #2476
- /activity peer_id filter — PR #2472
- runtime_wedge / smoke gate — PRs #2473 + #2475
- Canvas-E2E `.playwright-staging-state.json` requirement — PR #2327

All PR numbers verified against `gh pr view` in this repo.

## Test plan

- [ ] CI: docs-only change, expect lint + link-check to be the only
      gates; no test impact.
- [ ] Render the three files on the GitHub web UI and confirm the
      tables + headings render correctly.