### PR TITLE
fix(sweep-cf-tunnels): buffer pages to disk to avoid argv ARG_MAX

### DIFF
--- a/scripts/ops/sweep-cf-tunnels.sh
+++ b/scripts/ops/sweep-cf-tunnels.sh
@@ -94,27 +94,37 @@ log "  staging orgs: $(echo "$STAGING_SLUGS" | wc -w | tr -d ' ')"
 log "Fetching Cloudflare tunnels..."
 # The cfd_tunnel list endpoint is paginated; per_page max is 50.
 # Walk all pages so we don't silently miss orphans on busy accounts.
+#
+# Pages are buffered to a temp dir and merged at the end. The earlier
+# shape passed the accumulating JSON on argv every iteration, which on
+# a busy account (700+ tunnels = 14+ pages) blows past Linux ARG_MAX
+# (~128 KB combined argv+envp on the GH Ubuntu runner) and dies with
+# `python3: Argument list too long`. Disk-buffering also makes the
+# accumulator O(n) instead of O(n^2).
+PAGES_DIR=$(mktemp -d -t cf-tunnels-XXXXXX)
+trap 'rm -rf "$PAGES_DIR"' EXIT
 PAGE=1
-TUNNEL_JSON='{"result":[]}'
 while :; do
-  page_json=$(curl -sS -m 15 -H "Authorization: Bearer $CF_API_TOKEN" \
-    "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel?per_page=50&page=$PAGE&is_deleted=false")
-  page_count=$(echo "$page_json" | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('result') or []))")
-  if [ "$page_count" = "0" ]; then break; fi
-  # Merge pages
-  TUNNEL_JSON=$(python3 -c "
-import json, sys
-acc = json.loads(sys.argv[1])
-new = json.loads(sys.argv[2])
-acc['result'].extend(new.get('result') or [])
-print(json.dumps(acc))
-" "$TUNNEL_JSON" "$page_json")
+  page_file="$PAGES_DIR/page-$(printf '%05d' "$PAGE").json"
+  curl -sS -m 15 -H "Authorization: Bearer $CF_API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel?per_page=50&page=$PAGE&is_deleted=false" \
+    > "$page_file"
+  page_count=$(python3 -c "import json,sys; print(len(json.load(open(sys.argv[1])).get('result') or []))" "$page_file")
+  if [ "$page_count" = "0" ]; then rm -f "$page_file"; break; fi
   PAGE=$((PAGE + 1))
-  if [ "$PAGE" -gt 20 ]; then
-    log "::warning::stopping pagination at page 20 (1000 tunnels) — re-run if more"
+  if [ "$PAGE" -gt 40 ]; then
+    log "::warning::stopping pagination at page 40 (2000 tunnels) — re-run if more"
     break
   fi
 done
+TUNNEL_JSON=$(python3 -c '
+import glob, json, os, sys
+acc = {"result": []}
+for f in sorted(glob.glob(os.path.join(sys.argv[1], "page-*.json"))):
+    with open(f) as fh:
+        acc["result"].extend(json.load(fh).get("result") or [])
+print(json.dumps(acc))
+' "$PAGES_DIR")
 TOTAL_TUNNELS=$(echo "$TUNNEL_JSON" | python3 -c "import json,sys; print(len(json.load(sys.stdin)['result']))")
 log "  total tunnels: $TOTAL_TUNNELS"
 


### PR DESCRIPTION
## Summary

The Cloudflare tunnel sweep workflow has been failing every hour since secrets landed (most recently `run 25247052329`, `25246612779`, etc). After unblocking the missing-secret check by adding `CF_ACCOUNT_ID` to repo secrets earlier today, the next dispatch surfaced a second bug: the page-merge loop hits `python3: Argument list too long` (exit 126) once the account has enough tunnels.

## Root cause

```bash
TUNNEL_JSON=$(python3 -c "..." "$TUNNEL_JSON" "$page_json")
```

The accumulating JSON gets passed as argv on every iteration. With **672 tunnels (14 pages on Hongmingwangrabbit account)**, the accumulator grows to ~250KB+ and exceeds the GH Ubuntu runner's combined argv+envp ARG_MAX (~128KB on most distros).

## Fix

Buffer each page response to a file under a `mktemp -d` directory, merge from disk at the end. Side benefit: O(n) instead of the previous O(n²) (each page no longer re-passes the whole accumulated string).

Also bumps the page cap from 20 to 40 (1000 → 2000 tunnel ceiling) since the disk-merge shape makes the larger ceiling cheap.

## Verification

Ran locally against the live account before opening the PR:

```
[07:41:38] Fetching CP prod org slugs...
[07:41:39]   prod orgs: 3
[07:41:39] Fetching CP staging org slugs...
[07:41:39]   staging orgs: 3
[07:41:39] Fetching Cloudflare tunnels...
[07:41:43]   total tunnels: 672
[07:41:43] == Sweep plan ==
[07:41:43]   total tunnels:          672
[07:41:43]   tenant-shaped tunnels:  672
[07:41:43]   would delete:           666
[07:41:43]   would keep:             6
[07:41:43] SAFETY: would delete 99% of tenant-shaped tunnels (threshold 90%) — refusing.
```

Script now reaches the `MAX_DELETE_PCT` safety gate, which trips correctly at 99% > 90% as designed. The 666-orphan backlog (steady-state result of the workflow never having run successfully) will be cleared by an operator-driven `workflow_dispatch` with `max_delete_pct: 99` once this lands.

## Test plan

- [x] `bash -n` clean
- [x] `shellcheck -S warning` clean
- [x] Local dry-run against live CF account succeeds
- [ ] After merge: scheduled run at next `:45` reaches the safety gate (no more `Argument list too long`)
- [ ] After merge: manual dispatch with `max_delete_pct: 99 dry_run: false` clears the 666-tunnel backlog