### PR TITLE
fix(sweep-cf-tunnels): parallelize deletes + raise workflow timeout

### DIFF
--- a/.github/workflows/sweep-cf-tunnels.yml
+++ b/.github/workflows/sweep-cf-tunnels.yml
@@ -47,10 +47,22 @@ jobs:
   sweep:
     name: Sweep CF tunnels
     runs-on: ubuntu-latest
-    # 5 min surfaces hangs (CF API stall, slow pagination on busy
-    # accounts). Realistic worst case is ~3 min: 2 CP curls + N CF
-    # list pages + N×CF-DELETE, each capped at 10-15s by curl -m.
-    timeout-minutes: 5
+    # 30 min cap. Was 5 min on the theory that the only thing that
+    # could take >5min is a CF-API hang — but on 2026-05-02 a backlog
+    # of 672 stale tunnels accumulated (large staging E2E run + delayed
+    # sweep) and the serial `curl -X DELETE` loop (~0.7s/tunnel) needed
+    # ~7-8min to drain. The 5-min cap killed the run mid-sweep
+    # (cancelled at 424/672, see run 25248788312); a manual rerun
+    # finished the remainder fine.
+    #
+    # The fix is two-part: parallelize the delete loop (8-way xargs in
+    # the script — see scripts/ops/sweep-cf-tunnels.sh), AND raise the
+    # cap so a one-off backlog doesn't trip a hangs-detector that
+    # turned out to be a real-job-too-slow detector. With 8-way
+    # parallelism, 600+ tunnels drains in ~60s; 30 min is generous
+    # headroom for actual hangs to still surface (and is in line with
+    # the sweep-cf-orphans companion job).
+    timeout-minutes: 30
     env:
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
       CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/scripts/ops/sweep-cf-tunnels.sh
+++ b/scripts/ops/sweep-cf-tunnels.sh
@@ -102,7 +102,22 @@ log "Fetching Cloudflare tunnels..."
 # `python3: Argument list too long`. Disk-buffering also makes the
 # accumulator O(n) instead of O(n^2).
 PAGES_DIR=$(mktemp -d -t cf-tunnels-XXXXXX)
-trap 'rm -rf "$PAGES_DIR"' EXIT
+# Single cleanup() covering all tempfiles created downstream
+# ($DELETE_PLAN, $NAME_MAP, $FAIL_LOG, $RESULT_LOG). One trap call so a
+# later `trap '...' EXIT` doesn't silently overwrite an earlier one.
+DELETE_PLAN=""
+NAME_MAP=""
+FAIL_LOG=""
+RESULT_LOG=""
+cleanup() {
+  rm -rf "$PAGES_DIR"
+  [ -n "$DELETE_PLAN" ] && rm -f "$DELETE_PLAN"
+  [ -n "$NAME_MAP" ] && rm -f "$NAME_MAP"
+  [ -n "$FAIL_LOG" ] && rm -f "$FAIL_LOG"
+  [ -n "$RESULT_LOG" ] && rm -f "$RESULT_LOG"
+  return 0
+}
+trap cleanup EXIT
 PAGE=1
 while :; do
   page_file="$PAGES_DIR/page-$(printf '%05d' "$PAGE").json"
@@ -241,27 +256,75 @@ for l in sys.stdin:
 fi
 
 # --- Execute deletes -------------------------------------------------------
