### PR TITLE
fix(runtime): explicit empty per-model required_env means "no auth"

### DIFF
--- a/workspace/preflight.py
+++ b/workspace/preflight.py
@@ -167,15 +167,17 @@ def run_preflight(config: WorkspaceConfig, config_path: str) -> PreflightReport:
                 continue
             if entry_id.lower() != picked_lower:
                 continue
-            per_model_env = entry.get("required_env")
-            if per_model_env:
+            if "required_env" in entry:
                 # Per-model required_env wins outright — do NOT union with the
                 # top-level list. Templates use per-model entries precisely
                 # to express that different models have *different* auth
                 # paths (OAuth token vs API key vs third-party provider key);
                 # unioning would re-introduce the very crash-loop this fix
-                # closes.
-                required_env = list(per_model_env)
+                # closes. An explicit empty list means "no auth needed"
+                # (e.g. local Ollama or self-hosted endpoints) and MUST
+                # short-circuit the top-level fallback — that's why we key
+                # off `"required_env" in entry` rather than truthiness.
+                required_env = list(entry.get("required_env") or [])
             break
 
     for env_var in required_env:

--- a/workspace/tests/test_config.py
+++ b/workspace/tests/test_config.py
@@ -131,6 +131,38 @@ def test_runtime_config_model_yaml_wins_over_top_level(tmp_path, monkeypatch):
     assert cfg.runtime_config.model == "openai:gpt-4o"
 
 
