### PR TITLE
harness(phase-2-followup): fix assert_status mislabel + honest race comment

### DIFF
--- a/tests/harness/replays/per-tenant-independence.sh
+++ b/tests/harness/replays/per-tenant-independence.sh
@@ -120,10 +120,17 @@ assert "E3: postgres-alpha has zero beta-named workspaces" "0" "$ALPHA_HAS_BETA"
 assert "E4: postgres-beta has zero alpha-named workspaces" "0" "$BETA_HAS_ALPHA"
 
 # ─── Phase F: concurrent INSERT race ───────────────────────────────────
-# Both tenants take turns inserting 10 rows concurrently. Race shape
-# catches: shared-connection-pool corruption, lib/pq prepared-statement
-# cache collision (org-wide hazard per memory), redis cross-keyspace
-# bleed. Each side must end with EXACTLY +10 rows from its own writes.
+# Both tenants insert 10 rows concurrently. Race shape catches the
+# failure modes that CAN cross tenants in this topology:
+#   - redis cross-keyspace bleed (shared redis container).
+#   - shared-cp-stub state corruption (single Go process serves both).
+#   - cf-proxy buffer mixup under simultaneous in-flight writes.
+# Does NOT catch lib/pq prepared-statement cache collision or shared
+# *sql.DB pool poisoning — each tenant has its own DATABASE_URL and
+# its own postgres-{alpha,beta} container, so there is no shared pool
+# to corrupt. A future replay variant on a single shared Postgres
+# would be the right place to assert that failure mode.
+# Each side must end with EXACTLY +10 rows from its own writes.
 echo ""
 echo "[replay] F. concurrent insert race — 10 rows per tenant in parallel"
 

--- a/tests/harness/replays/tenant-isolation.sh
+++ b/tests/harness/replays/tenant-isolation.sh
@@ -61,6 +61,20 @@ assert_status() {
     fi
 }
 
+# Plain equality check — for non-HTTP values (counts, names, etc.).
+# Distinct from assert_status so output reads naturally instead of
+# claiming "(HTTP 0)" for what is really a count.
+assert() {
+    local desc="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        printf "  PASS %s\n" "$desc"
+        PASS=$((PASS + 1))
+    else
+        printf "  FAIL %s\n    expected: %s\n    got     : %s\n" "$desc" "$expected" "$actual" >&2
+        FAIL=$((FAIL + 1))
+    fi
+}
+
 # ─── Phase A: positive controls ────────────────────────────────────────
 echo "[replay] A. positive controls — each tenant accepts its own valid creds"
 
@@ -148,11 +162,11 @@ fi
 # Cross-check: neither tenant's list contains the other's workspace ids.
 LEAKED_INTO_ALPHA=$(echo "$ALPHA_LIST" | jq -r --arg b1 "$BETA_PARENT_ID" --arg b2 "$BETA_CHILD_ID" \
     '[.[] | select(.id == $b1 or .id == $b2)] | length')
-assert_status "F3: alpha list contains zero beta workspace ids" "0" "$LEAKED_INTO_ALPHA"
+assert "F3: alpha list contains zero beta workspace ids" "0" "$LEAKED_INTO_ALPHA"
 
 LEAKED_INTO_BETA=$(echo "$BETA_LIST" | jq -r --arg a1 "$ALPHA_PARENT_ID" --arg a2 "$ALPHA_CHILD_ID" \
     '[.[] | select(.id == $a1 or .id == $a2)] | length')
-assert_status "F4: beta list contains zero alpha workspace ids" "0" "$LEAKED_INTO_BETA"
+assert "F4: beta list contains zero alpha workspace ids" "0" "$LEAKED_INTO_BETA"
 
 # ─── Phase G: /health is allowlisted (sanity) ──────────────────────────
 echo ""


### PR DESCRIPTION
## Summary
Two review nits from PR #2493 (Phase 2 harness) — no behavioural change, both replays still pass 13/13 + 12/12.

1. **`tenant-isolation.sh` F3/F4 mislabeled as HTTP**. `LEAKED_INTO_ALPHA`/`BETA` are jq-derived counts, but the assertions ran through `assert_status` which formats the result as \"(HTTP 0)\". Output read like an HTTP call when there was none. Adds a plain `assert` helper matching `per-tenant-independence.sh`'s pattern, switches the two lines.
2. **`per-tenant-independence.sh` Phase F over-claimed coverage**. Comment said the concurrent-INSERT race catches \"shared-pool corruption\" and \"lib/pq prepared-statement cache collision\". Both are real, but neither can fire across tenants in *this* topology — each tenant owns its own DATABASE_URL + postgres-{alpha,beta} container. Comment now lists only what the test actually catches (redis cross-keyspace bleed, shared cp-stub state corruption, cf-proxy buffer mixup) and notes that a future shared-Postgres variant is the right home for the lib/pq cache assertion.

## Why this matters
The harness's value is that you trust what its replays claim to test. A test labeled \"(HTTP 0)\" when it didn't make an HTTP call, or a comment claiming to catch a failure mode that physically can't fire, both erode that trust. Cheap to fix while context is fresh.

## Test plan
- [x] `./run-all-replays.sh` from a clean state — 6/6 passed
- [x] `tenant-isolation.sh` output now reads `PASS F3: alpha list contains zero beta workspace ids` (no spurious `(HTTP 0)`)
- [ ] `Harness Replays` CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)