+#
+# Parallel delete loop. Was a serial `curl -X DELETE` while-loop;
+# at ~0.7s/tunnel that meant 672 stale tunnels needed ~7-8 min, which
+# tripped the workflow's 5-min timeout-minutes (run 25248788312,
+# cancelled at 424/672). Fan out to $SWEEP_CONCURRENCY workers via
+# xargs so a 600+ backlog drains in ~60s.
+#
+# Design notes:
+#   - Materialize the (id, name) plan to a tempfile for stdin'ing into
+#     xargs. xargs `-a FILE` is GNU-only; piping/`<` is portable to
+#     macOS/BSD xargs (matters for local testing).
+#   - Pass ONLY the id on argv. xargs tokenizes on whitespace by
+#     default; tab-separating id+name on argv risks mangling. We keep
+#     the name in a side-channel id→name map ($NAME_MAP) for failure
+#     log readability, and the worker also writes failure detail to
+#     $FAIL_LOG (`FAIL <name> <id>`) for grep-ability.
+#   - Workers print exactly `OK` or `FAIL` on stdout (one line per
+#     invocation); we tally with `grep -c '^OK$' / '^FAIL$'`.
+
+CONCURRENCY="${SWEEP_CONCURRENCY:-8}"
+DELETE_PLAN=$(mktemp -t cf-tunnels-plan-XXXXXX)
+NAME_MAP=$(mktemp -t cf-tunnels-names-XXXXXX)
+FAIL_LOG=$(mktemp -t cf-tunnels-fail-XXXXXX)
+RESULT_LOG=$(mktemp -t cf-tunnels-result-XXXXXX)
+
+# Build delete plan (just ids, one per line) and the side-channel
+# id→name map (tab-separated).
+echo "$DECISIONS" | python3 -c '
+import json, os, sys
+plan_path = sys.argv[1]
+map_path = sys.argv[2]
+with open(plan_path, "w") as plan, open(map_path, "w") as nmap:
+    for line in sys.stdin:
+        d = json.loads(line)
+        if d.get("action") != "delete":
+            continue
+        tid = d["id"]
+        name = d.get("name", "")
+        plan.write(tid + "\n")
+        nmap.write(tid + "\t" + name + "\n")
+' "$DELETE_PLAN" "$NAME_MAP"
 
 log ""
-log "Executing $DELETE_COUNT deletions..."
-DELETED=0
-FAILED=0
-while IFS= read -r line; do
-  action=$(echo "$line" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['action'])")
-  [ "$action" = "delete" ] || continue
-  tid=$(echo "$line" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['id'])")
-  name=$(echo "$line" | python3 -c "import json,sys; print(json.loads(sys.stdin.read())['name'])")
-  if curl -sS -m 10 -X DELETE \
-      -H "Authorization: Bearer $CF_API_TOKEN" \
-      "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$tid" \
-      | grep -q '"success":true'; then
-    DELETED=$((DELETED+1))
+log "Executing $DELETE_COUNT deletions ($CONCURRENCY-way parallel)..."
+
+export CF_API_TOKEN CF_ACCOUNT_ID NAME_MAP FAIL_LOG
+
+# shellcheck disable=SC2016
+xargs -P "$CONCURRENCY" -L 1 -I {} bash -c '
+  tid="$1"
+  resp=$(curl -sS -m 10 -X DELETE \
+    -H "Authorization: Bearer $CF_API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/cfd_tunnel/$tid")
+  if printf "%s" "$resp" | grep -q "\"success\":true"; then
+    echo OK
   else
-    FAILED=$((FAILED+1))
-    log "  FAILED: $name ($tid)"
+    name=$(awk -F"\t" -v id="$tid" "\$1==id {print \$2; exit}" "$NAME_MAP")
+    echo FAIL
+    echo "FAIL $name $tid" >> "$FAIL_LOG"
   fi
-done <<< "$DECISIONS"
+' _ {} < "$DELETE_PLAN" > "$RESULT_LOG"
+
+DELETED=$(grep -c '^OK$' "$RESULT_LOG" || true)
+FAILED=$(grep -c '^FAIL$' "$RESULT_LOG" || true)
 
 log ""
 log "Done. deleted=$DELETED failed=$FAILED"
+if [ "$FAILED" -ne 0 ]; then
+  log "Failure detail (first 20):"
+  head -20 "$FAIL_LOG" | while IFS= read -r fl; do log "  $fl"; done
+fi
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Symptom

