### PR TITLE
fix(redeploy-staging): tolerate e2e-* teardown race in fleet HTTP 500

### DIFF
--- a/.github/workflows/redeploy-tenants-on-staging.yml
+++ b/.github/workflows/redeploy-tenants-on-staging.yml
@@ -172,12 +172,44 @@ jobs:
             jq -r '.results[]? | "| \(.slug) | \(.phase) | \(.ssm_status // "-") | \(.ssm_exit_code) | \(.healthz_ok) | \(.error // "-") |"' "$HTTP_RESPONSE" || true
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "$HTTP_CODE" != "200" ]; then
+          # Distinguish "real fleet failure" from "E2E teardown race".
+          #
+          # CP returns HTTP 500 + ok=false whenever ANY tenant in the
+          # fleet failed SSM or healthz. In practice the recurring source
+          # of these is ephemeral e2e-* tenants (saas/canvas/ext) being
+          # torn down by their parent E2E run mid-redeploy: the EC2 dies →
+          # SSM exit=2 or healthz timeout → CP marks the fleet failed →
+          # this workflow goes red even though every operator-facing
+          # tenant rolled fine.
+          #
+          # Filter: if HTTP=500/ok=false AND every failed slug matches
+          # ^e2e-, treat as soft-warn and let the verify step downstream
+          # handle the unreachable-vs-stale distinction (it already knows
+          # the difference per #2402). Any non-e2e-* failure or a non-500
+          # HTTP response remains a hard failure.
+          OK=$(jq -r '.ok // "false"' "$HTTP_RESPONSE")
+          FAILED_SLUGS=$(jq -r '
+            .results[]?
+            | select((.healthz_ok != true) or (.ssm_status != "Success"))
+            | .slug' "$HTTP_RESPONSE" 2>/dev/null || true)
+          NON_E2E_FAILED=$(printf '%s\n' "$FAILED_SLUGS" | grep -v '^$' | grep -v '^e2e-' || true)
+
+          if [ "$HTTP_CODE" = "200" ] && [ "$OK" = "true" ]; then
+            : # happy path — fall through to verification
+          elif [ "$HTTP_CODE" = "500" ] && [ -z "$NON_E2E_FAILED" ] && [ -n "$FAILED_SLUGS" ]; then
+            COUNT=$(printf '%s\n' "$FAILED_SLUGS" | grep -c '^e2e-' || true)
+            echo "::warning::redeploy-fleet returned HTTP 500 but every failed tenant ($COUNT) is e2e-* ephemeral — treating as teardown race, soft-warning."
+            printf '%s\n' "$FAILED_SLUGS" | sed 's/^/::warning::  failed: /'
+          elif [ "$HTTP_CODE" != "200" ]; then
             echo "::error::redeploy-fleet returned HTTP $HTTP_CODE"
+            if [ -n "$NON_E2E_FAILED" ]; then
+              echo "::error::non-e2e tenant(s) failed:"
+              printf '%s\n' "$NON_E2E_FAILED" | sed 's/^/::error::  /'
+            fi
             exit 1
-          fi
-          OK=$(jq -r '.ok' "$HTTP_RESPONSE")
-          if [ "$OK" != "true" ]; then
+          else
+            # HTTP=200 but ok=false (shouldn't happen with current CP
+            # but keep the gate for completeness).
             echo "::error::redeploy-fleet reported ok=false (see summary for which tenant halted the rollout)"
             exit 1
           fi


### PR DESCRIPTION
## Symptom

\`redeploy-tenants-on-staging\` fails with:

\`\`\`
##[error]redeploy-fleet returned HTTP 500
##[error]Process completed with exit code 1.
\`\`\`

The per-tenant breakdown in the response body shows the failures are on ephemeral \`e2e-*\` tenants whose parent E2E run tore them down mid-redeploy — operator-facing tenants (\`dryrun-98407\`, \`demo-prep\`, etc) rolled fine in the same call.

Two recent occurrences (triage runs #7 and #9 today): runs [25247836697](https://github.com/Molecule-AI/molecule-core/actions/runs/25247836697) and [25248307107](https://github.com/Molecule-AI/molecule-core/actions/runs/25248307107).

## Root cause

CP returns HTTP 500 + \`ok:false\` whenever ANY tenant in the fleet failed SSM or healthz. The downstream \`Verify each staging tenant /buildinfo matches published SHA\` step ALREADY distinguishes STALE-vs-UNREACHABLE for exactly this reason (per #2402); only the top-level \`if HTTP_CODE != 200; exit 1\` gate misclassifies the race as a real fleet failure.

## Fix

Filter at the gate:
- HTTP 500 + every failed slug matches \`^e2e-\` → soft-warn, fall through to verify
- Any non-\`e2e-*\` failure → hard fail, with the failed slugs surfaced in the error message
- Non-500 HTTP → hard fail (CP-down, network, auth — none of which the e2e filter applies to)

## Test

Replayed the gate against 6 synthetic CP responses:
- happy path → pass through ✓
- HTTP 500 + only e2e-* failed → soft-warn ✓
- HTTP 500 + mixed real + e2e fail → hard-fail ✓
- HTTP 502 → hard-fail ✓
- HTTP 200 + ok:false → hard-fail ✓
- HTTP 500 + all real fail → hard-fail ✓

## Scope

Only \`redeploy-tenants-on-staging.yml\`. \`redeploy-tenants-on-main.yml\` is intentionally NOT touched: prod CP serves no \`e2e-*\` tenants, so the race can't occur there and the strict gate is the right behavior.

## Test plan

- [x] yaml + shell syntax clean
- [x] 6-case unit replay of gate logic
- [ ] Next staging push that overlaps an active E2E run reaches verify (no more "redeploy-fleet returned HTTP 500" if the only failures are \`e2e-*\` slugs)