### PR TITLE
fix(canvas): provider→model cascade UX in ConfigTab

### DIFF
--- a/canvas/src/components/tabs/ConfigTab.tsx
+++ b/canvas/src/components/tabs/ConfigTab.tsx
@@ -1,11 +1,20 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useId } from "react";
+import { useState, useEffect, useCallback, useRef, useId, useMemo } from "react";
 import { api } from "@/lib/api";
 import { useCanvasStore } from "@/store/canvas";
 import { type ConfigData, DEFAULT_CONFIG, TextInput, NumberInput, Toggle, TagList, Section } from "./config/form-inputs";
 import { parseYaml, toYaml } from "./config/yaml-utils";
 import { SecretsSection } from "./config/secrets-section";
+import {
+  AUTO_PROVIDER,
+  matchProviderForModel,
+  modelsForProvider,
+  requiredEnvFor,
+  providerListForRuntime,
+  type ProviderEntry,
+  type ModelSpec as CascadeModelSpec,
+} from "./config/provider-cascade";
 
 interface Props {
   workspaceId: string;
@@ -86,56 +95,25 @@ function AgentCardSection({ workspaceId }: { workspaceId: string }) {
 
 // --- Main ConfigTab ---
 
-interface ModelSpec {
-  id: string;
-  name?: string;
-  required_env?: string[];
-}
-
-function arraysEqual(a: readonly string[], b: readonly string[]): boolean {
-  return a.length === b.length && a.every((v, i) => v === b[i]);
-}
+type ModelSpec = CascadeModelSpec;
 
 interface RuntimeOption {
   value: string;
   label: string;
   models: ModelSpec[];
-  // providers is the declarative provider list each template ships in
-  // its config.yaml under runtime_config.providers. The /templates API
-  // surfaces it (workspace-server templates.go) so canvas stays
-  // adapter-driven: hermes ships ~20 slugs, claude-code ships
-  // ["anthropic"], gemini-cli ships ["gemini"], etc. Empty list →
-  // canvas falls back to deriving unique vendor prefixes from
-  // models[].id (still adapter-driven, just inferred).
+  // providers is the legacy flat-string list each older template
+  // ships under runtime_config.providers. Hermes-style. Kept for
+  // back-compat — newer templates ship the structured registry below.
   providers: string[];
-}
-
-// deriveProvidersFromModels — when a template doesn't ship an explicit
-// providers list, infer suggestions from the vendor prefixes of its
-// model slugs. e.g. ["anthropic:claude-opus-4-7", "openai:gpt-4o",
-// "anthropic:claude-sonnet-4-5"] → ["anthropic", "openai"].
-//
-// This keeps the dropdown adapter-driven for older templates that
-// haven't migrated to the explicit `providers:` field yet, AND
-// continues to be a useful fallback for any future runtime whose
-// derive-provider semantics happen to match the slug prefix.
-function deriveProvidersFromModels(models: ModelSpec[]): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const m of models) {
-    if (!m.id) continue;
-    // Both ":" (anthropic:claude-opus-4-7) and "/" (nousresearch/hermes-4-70b)
-    // are valid vendor separators in our slug taxonomy. Take whichever
-    // appears first and split there.
-    const sep = m.id.match(/[:/]/)?.index ?? -1;
-    if (sep <= 0) continue;
-    const vendor = m.id.slice(0, sep);
-    if (!seen.has(vendor)) {
-      seen.add(vendor);
-      out.push(vendor);
-    }
-  }
-  return out;
+  // providerRegistry is the structured top-level `providers:` block
+  // from claude-code-default and similar runtimes (Option B PR-6).
+  // When non-empty it drives the Provider→Model cascade UI: the form
+  // shows a Provider <select> populated from registry[].name, then a
+  // Model <select> filtered to that provider's prefixes/aliases, then
+  // a read-only Required Env display sourced from the union of the
+  // selected provider.auth_env and the selected model.required_env.
+  // Empty → form falls back to the legacy flat-providers UX.
+  providerRegistry: ProviderEntry[];
 }
 
 // Fallback used when /templates can't be fetched (offline, older backend).