Hourly `Sweep stale Cloudflare Tunnels` job got cancelled mid-cleanup on 2026-05-02 — [run 25248788312](https://github.com/Molecule-AI/molecule-core/actions/runs/25248788312), killed at the workflow's 5-min `timeout-minutes` after deleting **424/672** stale tunnels. A second manual dispatch finished the remaining 254 fine, so the immediate backlog cleared, but the underlying limit will bite again on any future big cleanup.

## Root cause

Two separate bugs that compose:

1. **Serial delete loop** in `scripts/ops/sweep-cf-tunnels.sh` (the original bottom-of-script `while IFS= read; do curl -X DELETE; done`). At ~0.7s/tunnel a 600+ backlog needs ~7-8 min.
2. **5-minute workflow cap** in `.github/workflows/sweep-cf-tunnels.yml`, set as a hangs-detector but in practice acted as a real-job-too-slow detector for any non-trivial cleanup.

Drive-by: the existing `trap 'rm -rf "$PAGES_DIR"' EXIT` would have been silently overwritten by any later `trap` call (single-trap-per-signal semantics).

## Fix

1. **Parallelize deletes via `xargs -P 8`.** Materialize the (id, name) plan to a tempfile, then `xargs -P "$CONCURRENCY" -L 1 -I {} bash -c '...' _ {} < "$DELETE_PLAN"`. Concurrency reads from `$SWEEP_CONCURRENCY` env, defaults to 8. With 8x parallelism the 600+ list drains in ~60s.
   - Stdin (`<`), not GNU's `xargs -a FILE`, so the script stays portable to BSD xargs (matters for local-runner testing on macOS).
   - Pass ONLY the tunnel id on argv. xargs tokenizes on whitespace by default; tab-separating id+name on argv risks mangling. Name is kept in a side-channel id→name map (`$NAME_MAP`) and looked up by the worker only on failure, for `$FAIL_LOG` readability.
   - Workers print exactly `OK` or `FAIL` on stdout; tally with `grep -c '^OK$' / '^FAIL$'`.
   - On non-zero `FAILED`, log the first 20 lines of `$FAIL_LOG` as `Failure detail (first 20):`.
2. **Raise `timeout-minutes` from 5 → 30** in the workflow, with the comment rewritten to explain why. 30 min gives generous headroom for the ~60s steady-state run while still surfacing genuine hangs (and is in line with the `sweep-cf-orphans` companion job). Comment references run `25248788312` and the post-fix expected runtime.
3. **Single `cleanup()` function** called once via `trap cleanup EXIT`, covering `PAGES_DIR` + all four new tempfiles (`DELETE_PLAN`, `NAME_MAP`, `FAIL_LOG`, `RESULT_LOG`). No more silent-trap-overwrite hazard.

## Verification

All four quality gates green on the working branch:

```
=== bash -n ===
BASH_N_CLEAN
=== shellcheck -S warning ===
SHELLCHECK_CLEAN
=== python3 yaml.safe_load ===
YAML_LOAD_CLEAN
=== synthetic 30-tunnel test ===
DELETED=26 FAILED=4
TEST PASS: DELETED=26 FAILED=4 (4 sentinel + 26 success), FAIL_LOG side-channel name lookup verified
```

The synthetic test builds a 30-line delete plan, marks every 7th id with a `-F` sentinel suffix (4 fails + 26 successes), runs the SAME `xargs -P 8 -L 1 -I {}` invocation as the real script with the curl call substituted by an inline `case "$tid" in *-F) echo '{"success":false}';; *) echo '{"success":true}';; esac`, and asserts both `DELETED=26 FAILED=4` and that the side-channel name lookup populated `$FAIL_LOG` correctly. Both branches of the case are exercised (sanity-checked before the assertion).

## Test plan (next scheduled run)

- [ ] Watch the next `:45` scheduled run after merge — should finish in well under 5 min even on a small backlog (steady-state runs typically have 0–20 deletes; a sub-minute total is normal).
- [ ] Verify `Executing N deletions (8-way parallel)...` appears in the log line (confirms the new branch is exercised).
- [ ] Verify `Done. deleted=N failed=0` is printed and the workflow exits 0.
- [ ] On the next intentional big-backlog dispatch (e.g. after a heavy E2E day), verify the run completes within the new 30-min cap with deleted ≈ planned and failed=0. If failures occur, the `Failure detail (first 20):` block surfaces names+ids for triage.
- [ ] If a future BSD-xargs runner ever runs this script (currently `runs-on: ubuntu-latest`), the `<` stdin redirection keeps it portable; confirm with `bash scripts/ops/sweep-cf-tunnels.sh` locally on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)