+def test_runtime_config_model_env_wins_over_explicit_yaml(tmp_path, monkeypatch):
+    """When BOTH MODEL_PROVIDER env AND runtime_config.model in YAML are set,
+    MODEL_PROVIDER wins. Pins the intentional precedence inversion shipped
+    in PR #2538 (2026-05-02): the canvas-picked model is the source of
+    truth, not the template's verbatim default. A self-hosted operator who
+    wants the YAML value to win MUST also unset MODEL_PROVIDER — the env
+    var is the operator's "current intent" signal, the YAML is a baked-in
+    default.
+
+    Without this pin, a future refactor could quietly restore the old
+    YAML-wins order and re-introduce Bug B (canvas-picked model silently
+    dropped for templated workspaces)."""
+    monkeypatch.setenv("MODEL_PROVIDER", "minimax/MiniMax-M2.7")
+    config_yaml = tmp_path / "config.yaml"
+    config_yaml.write_text(
+        yaml.dump(
+            {
+                "model": "anthropic:claude-opus-4-7",
+                "runtime_config": {"model": "openai:gpt-4o"},
+            }
+        )
+    )
+
+    cfg = load_config(str(tmp_path))
+    # Top-level still resolves to MODEL_PROVIDER (existing behavior).
+    assert cfg.model == "minimax/MiniMax-M2.7"
+    # And runtime_config.model now ALSO follows MODEL_PROVIDER, even
+    # though YAML had an explicit different value. This is the
+    # intentional inversion — the canvas pick beats the template.
+    assert cfg.runtime_config.model == "minimax/MiniMax-M2.7"
+
+
 def test_runtime_config_model_picks_up_env_via_top_level(tmp_path, monkeypatch):
     """End-to-end path the canvas Save+Restart relies on: user picks
     a model → workspace_secrets.MODEL_PROVIDER updated → CP user-data

--- a/workspace/tests/test_preflight.py
+++ b/workspace/tests/test_preflight.py
@@ -428,7 +428,6 @@ def test_per_model_explicit_empty_required_env_means_no_auth(tmp_path, monkeypat
     without lying in the per-model list. Distinguished from the no-key
     case via `"required_env" in entry` (key presence, not truthiness)."""
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
-    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
 
     config = make_config(
         runtime="claude-code",
@@ -440,6 +439,31 @@ def test_per_model_explicit_empty_required_env_means_no_auth(tmp_path, monkeypat
             models=[
                 {"id": "sonnet", "required_env": ["CLAUDE_CODE_OAUTH_TOKEN"]},
                 {"id": "local-llama", "required_env": []},  # explicit zero-auth
+            ],
+        ),
+    )
+
+    report = run_preflight(config, str(tmp_path))
+
+    assert report.ok is True
+    assert not any(issue.title == "Required env" for issue in report.failures)
+
+
+def test_per_model_required_env_null_treated_as_empty_no_auth(tmp_path, monkeypatch):
+    """YAML `required_env: null` deserializes to None — the parser falls
+    through to `entry.get("required_env") or []`, so null behaves the
+    same as explicit `[]` (zero-auth). Pins the parser tolerance —
+    template authors who write `required_env:` without a value (common
+    YAML mistake) get the no-auth path, not a confusing TypeError."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+
+    config = make_config(
+        runtime="claude-code",
+        runtime_config=RuntimeConfig(
+            model="local-llama",
+            required_env=["CLAUDE_CODE_OAUTH_TOKEN"],
+            models=[
+                {"id": "local-llama", "required_env": None},  # null in YAML
             ],
         ),
     )

--- a/workspace/tests/test_preflight.py
+++ b/workspace/tests/test_preflight.py
@@ -395,12 +395,12 @@ def test_per_model_match_is_case_insensitive(tmp_path, monkeypatch):
     assert not any(issue.title == "Required env" for issue in report.failures)
 
 
-def test_per_model_match_with_no_required_env_falls_back_to_top_level(tmp_path, monkeypatch):
-    """An entry that matches the picked model but has no `required_env`
-    (or an empty one) falls back to the top-level list. This protects
-    against partially-specified template entries — many templates list
-    a `name`/`description` per model without enumerating env vars when
-    the auth is identical across the family."""
+def test_per_model_match_with_no_required_env_key_falls_back_to_top_level(tmp_path, monkeypatch):
+    """An entry that matches the picked model but has NO `required_env`
+    key at all falls back to the top-level list. Distinct from the
+    explicit-empty case below — many templates list a `name`/`description`
+    per model without enumerating env vars when the auth is identical
+    across the family, and we should not surprise them."""
     monkeypatch.setenv("CLAUDE_CODE_OAUTH_TOKEN", "sk-test")
 
     config = make_config(
@@ -409,7 +409,37 @@ def test_per_model_match_with_no_required_env_falls_back_to_top_level(tmp_path, 
             model="sonnet",
             required_env=["CLAUDE_CODE_OAUTH_TOKEN"],
             models=[
-                {"id": "sonnet", "name": "Claude Sonnet"},  # no required_env
+                {"id": "sonnet", "name": "Claude Sonnet"},  # no required_env key
+            ],
+        ),
+    )
+
+    report = run_preflight(config, str(tmp_path))
+
+    assert report.ok is True
+    assert not any(issue.title == "Required env" for issue in report.failures)
+
+
+def test_per_model_explicit_empty_required_env_means_no_auth(tmp_path, monkeypatch):
+    """An entry with an explicit `required_env: []` means "this model
+    needs no auth" — common for local Ollama, Llamafile, or self-hosted
+    OpenAI-compat endpoints. This MUST short-circuit the top-level
+    fallback or the template author can't express a zero-auth model
+    without lying in the per-model list. Distinguished from the no-key
+    case via `"required_env" in entry` (key presence, not truthiness)."""
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("MINIMAX_API_KEY", raising=False)
+
+    config = make_config(
+        runtime="claude-code",
+        runtime_config=RuntimeConfig(
+            model="local-llama",
+            # Top-level requires an auth token — but the picked model is
+            # a local one that genuinely needs none. Explicit-empty wins.
+            required_env=["CLAUDE_CODE_OAUTH_TOKEN"],
+            models=[
+                {"id": "sonnet", "required_env": ["CLAUDE_CODE_OAUTH_TOKEN"]},
+                {"id": "local-llama", "required_env": []},  # explicit zero-auth
             ],
         ),
     )


### PR DESCRIPTION
## Summary

Two follow-ups from the independent review of merged #2538.

### preflight.py — explicit empty `required_env: []` now wins

**Today**: `if per_model_env: required_env = list(per_model_env)` falls through on `[]`, so a template entry that says \"this model needs no auth\" (Ollama, llamafile, self-hosted OpenAI-compat) is silently overridden by the top-level fallback. The template author cannot express a zero-auth model without lying about its env requirements.

**Fix**: key off `\"required_env\" in entry` (key presence, not truthiness). Missing key still falls back to top-level — that path is unchanged. Empty list now wins outright.

### test_preflight.py

- Renamed `test_per_model_match_with_no_required_env_falls_back_to_top_level` → `…_no_required_env_KEY_…` and tightened docstring to reflect missing-KEY case only.
- New `test_per_model_explicit_empty_required_env_means_no_auth` pinning the new explicit-empty semantic with a local-llama config.

### test_config.py

- New `test_runtime_config_model_env_wins_over_explicit_yaml`. Pins the intentional precedence inversion shipped in #2538 — when both \`MODEL_PROVIDER\` env AND \`runtime_config.model:\` in YAML are set, **MODEL_PROVIDER wins**. Without this pin a future refactor could quietly restore the old YAML-wins order and re-introduce Bug B (canvas-picked model silently dropped for templated workspaces).

## Test plan

- [x] \`pytest workspace/tests/test_preflight.py workspace/tests/test_config.py\` — 77/77 pass locally
- [x] Builds on merged #2538 — does not change preflight semantics for templates that have always declared `required_env` per entry
- [ ] CI must verify full coverage gate (≥86%)

Closes review follow-ups from #2538. Closes #250 in user's tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)