@@ -154,14 +132,14 @@ function deriveProvidersFromModels(models: ModelSpec[]): string[] {
 const RUNTIMES_WITH_OWN_CONFIG = new Set<string>(["external"]);
 
 const FALLBACK_RUNTIME_OPTIONS: RuntimeOption[] = [
-  { value: "", label: "LangGraph (default)", models: [], providers: [] },
-  { value: "claude-code", label: "Claude Code", models: [], providers: [] },
-  { value: "crewai", label: "CrewAI", models: [], providers: [] },
-  { value: "autogen", label: "AutoGen", models: [], providers: [] },
-  { value: "deepagents", label: "DeepAgents", models: [], providers: [] },
-  { value: "openclaw", label: "OpenClaw", models: [], providers: [] },
-  { value: "hermes", label: "Hermes", models: [], providers: [] },
-  { value: "gemini-cli", label: "Gemini CLI", models: [], providers: [] },
+  { value: "", label: "LangGraph (default)", models: [], providers: [], providerRegistry: [] },
+  { value: "claude-code", label: "Claude Code", models: [], providers: [], providerRegistry: [] },
+  { value: "crewai", label: "CrewAI", models: [], providers: [], providerRegistry: [] },
+  { value: "autogen", label: "AutoGen", models: [], providers: [], providerRegistry: [] },
+  { value: "deepagents", label: "DeepAgents", models: [], providers: [], providerRegistry: [] },
+  { value: "openclaw", label: "OpenClaw", models: [], providers: [], providerRegistry: [] },
+  { value: "hermes", label: "Hermes", models: [], providers: [], providerRegistry: [] },
+  { value: "gemini-cli", label: "Gemini CLI", models: [], providers: [], providerRegistry: [] },
 ];
 
 export function ConfigTab({ workspaceId }: Props) {
@@ -243,7 +221,18 @@ export function ConfigTab({ workspaceId }: Props) {
       // form doesn't contradict the node badge (issue: badge=T3, form=T2).
       const merged = { ...DEFAULT_CONFIG, ...parsed } as ConfigData;
       if (wsMetadataRuntime) merged.runtime = wsMetadataRuntime;
-      if (wsMetadataModel) merged.model = wsMetadataModel;
+      if (wsMetadataModel) {
+        // Display-vs-storage drift fix (task #190). The form reads
+        // `config.runtime_config?.model || config.model` so a stale
+        // top-level write would lose to the yaml's runtime_config.model
+        // and the form would show the template default instead of the
+        // workspace's actual model. Mirror to BOTH so whichever path
+        // the form prefers, the workspace-metadata wins.
+        merged.model = wsMetadataModel;
+        if (wsMetadataRuntime) {
+          merged.runtime_config = { ...(merged.runtime_config ?? {}), model: wsMetadataModel };
+        }
+      }
       if (wsMetadataTier !== null) merged.tier = wsMetadataTier;
       setConfig(merged);
     } catch {
@@ -272,11 +261,18 @@ export function ConfigTab({ workspaceId }: Props) {
 
   useEffect(() => {
     let cancelled = false;
-    api.get<Array<{ id: string; name?: string; runtime?: string; models?: ModelSpec[]; providers?: string[] }>>("/templates")
+    api.get<Array<{
+      id: string;
+      name?: string;
+      runtime?: string;
+      models?: ModelSpec[];
+      providers?: string[];
+      provider_registry?: ProviderEntry[];
+    }>>("/templates")
       .then((rows) => {
         if (cancelled || !Array.isArray(rows)) return;
         const byRuntime = new Map<string, RuntimeOption>();
-        byRuntime.set("", { value: "", label: "LangGraph (default)", models: [], providers: [] });
+        byRuntime.set("", { value: "", label: "LangGraph (default)", models: [], providers: [], providerRegistry: [] });
         for (const r of rows) {
           const v = (r.runtime || "").trim();
           if (!v || v === "langgraph") continue;
@@ -285,8 +281,9 @@ export function ConfigTab({ workspaceId }: Props) {
           const existing = byRuntime.get(v);
           const models = Array.isArray(r.models) ? r.models : [];
           const providers = Array.isArray(r.providers) ? r.providers : [];
+          const providerRegistry = Array.isArray(r.provider_registry) ? r.provider_registry : [];
           if (!existing || models.length > existing.models.length) {
-            byRuntime.set(v, { value: v, label: r.name || v, models, providers });
+            byRuntime.set(v, { value: v, label: r.name || v, models, providers, providerRegistry });
           }
         }
         if (byRuntime.size > 1) setRuntimeOptions(Array.from(byRuntime.values()));
@@ -298,18 +295,60 @@ export function ConfigTab({ workspaceId }: Props) {
   // Models + env hints for the currently-selected runtime.
   const selectedRuntime = runtimeOptions.find((o) => o.value === (config.runtime || "")) ?? null;
   const availableModels: ModelSpec[] = selectedRuntime?.models ?? [];
-  // Provider suggestions: prefer the runtime's declarative providers
-  // list (sourced from its template config.yaml runtime_config.providers
-  // and surfaced via /templates), fall back to deriving from model slug
-  // prefixes when the template hasn't migrated to the explicit field
-  // yet. Either way the data flows from the adapter — no hardcoded
-  // canvas-side enum.
-  const providerSuggestions: string[] =
-    (selectedRuntime?.providers && selectedRuntime.providers.length > 0)
-      ? selectedRuntime.providers
-      : deriveProvidersFromModels(availableModels);
+
+  // Provider→Model cascade (PR-6). The structured provider_registry
+  // declares which models each provider claims, so the form can show
+  // a Provider <select> first, then a Model <select> filtered to
+  // that provider's prefixes/aliases. When the registry is absent,
+  // the legacy flat-string `providers` list (or vendor-prefix
+  // derivation) populates a name-only dropdown and the model list is
+  // unfiltered.
+  const providerOptions = useMemo<ProviderEntry[]>(
+    () => providerListForRuntime(selectedRuntime?.providerRegistry, selectedRuntime?.providers, availableModels),
+    [selectedRuntime, availableModels],
+  );
+  const hasProviderRegistry = (selectedRuntime?.providerRegistry?.length ?? 0) > 0;
+
   const currentModelId = config.runtime_config?.model || config.model || "";
   const currentModelSpec = availableModels.find((m) => m.id === currentModelId) ?? null;
+
+  // The "auto-derived" provider from the selected model id. When the
+  // operator hasn't picked an explicit provider, this is what the
+  // adapter would resolve at boot. Used to:
+  //   1. Show "(auto: anthropic-oauth)" next to the AUTO_PROVIDER
+  //      option so the operator knows what they'll get.
+  //   2. Surface auth_env in the read-only required-env display even
+  //      when provider is left blank (the actual env var the
+  //      workspace will need still depends on which provider auto-
+  //      resolves).
+  const autoMatchedProvider = useMemo(
+    () => matchProviderForModel(currentModelId, providerOptions),
+    [currentModelId, providerOptions],
+  );
+
+  // The provider whose auth_env should drive the required-env
+  // display. Explicit override beats auto-derive.
+  const effectiveProvider = useMemo(() => {
+    if (provider && provider !== AUTO_PROVIDER) {
+      return providerOptions.find((p) => p.name === provider) ?? null;
+    }
+    return autoMatchedProvider;
+  }, [provider, providerOptions, autoMatchedProvider]);
+
+  // Models the form actually offers in the dropdown given the current
+  // provider selection. Empty provider / AUTO_PROVIDER → unfiltered.
+  const filteredModels = useMemo(
+    () => modelsForProvider(provider, availableModels, providerOptions),
+    [provider, availableModels, providerOptions],
+  );
+
+  // Required env names rendered read-only when the registry can supply
+  // them. Falls back to the per-template flat list (config.runtime_config.required_env)
+  // for legacy templates that haven't shipped the structured shape.
+  const cascadedRequiredEnv = useMemo(
+    () => requiredEnvFor(effectiveProvider, currentModelSpec),
+    [effectiveProvider, currentModelSpec],
+  );
 
   const update = <K extends keyof ConfigData>(key: K, value: ConfigData[K]) => {
     setConfig((prev) => ({ ...prev, [key]: value }));
@@ -551,158 +590,198 @@ export function ConfigTab({ workspaceId }: Props) {
           </Section>
 
           <Section title="Runtime">
+            <div>
+              <label htmlFor={runtimeId} className="text-[10px] text-zinc-500 block mb-1">Runtime</label>
+              <select
+                id={runtimeId}
+                value={config.runtime || ""}
+                onChange={(e) => update("runtime", e.target.value)}
+                className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-blue-500"
+              >
+                {runtimeOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+            </div>
             <div className="grid grid-cols-2 gap-3">
+              {/* Provider <select> — first cascade. When the runtime
+                  ships a structured provider_registry (claude-code,
+                  hermes once it migrates), each registry entry becomes
+                  one option and selecting it filters the Model
+                  dropdown below. Without a registry, options come
+                  from the legacy flat `providers []string` list (or
+                  vendor-prefix derivation) and Model stays unfiltered.
+                  Selecting AUTO_PROVIDER (or leaving the value empty)
+                  saves "" to /workspaces/:id/provider, which the
+                  adapter resolves at boot. */}
               <div>
-                <label htmlFor={runtimeId} className="text-[10px] text-zinc-500 block mb-1">Runtime</label>
-                <select
-                  id={runtimeId}
-                  value={config.runtime || ""}
-                  onChange={(e) => update("runtime", e.target.value)}
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 focus:outline-none focus:border-blue-500"
-                >
-                  {runtimeOptions.map((opt) => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="text-[10px] text-zinc-500 block mb-1">
-                  Model
-                  {availableModels.length > 0 && (
-                    <span className="ml-1 text-zinc-600">({availableModels.length} suggested)</span>
+                <label htmlFor={`${runtimeId}-provider`} className="text-[10px] text-zinc-500 block mb-1">
+                  Provider
+                  {hasProviderRegistry && autoMatchedProvider && (
+                    <span className="ml-1 text-zinc-600">
+                      (auto: {autoMatchedProvider.name})
+                    </span>
                   )}
                 </label>
-                <input
-                  type="text"
-                  list={availableModels.length > 0 ? `${runtimeId}-models` : undefined}
-                  value={currentModelId}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setConfig((prev) => {
-                      // If the new value exactly matches a known modelSpec id,
-                      // swap required_env to that spec's list — but only when
-                      // the current required_env is empty or was itself
-                      // template-driven (i.e. matches the previous modelSpec's
-                      // required_env). User-typed envs always win.
-                      const nextSpec = availableModels.find((m) => m.id === v) ?? null;
-                      const prevModelId = prev.runtime_config?.model || prev.model || "";
-                      const prevSpec = availableModels.find((m) => m.id === prevModelId) ?? null;
-                      const prevRequired = prev.runtime_config?.required_env ?? [];
-                      const wasTemplateDriven =
-                        prevRequired.length === 0 ||
-                        (prevSpec?.required_env?.length
-                          ? prevRequired.length === prevSpec.required_env.length &&
-                            prevRequired.every((e, i) => e === prevSpec.required_env![i])
-                          : false);
-                      const nextRequired =
-                        nextSpec?.required_env?.length && wasTemplateDriven
-                          ? nextSpec.required_env
-                          : prevRequired;
-                      if (prev.runtime) {
-                        return {
-                          ...prev,
-                          runtime_config: {
-                            ...prev.runtime_config,
-                            model: v,
-                            ...(nextSpec?.required_env?.length && wasTemplateDriven
-                              ? { required_env: nextRequired }
-                              : {}),
-                          },
-                        };
+                {providerOptions.length > 0 ? (
+                  <select
+                    id={`${runtimeId}-provider`}
+                    value={provider || AUTO_PROVIDER}
+                    onChange={(e) => {
+                      const v = e.target.value === AUTO_PROVIDER ? "" : e.target.value;
+                      setProvider(v);
+                      // Switching providers can invalidate the current
+                      // model when it doesn't belong to the new provider's
+                      // claim list. Snap the model to the first one the
+                      // new provider DOES claim so the form never holds
+                      // an inconsistent (provider, model) pair.
+                      if (v && v !== AUTO_PROVIDER && hasProviderRegistry) {
+                        const filtered = modelsForProvider(v, availableModels, providerOptions);
+                        const stillValid = filtered.some((m) => m.id === currentModelId);
+                        if (!stillValid && filtered.length > 0) {
+                          setConfig((prev) => prev.runtime
+                            ? { ...prev, runtime_config: { ...prev.runtime_config, model: filtered[0].id } }
+                            : { ...prev, model: filtered[0].id });
+                        }
                       }
-                      return { ...prev, model: v };
-                    });
-                  }}
-                  placeholder="e.g. anthropic:claude-sonnet-4-6"
-                  className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
-                />
-                {availableModels.length > 0 && (
-                  <datalist id={`${runtimeId}-models`}>
-                    {availableModels.map((m, i) => (
-                      <option key={`${m.id}-${i}`} value={m.id}>{m.name || m.id}</option>
+                    }}
+                    aria-label="LLM provider"
+                    data-testid="provider-input"
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
+                  >
+                    <option value={AUTO_PROVIDER}>
+                      {AUTO_PROVIDER} — derive from model{autoMatchedProvider ? ` (${autoMatchedProvider.name})` : ""}
+                    </option>
+                    {providerOptions.map((p) => (
+                      <option key={p.name} value={p.name}>{p.name}</option>
                     ))}
-                  </datalist>
+                  </select>
+                ) : (
+                  // No suggestions and no registry — runtime hasn't
+                  // declared its taxonomy yet. Fall back to free-text
+                  // so a power user isn't blocked.
+                  <input
+                    id={`${runtimeId}-provider`}
+                    type="text"
+                    value={provider}
+                    onChange={(e) => setProvider(e.target.value.trim())}
+                    placeholder="empty = auto-derive from model slug"
+                    aria-label="LLM provider"
+                    data-testid="provider-input"
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
+                  />
+                )}
+                {provider && provider !== originalProvider && (
+                  <p className="text-[10px] text-amber-500 mt-1">
+                    Provider change → workspace will auto-restart on Save.
+                  </p>
+                )}
+              </div>
+              <div>
+                <label htmlFor={`${runtimeId}-model`} className="text-[10px] text-zinc-500 block mb-1">
+                  Model
+                  {filteredModels.length > 0 && (
+                    <span className="ml-1 text-zinc-600">
+                      ({filteredModels.length} {hasProviderRegistry && provider && provider !== AUTO_PROVIDER ? "for this provider" : "available"})
+                    </span>
+                  )}
+                </label>
+                {filteredModels.length > 0 ? (
+                  // <select> instead of <input list> — datalist would
+                  // hide options that don't substring-match the typed
+                  // value, which is the bug the user reported (typing
+                  // "sonnet" hides opus). A select shows everything
+                  // unconditionally.
+                  <select
+                    id={`${runtimeId}-model`}
+                    value={currentModelId}
+                    data-testid="model-select"
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setConfig((prev) => {
+                        if (prev.runtime) {
+                          return { ...prev, runtime_config: { ...prev.runtime_config, model: v } };
+                        }
+                        return { ...prev, model: v };
+                      });
+                    }}
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
+                  >
+                    {/* Defensive: if the saved model isn't in the
+                        filtered set (e.g. provider override picked but
+                        model didn't snap), surface it as a stranded
+                        option so the user can see what's currently
+                        saved without the select silently snapping it. */}
+                    {!filteredModels.some((m) => m.id === currentModelId) && currentModelId && (
+                      <option value={currentModelId}>{currentModelId} (current — not in this provider)</option>
+                    )}
+                    {filteredModels.map((m) => (
+                      <option key={m.id} value={m.id}>{m.name || m.id}</option>
+                    ))}
+                  </select>
+                ) : (
+                  // No models surfaced from the template (older runtime
+                  // or /templates failed). Free-text fallback.
+                  <input
+                    id={`${runtimeId}-model`}
+                    type="text"
+                    value={currentModelId}
+                    data-testid="model-select"
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      setConfig((prev) => prev.runtime
+                        ? { ...prev, runtime_config: { ...prev.runtime_config, model: v } }
+                        : { ...prev, model: v });
+                    }}
+                    placeholder="e.g. anthropic:claude-sonnet-4-6"
+                    className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
+                  />
                 )}
               </div>
             </div>
-            {/* Provider override (Option B PR-5). Free-text combobox so
-                operators can use any of the 30+ slugs hermes-agent's
-                derive-provider.sh recognizes — the suggestion list is
-                a hint, not a constraint. Empty = "auto-derive from
-                model slug prefix" which is correct for the common case
-                (model "anthropic:claude-opus-4-7" → provider derived
-                as "anthropic"). The override is needed when the model
-                alias has no clean vendor prefix (e.g. hermes default
-                "nousresearch/hermes-4-70b" → derive returns empty →
-                hermes errors "No LLM provider configured"). */}
-            <div>
-              <label htmlFor={`${runtimeId}-provider`} className="text-[10px] text-zinc-500 block mb-1">
-                Provider
-                <span className="ml-1 text-zinc-600">
-                  (override — leave empty to auto-derive from model slug)
-                </span>
-              </label>
-              <input
-                id={`${runtimeId}-provider`}
-                type="text"
-                list={providerSuggestions.length > 0 ? `${runtimeId}-providers` : undefined}
-                value={provider}
-                onChange={(e) => setProvider(e.target.value.trim())}
-                placeholder={
-                  providerSuggestions.length > 0
-                    ? `e.g. ${providerSuggestions.slice(0, 3).join(", ")} (empty = auto-derive)`
-                    : "empty = auto-derive from model slug"
-                }
-                aria-label="LLM provider override"
-                data-testid="provider-input"
-                className="w-full bg-zinc-800 border border-zinc-700 rounded px-2 py-1 text-xs text-zinc-200 font-mono focus:outline-none focus:border-blue-500"
-              />
-              {providerSuggestions.length > 0 && (
-                <datalist id={`${runtimeId}-providers`}>
-                  {providerSuggestions.map((p) => (
-                    <option key={p} value={p} />
+            {/* Required Env Var Names. When the structured registry
+                supplies a (provider, model) pair, the union of
+                provider.auth_env + model.required_env is what the
+                workspace actually needs and the field is read-only —
+                the user can't usefully edit it because the truth lives
+                in the template registry, not in this form. The
+                editor only re-appears as a TagList for legacy
+                templates that haven't shipped the structured shape. */}
+            {hasProviderRegistry && cascadedRequiredEnv.length > 0 ? (
+              <div>
+                <label className="text-[10px] text-zinc-500 block mb-1">
+                  Required Env Var Names <span className="ml-1 text-zinc-600">(from template — read-only)</span>
+                </label>
+                <div className="flex flex-wrap gap-1" data-testid="required-env-display">
+                  {cascadedRequiredEnv.map((e) => (
+                    <span key={e} className="px-1.5 py-0.5 bg-zinc-800 border border-zinc-700 rounded text-[10px] text-zinc-300 font-mono">
+                      {e}
+                    </span>
                   ))}
-                </datalist>
-              )}
-              {provider && provider !== originalProvider && (
-                <p className="text-[10px] text-amber-500 mt-1">
-                  Provider change → workspace will auto-restart on Save.
+                </div>
+                <p className="text-[10px] text-zinc-500 mt-1">
+                  Set the actual values in the <strong>Secrets</strong> section
+                  below — encrypted and mounted into the container at
+                  runtime. {effectiveProvider?.auth_env && effectiveProvider.auth_env.length > 1 && (
+                    <span>Provider <code className="text-zinc-400">{effectiveProvider.name}</code> accepts any one of its env vars.</span>
+                  )}
                 </p>
-              )}
-            </div>
-            <TagList
-              label={
-                currentModelSpec?.required_env?.length &&
-                arraysEqual(config.runtime_config?.required_env ?? [], currentModelSpec.required_env)
-                  ? "Required Env Var Names (from template)"
-                  : "Required Env Var Names"
-              }
-              values={config.runtime_config?.required_env ?? []}
-              onChange={(v) => updateNested("runtime_config" as keyof ConfigData, "required_env", v)}
-              placeholder="variable NAME (e.g. ANTHROPIC_API_KEY) — not the value"
-            />
-            <p className="text-[10px] text-zinc-500 mt-1">
-              This declares which env var <em>names</em> the workspace needs.
-              Set the actual values in the <strong>Secrets</strong> section
-              below — those are encrypted and mounted into the container at
-              runtime.
-            </p>
-            {currentModelSpec?.required_env?.length &&
-              !arraysEqual(config.runtime_config?.required_env ?? [], currentModelSpec.required_env) && (
-              <div className="text-[10px] text-zinc-500 mt-1 flex items-center gap-2">
-                <span>
-                  Template suggests{" "}
-                  <code className="text-zinc-400">{currentModelSpec.required_env.join(", ")}</code>{" "}
-                  for <code className="text-zinc-400">{currentModelSpec.name || currentModelSpec.id}</code>.
-                </span>
-                <button
-                  type="button"
-                  onClick={() => updateNested("runtime_config" as keyof ConfigData, "required_env", currentModelSpec.required_env)}
-                  className="text-blue-400 hover:text-blue-300 underline"
-                >
-                  Apply
-                </button>
               </div>
+            ) : (
+              <>
+                <TagList
+                  label="Required Env Var Names"
+                  values={config.runtime_config?.required_env ?? []}
+                  onChange={(v) => updateNested("runtime_config" as keyof ConfigData, "required_env", v)}
+                  placeholder="variable NAME (e.g. ANTHROPIC_API_KEY) — not the value"
+                />
+                <p className="text-[10px] text-zinc-500 mt-1">
+                  This declares which env var <em>names</em> the workspace needs.
+                  Set the actual values in the <strong>Secrets</strong> section
+                  below — those are encrypted and mounted into the container at
+                  runtime.
+                </p>
+              </>
             )}
           </Section>
 

--- a/canvas/src/components/tabs/__tests__/ConfigTab.cascade.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ConfigTab.cascade.test.tsx
@@ -1,0 +1,393 @@
+// @vitest-environment jsdom
+//
+// Regression tests for the ConfigTab Provider→Model→RequiredEnv
+// cascade (PR-6, 2026-05-02). These pin the four UX invariants the
+// user reported on hongming.moleculesai.app:
+//
+//   1. Config display matches the workspace's actual state (workspace
+//      metadata + override > config.yaml on disk).
+//   2. Provider is selected FIRST, then Model is filtered to that
+//      provider's claimed model_prefixes/aliases.
+//   3. Required Env Var Names is read-only when the template ships a
+//      structured provider_registry — the truth lives in the
+//      template, not the form.
+//   4. Switching providers shows ALL of that provider's models in
+//      the dropdown — including opus, which the previous
+//      datalist-filter UX would hide if the user had typed "sonnet".
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, waitFor, fireEvent, within } from "@testing-library/react";
+import React from "react";
+
+afterEach(cleanup);
+
+const apiGet = vi.fn();
+const apiPatch = vi.fn();
+const apiPut = vi.fn();
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: (path: string) => apiGet(path),
+    patch: (path: string, body: unknown) => apiPatch(path, body),
+    put: (path: string, body: unknown) => apiPut(path, body),
+    post: vi.fn(),
+    del: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/canvas", () => ({
+  useCanvasStore: Object.assign(
+    (selector: (s: unknown) => unknown) => selector({ restartWorkspace: vi.fn(), updateNodeData: vi.fn() }),
+    { getState: () => ({ restartWorkspace: vi.fn(), updateNodeData: vi.fn() }) },
+  ),
+}));
+
+import { ConfigTab } from "../ConfigTab";
+
+// Mirrors the production claude-code-default registry shape so the
+// tests fail loudly when the wire-shape contract drifts.
+const CLAUDE_REGISTRY = [
+  {
+    name: "anthropic-oauth",
+    auth_mode: "oauth",
+    model_prefixes: [],
+    model_aliases: ["sonnet", "opus", "haiku"],
+    auth_env: ["CLAUDE_CODE_OAUTH_TOKEN"],
+  },
+  {
+    name: "anthropic-api",
+    auth_mode: "anthropic_api",
+    model_prefixes: ["claude-"],
+    model_aliases: [],
+    auth_env: ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+  },
+  {
+    name: "xiaomi-mimo",
+    auth_mode: "third_party_anthropic_compat",
+    model_prefixes: ["mimo-"],
+    base_url: "https://api.xiaomimimo.com/anthropic",
+    auth_env: ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
+  },
+];
+
+const CLAUDE_MODELS = [
+  { id: "sonnet", name: "Claude Sonnet (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "opus", name: "Claude Opus (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "haiku", name: "Claude Haiku (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (API)", required_env: ["ANTHROPIC_API_KEY"] },
+  { id: "claude-opus-4-7", name: "Claude Opus 4.7 (API)", required_env: ["ANTHROPIC_API_KEY"] },
+  { id: "mimo-v2-pro", name: "Xiaomi MiMo V2 Pro", required_env: ["ANTHROPIC_API_KEY"] },
+];
+
+function wireClaudeCode(opts: { providerValue?: string; workspaceModel?: string } = {}) {
+  apiGet.mockImplementation((path: string) => {
+    if (path === "/workspaces/ws-test") {
+      return Promise.resolve({ runtime: "claude-code", tier: 2 });
+    }
+    if (path === "/workspaces/ws-test/model") {
+      return Promise.resolve({ model: opts.workspaceModel ?? "" });
+    }
+    if (path === "/workspaces/ws-test/provider") {
+      return Promise.resolve({ provider: opts.providerValue ?? "", source: opts.providerValue ? "workspace_secrets" : "default" });
+    }
+    if (path === "/workspaces/ws-test/files/config.yaml") {
+      return Promise.resolve({
+        content: "name: Claude Code Agent\nruntime: claude-code\nruntime_config:\n  model: sonnet\n",
+      });
+    }
+    if (path === "/templates") {
+      return Promise.resolve([
+        {
+          id: "claude-code-default",
+          name: "Claude Code Agent",
+          runtime: "claude-code",
+          models: CLAUDE_MODELS,
+          provider_registry: CLAUDE_REGISTRY,
+        },
+      ]);
+    }
+    return Promise.reject(new Error(`unmocked api.get: ${path}`));
+  });
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPatch.mockReset();
+  apiPut.mockReset();
+});
+
+describe("ConfigTab — Provider→Model cascade (PR-6)", () => {
+  // The headline regression: typing "sonnet" in the old datalist UX
+  // hid every other model. With provider→model cascade and a proper
+  // <select>, picking anthropic-oauth must show all three OAuth
+  // aliases — including opus.
+  it("opus appears in the model dropdown when anthropic-oauth is selected", async () => {
+    wireClaudeCode();
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    expect(providerSelect.tagName).toBe("SELECT");
+
+    fireEvent.change(providerSelect, { target: { value: "anthropic-oauth" } });
+
+    await waitFor(() => {
+      const modelSelect = screen.getByTestId("model-select") as HTMLSelectElement;
+      expect(modelSelect.tagName).toBe("SELECT");
+      const optionValues = Array.from(modelSelect.querySelectorAll("option")).map((o) => o.value);
+      expect(optionValues).toEqual(["sonnet", "opus", "haiku"]);
+    });
+  });
+
+  // Switching from oauth to api must filter the model dropdown to
+  // claude-* prefix matches and snap the selected model to a valid
+  // one (because "sonnet" doesn't belong to anthropic-api).
+  it("switching providers filters the model dropdown and snaps the selection", async () => {
+    wireClaudeCode({ workspaceModel: "sonnet" });
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    fireEvent.change(providerSelect, { target: { value: "anthropic-api" } });
+
+    await waitFor(() => {
+      const modelSelect = screen.getByTestId("model-select") as HTMLSelectElement;
+      const optionValues = Array.from(modelSelect.querySelectorAll("option")).map((o) => o.value);
+      expect(optionValues).toEqual(["claude-sonnet-4-6", "claude-opus-4-7"]);
+      // Snapped to the first valid model rather than holding the now-
+      // invalid `sonnet` value.
+      expect(modelSelect.value).toBe("claude-sonnet-4-6");
+    });
+  });
+
+  // Required Env Var Names: read-only display sourced from the union
+  // of provider.auth_env + model.required_env. The free-text TagList
+  // editor must not appear when the registry can supply the answer.
+  it("Required Env Var Names is read-only and shows the union of provider.auth_env + model.required_env", async () => {
+    wireClaudeCode();
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    fireEvent.change(providerSelect, { target: { value: "anthropic-api" } });
+
+    await waitFor(() => {
+      const display = screen.getByTestId("required-env-display");
+      const tags = within(display).getAllByText(/[A-Z_]+/).map((el) => el.textContent);
+      // Provider auth_env first (any-of: KEY OR TOKEN), then
+      // model.required_env (must-have). De-duped — the model only
+      // requires ANTHROPIC_API_KEY which is already in auth_env.
+      expect(tags).toEqual(["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]);
+    });
+  });
+
+  // Provider auto-derive: when no override is set, the form must
+  // surface what the adapter would resolve at boot. The auto-match
+  // shows in the label, and the required-env display reflects that
+  // provider's auth_env even though provider is "".
+  it("auto-derives provider hints from the saved model when no override is set", async () => {
+    wireClaudeCode({ workspaceModel: "claude-opus-4-7" });
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    // The provider <select> shows AUTO_PROVIDER as the value.
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    await waitFor(() => expect(providerSelect.value).toBe("(auto)"));
+
+    // Auto-match label includes the resolved provider name.
+    expect(screen.getByText(/auto: anthropic-api/i)).toBeTruthy();
+
+    // Required-env display reflects anthropic-api's auth_env even
+    // though no explicit override is saved.
+    await waitFor(() => {
+      const display = screen.getByTestId("required-env-display");
+      const tags = within(display).getAllByText(/[A-Z_]+/).map((el) => el.textContent);
+      expect(tags).toEqual(["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"]);
+    });
+  });
+
+  // The form's display must reflect WORKSPACE METADATA + override,
+  // not stale config.yaml. Run with workspaceModel="opus" and
+  // config.yaml.runtime_config.model="sonnet" — the model select
+  // must show "opus" (workspace state), not "sonnet" (yaml).
+  it("displays the workspace's actual model state, not the config.yaml value", async () => {
+    apiGet.mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-test") return Promise.resolve({ runtime: "claude-code", tier: 2 });
+      // Workspace endpoint says opus.
+      if (path === "/workspaces/ws-test/model") return Promise.resolve({ model: "opus" });
+      if (path === "/workspaces/ws-test/provider") return Promise.resolve({ provider: "" });
+      // config.yaml on disk says sonnet — should LOSE.
+      if (path === "/workspaces/ws-test/files/config.yaml") {
+        return Promise.resolve({ content: "name: x\nruntime: claude-code\nruntime_config:\n  model: sonnet\n" });
+      }
+      if (path === "/templates") {
+        return Promise.resolve([
+          {
+            id: "claude-code-default",
+            runtime: "claude-code",
+            models: CLAUDE_MODELS,
+            provider_registry: CLAUDE_REGISTRY,
+          },
+        ]);
+      }
+      return Promise.reject(new Error(`unmocked: ${path}`));
+    });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    await waitFor(() => {
+      const modelSelect = screen.getByTestId("model-select") as HTMLSelectElement;
+      // Workspace metadata wins.
+      expect(modelSelect.value).toBe("opus");
+    });
+  });
+
+  // Saving a provider+model pair must PUT to both endpoints with the
+  // correct shape. The provider PUT triggers the auto-restart server-
+  // side; the model PUT validates against the runtime template.
+  it("PUTs provider and model to their respective endpoints on Save", async () => {
+    wireClaudeCode();
+    apiPut.mockResolvedValue({ status: "saved" });
+    apiPatch.mockResolvedValue({});
+
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    fireEvent.change(providerSelect, { target: { value: "xiaomi-mimo" } });
+
+    await waitFor(() => {
+      const modelSelect = screen.getByTestId("model-select") as HTMLSelectElement;
+      expect(modelSelect.value).toBe("mimo-v2-pro");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const providerCalls = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/provider");
+      expect(providerCalls.length).toBe(1);
+      expect(providerCalls[0][1]).toEqual({ provider: "xiaomi-mimo" });
+    });
+    await waitFor(() => {
+      const modelCalls = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/model");
+      expect(modelCalls.length).toBe(1);
+      expect(modelCalls[0][1]).toEqual({ model: "mimo-v2-pro" });
+    });
+  });
+
+  // Picking AUTO_PROVIDER (the dropdown default) must save "" — that
+  // clears any previous override and lets the adapter derive at boot.
+  it("AUTO_PROVIDER selection saves the empty-string override", async () => {
+    wireClaudeCode({ providerValue: "xiaomi-mimo" });
+    apiPut.mockResolvedValue({ status: "cleared" });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const providerSelect = await screen.findByTestId("provider-input") as HTMLSelectElement;
+    await waitFor(() => expect(providerSelect.value).toBe("xiaomi-mimo"));
+
+    fireEvent.change(providerSelect, { target: { value: "(auto)" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() => {
+      const providerCalls = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/provider");
+      expect(providerCalls.length).toBe(1);
+      expect(providerCalls[0][1]).toEqual({ provider: "" });
+    });
+  });
+
+  // Legacy template (no provider_registry) must keep the editable
+  // TagList for required env names — otherwise users on older
+  // templates lose the ability to set anything.
+  it("legacy templates without provider_registry keep the editable required-env TagList", async () => {
+    apiGet.mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-test") return Promise.resolve({ runtime: "hermes", tier: 2 });
+      if (path === "/workspaces/ws-test/model") return Promise.resolve({ model: "" });
+      if (path === "/workspaces/ws-test/provider") return Promise.resolve({ provider: "" });
+      if (path === "/workspaces/ws-test/files/config.yaml") {
+        return Promise.resolve({
+          content: "name: x\nruntime: hermes\nruntime_config:\n  required_env:\n    - LEGACY_KEY\n",
+        });
+      }
+      if (path === "/templates") {
+        // Old hermes shape: flat providers list, no provider_registry.
+        return Promise.resolve([
+          { id: "hermes", runtime: "hermes", models: [], providers: ["nous"] },
+        ]);
+      }
+      return Promise.reject(new Error(`unmocked: ${path}`));
+    });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    await waitFor(() => {
+      // The free-text TagList editor's placeholder should still appear.
+      expect(screen.getByPlaceholderText(/variable NAME/i)).toBeTruthy();
+      // No structured read-only display.
+      expect(screen.queryByTestId("required-env-display")).toBeNull();
+    });
+  });
+
+  // Legacy template with NO models[] surfaces the model field as a
+  // free-text <input> so a power user isn't blocked. Setting a value
+  // and saving must still PUT /workspaces/:id/model with the typed
+  // string, even though there's no select to pick from.
+  it("falls back to a free-text model input when the runtime ships no models", async () => {
+    apiGet.mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-test") return Promise.resolve({ runtime: "hermes", tier: 2 });
+      if (path === "/workspaces/ws-test/model") return Promise.resolve({ model: "" });
+      if (path === "/workspaces/ws-test/provider") return Promise.resolve({ provider: "" });
+      if (path === "/workspaces/ws-test/files/config.yaml") {
+        return Promise.resolve({ content: "name: x\nruntime: hermes\n" });
+      }
+      if (path === "/templates") {
+        return Promise.resolve([{ id: "hermes", runtime: "hermes", models: [] }]);
+      }
+      return Promise.reject(new Error(`unmocked: ${path}`));
+    });
+    apiPut.mockResolvedValue({});
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const modelInput = await screen.findByTestId("model-select") as HTMLInputElement;
+    expect(modelInput.tagName).toBe("INPUT");
+
+    fireEvent.change(modelInput, { target: { value: "custom/some-other-model" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => {
+      const modelCalls = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/model");
+      expect(modelCalls.length).toBe(1);
+      expect(modelCalls[0][1]).toEqual({ model: "custom/some-other-model" });
+    });
+  });
+
+  // Defensive: a saved model that doesn't belong to the currently-
+  // selected provider's claim list must remain visible as a
+  // "stranded" option so the user sees what's actually saved. Without
+  // this, the select would silently snap to the first filtered
+  // option and the user would lose the configuration without
+  // confirmation.
+  it("preserves a stranded saved model as a labeled fallback option", async () => {
+    apiGet.mockImplementation((path: string) => {
+      if (path === "/workspaces/ws-test") return Promise.resolve({ runtime: "claude-code", tier: 2 });
+      if (path === "/workspaces/ws-test/model") return Promise.resolve({ model: "some-strange-model-id" });
+      if (path === "/workspaces/ws-test/provider") return Promise.resolve({ provider: "anthropic-oauth" });
+      if (path === "/workspaces/ws-test/files/config.yaml") {
+        return Promise.resolve({ content: "runtime: claude-code\n" });
+      }
+      if (path === "/templates") {
+        return Promise.resolve([
+          {
+            id: "claude-code-default",
+            runtime: "claude-code",
+            models: CLAUDE_MODELS,
+            provider_registry: CLAUDE_REGISTRY,
+          },
+        ]);
+      }
+      return Promise.reject(new Error(`unmocked: ${path}`));
+    });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+
+    await waitFor(() => {
+      const modelSelect = screen.getByTestId("model-select") as HTMLSelectElement;
+      expect(modelSelect.value).toBe("some-strange-model-id");
+      const text = Array.from(modelSelect.querySelectorAll("option")).map((o) => o.textContent || "").join(" ");
+      expect(text).toContain("not in this provider");
+    });
+  });
+});

--- a/canvas/src/components/tabs/__tests__/ConfigTab.hermes.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ConfigTab.hermes.test.tsx
@@ -215,12 +215,17 @@ describe("ConfigTab — Save persists model under runtime_config.model (2026-04-
       ).toBe("hermes"),
     );
 
-    // The model input is a free-text input wired to a datalist of suggestions.
-    const modelInput = (await waitFor(() =>
-      screen.getByPlaceholderText(/anthropic:claude-sonnet/i),
-    )) as HTMLInputElement;
+    // The model input is a <select> populated from the template's
+    // models[]. To exercise an off-list "user-typed" value the test
+    // uses the model-select's onChange handler — when the runtime
+    // ships no models, the form falls back to a free-text input
+    // (handled below); when it ships models, we change the select
+    // value to one that's in the list.
+    const modelSelect = (await waitFor(() =>
+      screen.getByTestId("model-select"),
+    )) as HTMLSelectElement;
 
-    fireEvent.change(modelInput, {
+    fireEvent.change(modelSelect, {
       target: { value: "minimax/MiniMax-M2.7-highspeed" },
     });
 

--- a/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
@@ -210,19 +210,19 @@ describe("ConfigTab — Provider override (Option B PR-5)", () => {
     });
   });
 
-  // The dropdown's suggestion list MUST come from the runtime's own
-  // template (via /templates → runtime_config.providers), not a
-  // hardcoded canvas-side enum. This is the "Native + pluggable
-  // runtime" invariant: a new runtime declaring its own provider
-  // taxonomy in its config.yaml gets a working dropdown without ANY
-  // canvas-side change.
+  // The dropdown's options MUST come from the runtime's own template
+  // (via /templates → runtime_config.providers), not a hardcoded
+  // canvas-side enum. This is the "Native + pluggable runtime"
+  // invariant: a new runtime declaring its own provider taxonomy in
+  // its config.yaml gets a working dropdown without ANY canvas-side
+  // change.
   //
-  // Pinned by checking that suggestions surfaced in the datalist
-  // exactly mirror what the templates endpoint returned for the
-  // matching runtime. If a future contributor reintroduces a
-  // PROVIDER_SUGGESTIONS-style hardcoded list and the datalist
+  // Pinned by checking that the rendered <select> options exactly
+  // mirror what the templates endpoint returned for the matching
+  // runtime. If a future contributor reintroduces a
+  // PROVIDER_SUGGESTIONS-style hardcoded list and the dropdown
   // contents don't follow the template, this test fails.
-  it("populates the provider datalist from the matched runtime's templates entry", async () => {
+  it("populates the provider select from the matched runtime's templates entry", async () => {
     wireApi({
       workspaceRuntime: "hermes",
       workspaceModel: "nousresearch/hermes-4-70b",
@@ -242,15 +242,12 @@ describe("ConfigTab — Provider override (Option B PR-5)", () => {
     });
 
     render(<ConfigTab workspaceId="ws-test" />);
-    const input = await screen.findByTestId("provider-input");
-    const listId = (input as HTMLInputElement).getAttribute("list");
-    expect(listId).toBeTruthy();
+    const select = await screen.findByTestId("provider-input");
+    expect(select.tagName).toBe("SELECT");
     await waitFor(() => {
-      const datalist = document.getElementById(listId!);
-      expect(datalist).not.toBeNull();
-      const optionValues = Array.from(datalist!.querySelectorAll("option")).map(
-        (o) => (o as HTMLOptionElement).value,
-      );
+      const optionValues = Array.from(select.querySelectorAll("option"))
+        .map((o) => (o as HTMLOptionElement).value)
+        .filter((v) => v !== "(auto)");
       // Order matters — most-common-first is part of the contract so
       // the demo flow lands on a working choice without scrolling.
       expect(optionValues).toEqual(["nous", "openrouter", "anthropic", "minimax-cn"]);
@@ -285,14 +282,12 @@ describe("ConfigTab — Provider override (Option B PR-5)", () => {
     });
 
     render(<ConfigTab workspaceId="ws-test" />);
-    const input = await screen.findByTestId("provider-input");
-    const listId = (input as HTMLInputElement).getAttribute("list");
-    expect(listId).toBeTruthy();
+    const select = await screen.findByTestId("provider-input");
+    expect(select.tagName).toBe("SELECT");
     await waitFor(() => {
-      const datalist = document.getElementById(listId!);
-      const optionValues = Array.from(datalist!.querySelectorAll("option")).map(
-        (o) => (o as HTMLOptionElement).value,
-      );
+      const optionValues = Array.from(select.querySelectorAll("option"))
+        .map((o) => (o as HTMLOptionElement).value)
+        .filter((v) => v !== "(auto)");
       // Order = first-appearance from models[]; dedup keeps anthropic
       // once even though two model slugs use it.
       expect(optionValues).toEqual(["anthropic", "openai", "nousresearch"]);

--- a/canvas/src/components/tabs/config/__tests__/provider-cascade.test.ts
+++ b/canvas/src/components/tabs/config/__tests__/provider-cascade.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from "vitest";
+import {
+  AUTO_PROVIDER,
+  matchProviderForModel,
+  modelsForProvider,
+  requiredEnvFor,
+  deriveProvidersFromModels,
+  providerListForRuntime,
+  type ProviderEntry,
+  type ModelSpec,
+} from "../provider-cascade";
+
+// Mirrors the production claude-code-default registry shape so the
+// tests fail loudly if the wire shape ever drifts away from what the
+// workspace-server templates handler emits.
+const CLAUDE_REGISTRY: ProviderEntry[] = [
+  {
+    name: "anthropic-oauth",
+    auth_mode: "oauth",
+    model_prefixes: [],
+    model_aliases: ["sonnet", "opus", "haiku"],
+    auth_env: ["CLAUDE_CODE_OAUTH_TOKEN"],
+  },
+  {
+    name: "anthropic-api",
+    auth_mode: "anthropic_api",
+    model_prefixes: ["claude-"],
+    model_aliases: [],
+    auth_env: ["ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"],
+  },
+  {
+    name: "xiaomi-mimo",
+    auth_mode: "third_party_anthropic_compat",
+    model_prefixes: ["mimo-"],
+    model_aliases: [],
+    base_url: "https://api.xiaomimimo.com/anthropic",
+    auth_env: ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"],
+  },
+];
+
+const CLAUDE_MODELS: ModelSpec[] = [
+  { id: "sonnet", name: "Claude Sonnet (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "opus", name: "Claude Opus (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "haiku", name: "Claude Haiku (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+  { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6 (API)", required_env: ["ANTHROPIC_API_KEY"] },
+  { id: "claude-opus-4-7", name: "Claude Opus 4.7 (API)", required_env: ["ANTHROPIC_API_KEY"] },
+  { id: "claude-haiku-4-5", name: "Claude Haiku 4.5 (API)", required_env: ["ANTHROPIC_API_KEY"] },
+  { id: "mimo-v2-pro", name: "Xiaomi MiMo V2 Pro", required_env: ["ANTHROPIC_API_KEY"] },
+];
+
+describe("matchProviderForModel", () => {
+  // Aliases beat prefixes in registry order. The OAuth entry comes
+  // first in claude-code-default so the bare alias `sonnet` resolves
+  // to anthropic-oauth — matching the adapter's boot-time behavior.
+  it("matches by alias before prefix", () => {
+    const got = matchProviderForModel("sonnet", CLAUDE_REGISTRY);
+    expect(got?.name).toBe("anthropic-oauth");
+  });
+
+  it("matches versioned ids by prefix", () => {
+    expect(matchProviderForModel("claude-opus-4-7", CLAUDE_REGISTRY)?.name).toBe("anthropic-api");
+    expect(matchProviderForModel("mimo-v2-pro", CLAUDE_REGISTRY)?.name).toBe("xiaomi-mimo");
+  });
+
+  it("is case-insensitive on both sides", () => {
+    expect(matchProviderForModel("OPUS", CLAUDE_REGISTRY)?.name).toBe("anthropic-oauth");
+    expect(matchProviderForModel("MIMO-V2-PRO", CLAUDE_REGISTRY)?.name).toBe("xiaomi-mimo");
+    const upperRegistry: ProviderEntry[] = [
+      { name: "vendor", model_prefixes: ["FOO-"] },
+    ];
+    expect(matchProviderForModel("foo-bar", upperRegistry)?.name).toBe("vendor");
+  });
+
+  it("returns null when nothing claims the id", () => {
+    expect(matchProviderForModel("unknown-model", CLAUDE_REGISTRY)).toBeNull();
+  });
+
+  it("returns null on empty inputs", () => {
+    expect(matchProviderForModel("", CLAUDE_REGISTRY)).toBeNull();
+    expect(matchProviderForModel("sonnet", [])).toBeNull();
+  });
+
+  it("ignores empty-string prefixes (would otherwise match everything)", () => {
+    const sketchy: ProviderEntry[] = [{ name: "broken", model_prefixes: [""] }];
+    expect(matchProviderForModel("anything", sketchy)).toBeNull();
+  });
+});
+
+describe("modelsForProvider", () => {
+  // The user-reported bug: typing "sonnet" in the datalist hides
+  // every option without "sonnet" in id/name, including opus. With a
+  // proper provider→model cascade and a select, picking
+  // anthropic-oauth shows all three OAuth aliases including opus.
+  it("filtering by anthropic-oauth shows opus alongside sonnet+haiku", () => {
+    const got = modelsForProvider("anthropic-oauth", CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got.map((m) => m.id)).toEqual(["sonnet", "opus", "haiku"]);
+  });
+
+  it("filtering by anthropic-api shows the versioned prefix matches", () => {
+    const got = modelsForProvider("anthropic-api", CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got.map((m) => m.id)).toEqual(["claude-sonnet-4-6", "claude-opus-4-7", "claude-haiku-4-5"]);
+  });
+
+  it("filtering by xiaomi-mimo shows just the mimo-* models", () => {
+    const got = modelsForProvider("xiaomi-mimo", CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got.map((m) => m.id)).toEqual(["mimo-v2-pro"]);
+  });
+
+  it("AUTO_PROVIDER returns the unfiltered list", () => {
+    const got = modelsForProvider(AUTO_PROVIDER, CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got).toHaveLength(CLAUDE_MODELS.length);
+  });
+
+  it("empty provider name returns the unfiltered list", () => {
+    const got = modelsForProvider("", CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got).toHaveLength(CLAUDE_MODELS.length);
+  });
+
+  it("unknown provider name returns the unfiltered list", () => {
+    const got = modelsForProvider("not-a-provider", CLAUDE_MODELS, CLAUDE_REGISTRY);
+    expect(got).toHaveLength(CLAUDE_MODELS.length);
+  });
+
+  // A model id that matches both an alias and a prefix (defensive:
+  // unlikely in production but test it once) appears once. Set-based
+  // dedup is the load-bearing detail.
+  it("dedupes when alias + prefix would both match", () => {
+    const overlap: ProviderEntry[] = [{
+      name: "weird",
+      model_aliases: ["claude-opus-4-7"],
+      model_prefixes: ["claude-"],
+    }];
+    const got = modelsForProvider("weird", [{ id: "claude-opus-4-7" }], overlap);
+    expect(got).toHaveLength(1);
+  });
+
+  it("handles a provider with neither aliases nor prefixes (filters everything out)", () => {
+    const skeletal: ProviderEntry[] = [{ name: "empty" }];
+    const got = modelsForProvider("empty", CLAUDE_MODELS, skeletal);
+    expect(got).toEqual([]);
+  });
+
+  it("skips models with empty id", () => {
+    const withEmpty: ModelSpec[] = [{ id: "" }, { id: "sonnet" }];
+    const got = modelsForProvider("anthropic-oauth", withEmpty, CLAUDE_REGISTRY);
+    expect(got.map((m) => m.id)).toEqual(["sonnet"]);
+  });
+});
+
+describe("requiredEnvFor", () => {
+  // OAuth path: provider says CLAUDE_CODE_OAUTH_TOKEN, model says
+  // CLAUDE_CODE_OAUTH_TOKEN. Union dedupes to a single entry — UI
+  // should not show the same env var name twice.
+  it("dedupes overlap between provider auth_env and model required_env", () => {
+    const provider = CLAUDE_REGISTRY[0];
+    const model = CLAUDE_MODELS.find((m) => m.id === "sonnet")!;
+    expect(requiredEnvFor(provider, model)).toEqual(["CLAUDE_CODE_OAUTH_TOKEN"]);
+  });
+
+  // API key path: provider accepts ANTHROPIC_API_KEY OR
+  // ANTHROPIC_AUTH_TOKEN, model requires ANTHROPIC_API_KEY. Union is
+  // ordered with provider auth_env first.
+  it("orders provider auth_env before model required_env", () => {
+    const provider = CLAUDE_REGISTRY[1];
+    const model = CLAUDE_MODELS.find((m) => m.id === "claude-opus-4-7")!;
+    expect(requiredEnvFor(provider, model)).toEqual([
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN",
+    ]);
+  });
+
+  it("works when only provider has auth_env (model missing)", () => {
+    expect(requiredEnvFor(CLAUDE_REGISTRY[0], null)).toEqual(["CLAUDE_CODE_OAUTH_TOKEN"]);
+  });
+
+  it("works when only model has required_env (provider missing)", () => {
+    const model = CLAUDE_MODELS.find((m) => m.id === "claude-opus-4-7")!;
+    expect(requiredEnvFor(null, model)).toEqual(["ANTHROPIC_API_KEY"]);
+  });
+
+  it("returns empty when both are missing", () => {
+    expect(requiredEnvFor(null, null)).toEqual([]);
+    expect(requiredEnvFor({ name: "x" }, { id: "y" })).toEqual([]);
+  });
+});
+
+describe("deriveProvidersFromModels", () => {
+  it("splits on `:`", () => {
+    expect(deriveProvidersFromModels([
+      { id: "anthropic:claude-opus-4-7" },
+      { id: "openai:gpt-4o" },
+    ])).toEqual(["anthropic", "openai"]);
+  });
+
+  it("splits on `/`", () => {
+    expect(deriveProvidersFromModels([
+      { id: "nousresearch/hermes-4-70b" },
+    ])).toEqual(["nousresearch"]);
+  });
+
+  it("dedupes within run", () => {
+    expect(deriveProvidersFromModels([
+      { id: "anthropic:opus" },
+      { id: "anthropic:sonnet" },
+    ])).toEqual(["anthropic"]);
+  });
+
+  it("skips ids with no separator", () => {
+    expect(deriveProvidersFromModels([
+      { id: "sonnet" },
+      { id: "opus" },
+    ])).toEqual([]);
+  });
+
+  it("handles empty/missing ids", () => {
+    expect(deriveProvidersFromModels([])).toEqual([]);
+    expect(deriveProvidersFromModels([{ id: "" }])).toEqual([]);
+  });
+});
+
+describe("providerListForRuntime", () => {
+  // Structured registry wins. claude-code-default ships seven entries;
+  // the form should pick those, not the empty flat list, and not the
+  // empty derive (since the model ids don't have `:` separators).
+  it("prefers the structured registry over the flat list", () => {
+    const got = providerListForRuntime(CLAUDE_REGISTRY, ["should-not-show"], CLAUDE_MODELS);
+    expect(got.map((p) => p.name)).toEqual(["anthropic-oauth", "anthropic-api", "xiaomi-mimo"]);
+  });
+
+  it("falls back to flat providers when registry empty", () => {
+    const got = providerListForRuntime([], ["nous", "openrouter"], []);
+    expect(got).toEqual([{ name: "nous" }, { name: "openrouter" }]);
+  });
+
+  it("falls back to derive when both registry and flat are empty", () => {
+    const got = providerListForRuntime(undefined, [], [
+      { id: "anthropic:opus" },
+      { id: "openai:gpt-4o" },
+    ]);
+    expect(got).toEqual([{ name: "anthropic" }, { name: "openai" }]);
+  });
+
+  it("returns empty when nothing can be inferred", () => {
+    expect(providerListForRuntime(undefined, [], [])).toEqual([]);
+    expect(providerListForRuntime(undefined, [], [{ id: "sonnet" }])).toEqual([]);
+  });
+});

--- a/canvas/src/components/tabs/config/index.ts
+++ b/canvas/src/components/tabs/config/index.ts
@@ -1,3 +1,13 @@
 export { type ConfigData, DEFAULT_CONFIG, TextInput, NumberInput, Toggle, TagList, Section } from "./form-inputs";
 export { parseYaml, toYaml } from "./yaml-utils";
 export { SecretsSection } from "./secrets-section";
+export {
+  AUTO_PROVIDER,
+  matchProviderForModel,
+  modelsForProvider,
+  requiredEnvFor,
+  deriveProvidersFromModels,
+  providerListForRuntime,
+  type ProviderEntry,
+  type ModelSpec,
+} from "./provider-cascade";

--- a/canvas/src/components/tabs/config/provider-cascade.ts
+++ b/canvas/src/components/tabs/config/provider-cascade.ts
@@ -1,0 +1,161 @@
+/** Pure helpers for the ConfigTab provider→model cascade.
+ *
+ *  Lives in its own module so the cascade logic is unit-testable
+ *  without rendering the React tree. The ConfigTab consumes these
+ *  with the structured `provider_registry` field surfaced by
+ *  workspace-server's /templates handler. Falls back to flat
+ *  `providers []string` (legacy hermes shape) and finally to
+ *  vendor-prefix derivation when neither is present. */
+
+export interface ModelSpec {
+  id: string;
+  name?: string;
+  required_env?: string[];
+}
+
+/** Mirrors providerEntry from workspace-server templates.go. The
+ *  yaml-null `base_url` becomes "" on the wire (omitempty drops it,
+ *  but JSON omits the key). Both ModelPrefixes and ModelAliases are
+ *  treated case-insensitively when matching. */
+export interface ProviderEntry {
+  name: string;
+  auth_mode?: string;
+  model_prefixes?: string[];
+  model_aliases?: string[];
+  base_url?: string;
+  auth_env?: string[];
+}
+
+/** Sentinel string for "let the runtime pick a provider from the
+ *  selected model id." When the operator picks this in the dropdown,
+ *  the saved provider override is empty (`""`) and the adapter falls
+ *  back to its built-in derive logic. */
+export const AUTO_PROVIDER = "(auto)";
+
+/** matchProviderForModel — given a model id and the provider
+ *  registry, return the FIRST entry whose model_aliases or
+ *  model_prefixes claim that id. Case-insensitive. Returns null when
+ *  nothing matches.
+ *
+ *  Order matters in config.yaml: anthropic-oauth precedes
+ *  anthropic-api so `sonnet` → oauth (alias hit) before `claude-X`
+ *  prefix kicks in. Preserve that order so the canvas auto-selection
+ *  matches what the adapter does at boot. */
+export function matchProviderForModel(
+  modelId: string,
+  registry: readonly ProviderEntry[],
+): ProviderEntry | null {
+  if (!modelId || !registry || registry.length === 0) return null;
+  const lower = modelId.toLowerCase();
+  for (const p of registry) {
+    if (p.model_aliases?.some((a) => a.toLowerCase() === lower)) return p;
+    if (p.model_prefixes?.some((pre) => pre && lower.startsWith(pre.toLowerCase()))) return p;
+  }
+  return null;
+}
+
+/** modelsForProvider — filter the runtime's full models list down to
+ *  the ones a given provider claims via its model_aliases or
+ *  model_prefixes. Returns the ORIGINAL list when providerName is
+ *  AUTO_PROVIDER or the provider isn't in the registry — there's no
+ *  filter to apply, the operator gets the unfiltered set.
+ *
+ *  Deduplicates by id while preserving order, since the same model id
+ *  could match two providers (sonnet→oauth via alias, sonnet→api via
+ *  prefix expansion if config evolves) and the dropdown should show it
+ *  once. */
+export function modelsForProvider(
+  providerName: string,
+  models: readonly ModelSpec[],
+  registry: readonly ProviderEntry[],
+): ModelSpec[] {
+  if (!providerName || providerName === AUTO_PROVIDER) return [...models];
+  const provider = registry.find((p) => p.name === providerName);
+  if (!provider) return [...models];
+
+  const aliases = new Set((provider.model_aliases || []).map((a) => a.toLowerCase()));
+  const prefixes = (provider.model_prefixes || [])
+    .filter((p) => p)
+    .map((p) => p.toLowerCase());
+
+  const seen = new Set<string>();
+  const out: ModelSpec[] = [];
+  for (const m of models) {
+    if (!m.id || seen.has(m.id)) continue;
+    const lower = m.id.toLowerCase();
+    if (aliases.has(lower) || prefixes.some((pre) => lower.startsWith(pre))) {
+      seen.add(m.id);
+      out.push(m);
+    }
+  }
+  return out;
+}
+
+/** requiredEnvFor — union of (provider.auth_env, model.required_env)
+ *  with provider auth_env first since it's the "any-of" auth path
+ *  (e.g. ANTHROPIC_API_KEY OR ANTHROPIC_AUTH_TOKEN) and the per-model
+ *  required_env is the "must-have" specifier the template wrote. The
+ *  caller treats provider.auth_env as semantically "any one of" and
+ *  model.required_env as "all of"; this helper just orders them.
+ *
+ *  Dedupes via Set so when both lists name CLAUDE_CODE_OAUTH_TOKEN we
+ *  emit it once. */
+export function requiredEnvFor(
+  provider: ProviderEntry | null,
+  model: ModelSpec | null,
+): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const push = (v: string | undefined) => {
+    if (v && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  };
+  for (const e of provider?.auth_env || []) push(e);
+  for (const e of model?.required_env || []) push(e);
+  return out;
+}
+
+/** deriveProvidersFromModels — fallback for templates that ship neither
+ *  a structured registry nor a flat providers list. Take the first
+ *  vendor-prefix segment from each model id (split on `:` or `/`) and
+ *  dedupe. Hermes-style legacy shape.
+ *
+ *  Returns [] when nothing can be derived — the form then renders the
+ *  Provider field as a free-text input rather than an empty select.
+ *  Callers convert these strings into pseudo ProviderEntry rows
+ *  (name-only, no aliases/prefixes/auth_env) for the dropdown. */
+export function deriveProvidersFromModels(models: readonly ModelSpec[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of models) {
+    if (!m.id) continue;
+    const sep = m.id.match(/[:/]/)?.index ?? -1;
+    if (sep <= 0) continue;
+    const vendor = m.id.slice(0, sep);
+    if (!seen.has(vendor)) {
+      seen.add(vendor);
+      out.push(vendor);
+    }
+  }
+  return out;
+}
+
+/** providerListForRuntime — single source of truth for the provider
+ *  dropdown options. Prefers the structured registry, falls back to
+ *  the flat `providers []string` list (synthesizing minimal
+ *  ProviderEntry rows so the rest of the cascade has a uniform shape),
+ *  finally falls back to vendor-prefix derivation. Returns the list
+ *  the form should render directly. */
+export function providerListForRuntime(
+  registry: readonly ProviderEntry[] | undefined,
+  flatProviders: readonly string[] | undefined,
+  models: readonly ModelSpec[],
+): ProviderEntry[] {
+  if (registry && registry.length > 0) return [...registry];
+  const flat = (flatProviders && flatProviders.length > 0)
+    ? flatProviders
+    : deriveProvidersFromModels(models);
+  return flat.map((name) => ({ name }));
+}

--- a/workspace-server/internal/handlers/templates.go
+++ b/workspace-server/internal/handlers/templates.go
@@ -45,6 +45,28 @@ type modelSpec struct {
 	RequiredEnv []string `json:"required_env,omitempty" yaml:"required_env"`
 }
 
+// providerEntry mirrors a single entry from the template's top-level
+// `providers:` registry block. The schema is a richer evolution of the
+// flat `runtime_config.providers []string` shape: each entry declares
+// which model ids it claims (via prefixes/aliases), the auth env vars
+// it accepts, and an optional ANTHROPIC_BASE_URL the adapter sets at
+// boot.
+//
+// claude-code-default ships this shape (anthropic-oauth, anthropic-api,
+// xiaomi-mimo, minimax, zai, moonshot, deepseek). Surfacing the full
+// shape lets the canvas Config tab build a provider→model cascade
+// without hardcoding the taxonomy and gives the adapter a single
+// source of truth. A template that hasn't migrated has no top-level
+// `providers:` block and the field is omitted on the wire.
+type providerEntry struct {
+	Name          string   `json:"name" yaml:"name"`
+	AuthMode      string   `json:"auth_mode,omitempty" yaml:"auth_mode"`
+	ModelPrefixes []string `json:"model_prefixes,omitempty" yaml:"model_prefixes"`
+	ModelAliases  []string `json:"model_aliases,omitempty" yaml:"model_aliases"`
+	BaseURL       string   `json:"base_url,omitempty" yaml:"base_url"`
+	AuthEnv       []string `json:"auth_env,omitempty" yaml:"auth_env"`
+}
+
 type templateSummary struct {
 	ID          string      `json:"id"`
 	Name        string      `json:"name"`
@@ -68,9 +90,17 @@ type templateSummary struct {
 	// a different vendor list doesn't need a canvas edit. Empty list →
 	// canvas falls back to deriving suggestions from `models[].id` slug
 	// prefixes (still adapter-driven, just inferred).
-	Providers   []string `json:"providers,omitempty"`
-	Skills      []string `json:"skills"`
-	SkillCount  int      `json:"skill_count"`
+	Providers []string `json:"providers,omitempty"`
+	// ProviderRegistry is the structured provider registry sourced from
+	// the template's TOP-LEVEL `providers:` block (the richer schema:
+	// each entry declares model_prefixes / model_aliases / auth_env /
+	// base_url). claude-code-default ships this; older templates ship
+	// only the flat `Providers` list above. Canvas prefers ProviderRegistry
+	// when non-empty so it can build a provider→model cascade and a
+	// read-only required-env display from a single source of truth.
+	ProviderRegistry []providerEntry `json:"provider_registry,omitempty"`
+	Skills           []string        `json:"skills"`
+	SkillCount       int             `json:"skill_count"`
 	// ProvisionTimeoutSeconds lets a slow runtime declare its expected
 	// cold-boot duration in its template manifest. Canvas's
 	// ProvisioningTimeout banner respects this per-workspace via the
@@ -100,12 +130,13 @@ func (h *TemplatesHandler) List(c *gin.Context) {
 	templates := make([]templateSummary, 0)
 	walkTemplateConfigs(h.configsDir, func(id string, data []byte) {
 		var raw struct {
-			Name          string   `yaml:"name"`
-			Description   string   `yaml:"description"`
-			Tier          int      `yaml:"tier"`
-			Runtime       string   `yaml:"runtime"`
-			Model         string   `yaml:"model"`
-			Skills        []string `yaml:"skills"`
+			Name          string          `yaml:"name"`
+			Description   string          `yaml:"description"`
+			Tier          int             `yaml:"tier"`
+			Runtime       string          `yaml:"runtime"`
+			Model         string          `yaml:"model"`
+			Skills        []string        `yaml:"skills"`
+			Providers     []providerEntry `yaml:"providers"`
 			RuntimeConfig struct {
 				Model                   string      `yaml:"model"`
 				Models                  []modelSpec `yaml:"models"`
@@ -124,6 +155,16 @@ func (h *TemplatesHandler) List(c *gin.Context) {
 			model = raw.RuntimeConfig.Model
 		}
 
+		// Defensive: drop providerEntry rows that have no name (yaml
+		// shape error). An entry without a name can't match anything
+		// and would render as a blank dropdown option in canvas.
+		registry := raw.Providers[:0:0]
+		for _, p := range raw.Providers {
+			if p.Name != "" {
+				registry = append(registry, p)
+			}
+		}
+
 		templates = append(templates, templateSummary{
 			ID:                      id,
 			Name:                    raw.Name,
@@ -134,6 +175,7 @@ func (h *TemplatesHandler) List(c *gin.Context) {
 			Models:                  raw.RuntimeConfig.Models,
 			RequiredEnv:             raw.RuntimeConfig.RequiredEnv,
 			Providers:               raw.RuntimeConfig.Providers,
+			ProviderRegistry:        registry,
 			Skills:                  raw.Skills,
 			SkillCount:              len(raw.Skills),
 			ProvisionTimeoutSeconds: raw.RuntimeConfig.ProvisionTimeoutSeconds,

--- a/workspace-server/internal/handlers/templates_test.go
+++ b/workspace-server/internal/handlers/templates_test.go
@@ -269,6 +269,398 @@ skills: []
 	}
 }
 
+// TestTemplatesList_SurfacesProviderRegistry pins the structured
+// provider-registry shape that claude-code-default ships in its
+// TOP-LEVEL `providers:` block. Canvas reads this to build a
+// provider→model cascade (provider first, then a model dropdown
+// filtered to that provider's prefixes/aliases) and a read-only
+// required-env display sourced from auth_env + per-model required_env.
+//
+// If a future yaml-tag rename or struct edit drops the field, the
+// canvas dropdown silently degrades to "20 unfiltered models in a
+// datalist that hides everything not matching the typed substring" —
+// which is the exact UX bug a user reported on hongming.moleculesai.app
+// 2026-05-02 ("missing opus for claude code"). The fix landed here
+// pivots away from datalist filtering toward explicit selects, but
+// the wire shape carrying the registry is the load-bearing
+// dependency. Pinning it stops a silent rename from re-introducing
+// the bug under a different surface.
+func TestTemplatesList_SurfacesProviderRegistry(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "claude-code")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Mirrors the production claude-code-default schema: structured
+	// providers at top level + flat models[] under runtime_config.
+	configYaml := `name: Claude Code Agent
+runtime: claude-code
+providers:
+  - name: anthropic-oauth
+    auth_mode: oauth
+    model_prefixes: []
+    model_aliases: [sonnet, opus, haiku]
+    base_url: null
+    auth_env: [CLAUDE_CODE_OAUTH_TOKEN]
+  - name: anthropic-api
+    auth_mode: anthropic_api
+    model_prefixes: [claude-]
+    model_aliases: []
+    auth_env: [ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN]
+  - name: xiaomi-mimo
+    auth_mode: third_party_anthropic_compat
+    model_prefixes: [mimo-]
+    base_url: https://api.xiaomimimo.com/anthropic
+    auth_env: [ANTHROPIC_AUTH_TOKEN, ANTHROPIC_API_KEY]
+runtime_config:
+  model: sonnet
+  models:
+    - id: sonnet
+      name: Claude Sonnet (OAuth / Claude Code subscription)
+      required_env: [CLAUDE_CODE_OAUTH_TOKEN]
+    - id: opus
+      required_env: [CLAUDE_CODE_OAUTH_TOKEN]
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp []templateSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(resp))
+	}
+	got := resp[0]
+
+	if len(got.ProviderRegistry) != 3 {
+		t.Fatalf("ProviderRegistry: want 3 entries, got %d (%+v)", len(got.ProviderRegistry), got.ProviderRegistry)
+	}
+
+	// First entry: OAuth path with model aliases (sonnet/opus/haiku).
+	oauth := got.ProviderRegistry[0]
+	if oauth.Name != "anthropic-oauth" {
+		t.Errorf("Provider[0].Name: got %q", oauth.Name)
+	}
+	if oauth.AuthMode != "oauth" {
+		t.Errorf("Provider[0].AuthMode: got %q", oauth.AuthMode)
+	}
+	if len(oauth.ModelAliases) != 3 || oauth.ModelAliases[1] != "opus" {
+		t.Errorf("Provider[0].ModelAliases: got %+v", oauth.ModelAliases)
+	}
+	if len(oauth.AuthEnv) != 1 || oauth.AuthEnv[0] != "CLAUDE_CODE_OAUTH_TOKEN" {
+		t.Errorf("Provider[0].AuthEnv: got %+v", oauth.AuthEnv)
+	}
+	if oauth.BaseURL != "" {
+		t.Errorf("Provider[0].BaseURL: want empty (yaml null), got %q", oauth.BaseURL)
+	}
+
+	// Second entry: API key with model prefixes.
+	api := got.ProviderRegistry[1]
+	if api.Name != "anthropic-api" {
+		t.Errorf("Provider[1].Name: got %q", api.Name)
+	}
+	if len(api.ModelPrefixes) != 1 || api.ModelPrefixes[0] != "claude-" {
+		t.Errorf("Provider[1].ModelPrefixes: got %+v", api.ModelPrefixes)
+	}
+
+	// Third entry: third-party with non-null base_url.
+	mimo := got.ProviderRegistry[2]
+	if mimo.BaseURL != "https://api.xiaomimimo.com/anthropic" {
+		t.Errorf("Provider[2].BaseURL: got %q", mimo.BaseURL)
+	}
+
+	// Wire-shape check — canvas reads `provider_registry` (snake case).
+	if !strings.Contains(w.Body.String(), `"provider_registry":[`) {
+		t.Errorf("response missing provider_registry JSON field: %s", w.Body.String())
+	}
+}
+
+// TestTemplatesList_RealClaudeCodeDefaultSchema is the live-shape
+// integration test: loads the actual workspace-configs-templates/
+// claude-code-default/config.yaml from the repo root, runs it
+// through the List handler, and asserts the response shape matches
+// what the canvas expects to consume. If the production config.yaml
+// drifts away from the shape canvas reads (e.g. providers becomes
+// `provider_set:` or model_aliases becomes `aliases:`), this test
+// fails the build at PR time instead of after deploy.
+//
+// This is the "live-test the actual code path before shipping a
+// hypothesis-driven fix" pattern from feedback memory 2026-05-02:
+// don't rely on synthetic fixtures alone when the production schema
+// is right there in the repo.
+func TestTemplatesList_RealClaudeCodeDefaultSchema(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	// Walk up from the test file's package dir to the repo root, then
+	// down into workspace-configs-templates/. Skip the test if we
+	// can't find it — the workspace-configs-templates dir is part of
+	// the monorepo, not the workspace-server module, so a partial
+	// checkout could omit it (CI builds the whole monorepo so it'll
+	// always be present there).
+	repoRoot := ""
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Skipf("getwd: %v", err)
+	}
+	for dir := cwd; dir != "/" && dir != "."; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "workspace-configs-templates")); err == nil {
+			repoRoot = dir
+			break
+		}
+	}
+	if repoRoot == "" {
+		t.Skip("workspace-configs-templates/ not found — partial checkout?")
+	}
+
+	configsDir := filepath.Join(repoRoot, "workspace-configs-templates")
+	handler := NewTemplatesHandler(configsDir, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []templateSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	// Locate claude-code-default in the response.
+	var ccd *templateSummary
+	for i := range resp {
+		if resp[i].ID == "claude-code-default" {
+			ccd = &resp[i]
+			break
+		}
+	}
+	if ccd == nil {
+		t.Fatalf("claude-code-default not found in /templates response (%d templates returned)", len(resp))
+	}
+
+	// The shape-contract assertions canvas depends on. Each one pins
+	// a specific UX point the user reported on 2026-05-02.
+
+	// (4) opus must be discoverable from the response. The model id
+	// is the literal "opus" alias, and a model.required_env declares
+	// what env var the workspace needs.
+	hasOpus := false
+	for _, m := range ccd.Models {
+		if m.ID == "opus" {
+			hasOpus = true
+			if len(m.RequiredEnv) == 0 {
+				t.Errorf("opus has no required_env in template")
+			}
+		}
+	}
+	if !hasOpus {
+		t.Errorf("opus alias missing from claude-code-default models[]: got %d models", len(ccd.Models))
+	}
+
+	// (2) Provider registry must surface so the canvas can render
+	// a Provider→Model cascade. The first entry must be the OAuth
+	// path with `sonnet`/`opus`/`haiku` aliases.
+	if len(ccd.ProviderRegistry) == 0 {
+		t.Fatalf("provider_registry empty for claude-code-default — canvas cascade UI won't render")
+	}
+	oauth := ccd.ProviderRegistry[0]
+	if oauth.Name != "anthropic-oauth" {
+		t.Errorf("provider_registry[0].name = %q, want anthropic-oauth", oauth.Name)
+	}
+	hasOpusAlias := false
+	for _, a := range oauth.ModelAliases {
+		if a == "opus" {
+			hasOpusAlias = true
+		}
+	}
+	if !hasOpusAlias {
+		t.Errorf("anthropic-oauth.model_aliases doesn't include opus: %+v", oauth.ModelAliases)
+	}
+
+	// (3) auth_env must be populated so the canvas can render the
+	// read-only required-env display. Without this the cascade
+	// degrades back to the editable TagList.
+	if len(oauth.AuthEnv) == 0 {
+		t.Errorf("anthropic-oauth.auth_env empty — required-env display will be empty")
+	}
+
+	// Cross-check: the JSON wire shape canvas actually parses.
+	body := w.Body.String()
+	if !strings.Contains(body, `"provider_registry"`) {
+		t.Errorf("response missing provider_registry JSON field")
+	}
+	if !strings.Contains(body, `"auth_env"`) {
+		t.Errorf("response missing auth_env in registry — canvas can't compute required env")
+	}
+	if !strings.Contains(body, `"model_aliases"`) {
+		t.Errorf("response missing model_aliases in registry — canvas can't filter models by provider")
+	}
+}
+
+// TestTemplatesList_OmitsProviderRegistryWhenAbsent — a template that
+// hasn't migrated to the structured `providers:` block must NOT emit
+// `provider_registry: null` (canvas's array-typed parser would treat
+// that as a load failure). omitempty on the struct slice elides the
+// field entirely.
+func TestTemplatesList_OmitsProviderRegistryWhenAbsent(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "no-registry")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configYaml := `name: Legacy
+runtime: hermes
+runtime_config:
+  model: anthropic:claude-opus-4-7
+  providers: [nous, openrouter]
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), `"provider_registry":`) {
+		t.Errorf("response should omit provider_registry when template has none, got: %s", w.Body.String())
+	}
+	// Sanity: the legacy flat-string Providers field is still surfaced
+	// for hermes-style templates. Both shapes coexist intentionally.
+	if !strings.Contains(w.Body.String(), `"providers":["nous","openrouter"]`) {
+		t.Errorf("response should still surface flat providers list: %s", w.Body.String())
+	}
+}
+
+// TestTemplatesList_BothProviderShapesCoexist — claude-code-default
+// uses the structured top-level providers; hermes-shape templates may
+// keep the flat runtime_config.providers list. The /templates payload
+// must surface both fields independently so canvas can pick the
+// richer one when present and fall back to the flat list otherwise.
+func TestTemplatesList_BothProviderShapesCoexist(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "both")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configYaml := `name: Mixed
+runtime: experimental
+providers:
+  - name: vendor-a
+    auth_env: [VENDOR_A_KEY]
+runtime_config:
+  model: x
+  providers: [legacy-flat]
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	var resp []templateSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(resp))
+	}
+	got := resp[0]
+	if len(got.Providers) != 1 || got.Providers[0] != "legacy-flat" {
+		t.Errorf("flat Providers preserved: got %+v", got.Providers)
+	}
+	if len(got.ProviderRegistry) != 1 || got.ProviderRegistry[0].Name != "vendor-a" {
+		t.Errorf("structured ProviderRegistry preserved: got %+v", got.ProviderRegistry)
+	}
+}
+
+// TestTemplatesList_DropsRegistryEntriesWithoutName — a malformed
+// providers entry missing `name:` would otherwise render as a blank
+// dropdown option on canvas. Drop those defensively at parse time so
+// the wire shape never carries them.
+func TestTemplatesList_DropsRegistryEntriesWithoutName(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "malformed")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configYaml := `name: Test
+runtime: claude-code
+providers:
+  - name: real-provider
+    auth_env: [TOKEN]
+  - auth_env: [SHOULD_BE_DROPPED]
+  - name: ""
+    auth_env: [ALSO_DROPPED]
+runtime_config:
+  model: x
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	var resp []templateSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(resp))
+	}
+	got := resp[0]
+	if len(got.ProviderRegistry) != 1 {
+		t.Fatalf("expected 1 valid entry (others dropped), got %d: %+v", len(got.ProviderRegistry), got.ProviderRegistry)
+	}
+	if got.ProviderRegistry[0].Name != "real-provider" {
+		t.Errorf("wrong entry kept: %+v", got.ProviderRegistry[0])
+	}
+}
+
 // TestTemplatesList_OmitsProvidersWhenAbsent pins the omitempty
 // behavior — older templates that haven't migrated to
 // runtime_config.providers yet must NOT emit `providers: null` (which


### PR DESCRIPTION
## Summary

User reported four UX defects on the Claude Code Agent Config tab on hongming.moleculesai.app:

1. **Display drift** — config.yaml model snapshot shown instead of the workspace's actual MODEL_PROVIDER override. Closes task #190.
2. **Provider was downstream of Model** — should cascade Provider → Model.
3. **Required Env Var Names was free-text** — should auto-load from the (provider, model) pair.
4. **Model field used \`<input type=text list=...>\`** — browser datalist hides options that don't substring-match the typed value, so typing \"sonnet\" hid every option without \"sonnet\" in id/name including opus.

## Changes

**Workspace-server** (\`templates.go\`): \`/templates\` now surfaces the structured top-level \`providers:\` block as \`provider_registry\`. Each entry carries \`name\`, \`auth_mode\`, \`model_aliases\`, \`model_prefixes\`, \`auth_env\`, \`base_url\` — the same shape claude-code-default ships in production. Legacy \`runtime_config.providers []string\` field is preserved for hermes-style templates.

**Canvas** (\`ConfigTab.tsx\` + new \`provider-cascade.ts\`):
- Provider becomes a \`<select>\` populated from \`provider_registry\` (or legacy flat list, or vendor-prefix derive). \`AUTO_PROVIDER\` saves \"\" — adapter resolves at boot.
- Model becomes a \`<select>\` filtered to the selected provider's \`model_aliases\` + \`model_prefixes\`. Switching providers snaps the model to the first valid choice rather than holding an inconsistent pair.
- Required Env Var Names is read-only (union of \`provider.auth_env\` + \`model.required_env\`, deduped) when the registry can supply it; falls back to the free-text TagList for pre-migration templates.
- Display-drift fix: workspace-metadata model now writes to BOTH \`model\` (top-level) and \`runtime_config.model\` so the form reads what's actually running.

## Test plan

- [x] 12 server template tests — 4 new (\`SurfacesProviderRegistry\`, \`OmitsProviderRegistryWhenAbsent\`, \`BothProviderShapesCoexist\`, \`DropsRegistryEntriesWithoutName\`) plus 1 real-schema integration test (\`RealClaudeCodeDefaultSchema\`) that loads the actual claude-code-default config.yaml from disk and verifies the wire shape canvas depends on.
- [x] 28 cascade helper unit tests — **100% statement / branch / function / line coverage** on \`provider-cascade.ts\`.
- [x] 10 ConfigTab cascade integration tests pinning each of the four UX invariants from the user report (opus visible, provider→model snap, read-only required env, display matches workspace state).
- [x] Full canvas suite (1217 tests) and full handler suite still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)