### PR TITLE
fix(workspace-server): surface structured provider registry on /templates (#235)

### DIFF
--- a/workspace-server/internal/handlers/templates.go
+++ b/workspace-server/internal/handlers/templates.go
@@ -45,6 +45,28 @@ type modelSpec struct {
 	RequiredEnv []string `json:"required_env,omitempty" yaml:"required_env"`
 }
 
+// providerRegistryEntry mirrors a row from a template's top-level
+// `providers:` registry block (claude-code, hermes, etc.). Each entry
+// fully describes one provider: its name, auth flow, the model id
+// prefixes/aliases that route to it, an optional base_url override, and
+// the env vars required to authenticate.
+//
+// This is the structured taxonomy the canvas's ProviderModelSelector
+// comment anticipates ("Templates that ship explicit vendor metadata
+// (future) should override the heuristic.") — surfacing it here lets
+// the canvas drop its prefix-inference fallback for templates that ship
+// an explicit registry. Templates without the block omit the field
+// (omitempty); the canvas falls back to its current per-model
+// required_env derivation.
+type providerRegistryEntry struct {
+	Name          string   `json:"name" yaml:"name"`
+	AuthMode      string   `json:"auth_mode,omitempty" yaml:"auth_mode"`
+	ModelPrefixes []string `json:"model_prefixes,omitempty" yaml:"model_prefixes"`
+	ModelAliases  []string `json:"model_aliases,omitempty" yaml:"model_aliases"`
+	BaseURL       string   `json:"base_url,omitempty" yaml:"base_url"`
+	AuthEnv       []string `json:"auth_env,omitempty" yaml:"auth_env"`
+}
+
 type templateSummary struct {
 	ID          string      `json:"id"`
 	Name        string      `json:"name"`
@@ -68,9 +90,24 @@ type templateSummary struct {
 	// a different vendor list doesn't need a canvas edit. Empty list →
 	// canvas falls back to deriving suggestions from `models[].id` slug
 	// prefixes (still adapter-driven, just inferred).
-	Providers   []string `json:"providers,omitempty"`
-	Skills      []string `json:"skills"`
-	SkillCount  int      `json:"skill_count"`
+	Providers []string `json:"providers,omitempty"`
+	// ProviderRegistry is the structured provider taxonomy from the
+	// template's TOP-LEVEL `providers:` block (separate from the
+	// runtime_config.providers slug list above). Each entry carries
+	// auth_env / model_prefixes / model_aliases / base_url so the canvas
+	// can render an authoritative Provider→Model cascade without
+	// re-deriving vendor metadata from per-model required_env tuples.
+	//
+	// Closes #235 (server-side enrichment): the `Providers []string`
+	// field shipped a name list but never the structured payload the
+	// canvas's ProviderModelSelector comment block anticipates as the
+	// override for its prefix-inference heuristic. Pre-existing
+	// templates without the top-level block omit the field
+	// (omitempty); the canvas's existing per-model fallback continues
+	// to work for them.
+	ProviderRegistry []providerRegistryEntry `json:"provider_registry,omitempty"`
+	Skills           []string                `json:"skills"`
+	SkillCount       int                     `json:"skill_count"`
 	// ProvisionTimeoutSeconds lets a slow runtime declare its expected
 	// cold-boot duration in its template manifest. Canvas's
 	// ProvisioningTimeout banner respects this per-workspace via the
@@ -100,12 +137,18 @@ func (h *TemplatesHandler) List(c *gin.Context) {
 	templates := make([]templateSummary, 0)
 	walkTemplateConfigs(h.configsDir, func(id string, data []byte) {
 		var raw struct {
-			Name          string   `yaml:"name"`
-			Description   string   `yaml:"description"`
-			Tier          int      `yaml:"tier"`
-			Runtime       string   `yaml:"runtime"`
-			Model         string   `yaml:"model"`
-			Skills        []string `yaml:"skills"`
+			Name        string   `yaml:"name"`
+			Description string   `yaml:"description"`
+			Tier        int      `yaml:"tier"`
+			Runtime     string   `yaml:"runtime"`
+			Model       string   `yaml:"model"`
+			Skills      []string `yaml:"skills"`
+			// Top-level `providers:` block — structured registry. Distinct
+			// from runtime_config.providers (slug list) below. Both shapes
+			// coexist in production: claude-code ships the structured
+			// registry, hermes still uses the slug list. /templates surfaces
+			// both verbatim so each runtime owns its taxonomy.
+			Providers     []providerRegistryEntry `yaml:"providers"`
 			RuntimeConfig struct {
 				Model                   string      `yaml:"model"`
 				Models                  []modelSpec `yaml:"models"`
@@ -134,6 +177,7 @@ func (h *TemplatesHandler) List(c *gin.Context) {
 			Models:                  raw.RuntimeConfig.Models,
 			RequiredEnv:             raw.RuntimeConfig.RequiredEnv,
 			Providers:               raw.RuntimeConfig.Providers,
+			ProviderRegistry:        raw.Providers,
 			Skills:                  raw.Skills,
 			SkillCount:              len(raw.Skills),
 			ProvisionTimeoutSeconds: raw.RuntimeConfig.ProvisionTimeoutSeconds,

--- a/workspace-server/internal/handlers/templates_test.go
+++ b/workspace-server/internal/handlers/templates_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -266,6 +267,151 @@ skills: []
 	// break consumers without surfacing in the typed assertions above.
 	if !strings.Contains(w.Body.String(), `"providers":["nous","openrouter","anthropic"]`) {
 		t.Errorf("response missing providers JSON field: %s", w.Body.String())
+	}
+}
+
+// TestTemplatesList_SurfacesProviderRegistry pins the #235 enrichment:
+// /templates must echo the template's TOP-LEVEL `providers:` block as a
+// structured array of providerRegistryEntry, separate from the
+// runtime_config.providers slug list above. Each entry carries auth_env
+// + model_prefixes + base_url so the canvas can stop inferring vendor
+// taxonomy from per-model required_env tuples.
+//
+// Use a claude-code-shaped fixture (the only template in production
+// that ships the registry today, modulo the per-vendor work in PR #33).
+// Order MUST be preserved — the canvas surfaces the dropdown in
+// declaration order so operators can put their preferred provider first.
+func TestTemplatesList_SurfacesProviderRegistry(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "claude-code")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configYaml := `name: Claude Code
+runtime: claude-code
+providers:
+  - name: anthropic-oauth
+    auth_mode: oauth
+    model_prefixes: []
+    model_aliases: [sonnet, opus, haiku]
+    base_url: null
+    auth_env: [CLAUDE_CODE_OAUTH_TOKEN]
+  - name: minimax
+    auth_mode: third_party_anthropic_compat
+    model_prefixes: [minimax-]
+    model_aliases: []
+    base_url: https://api.minimax.io/anthropic
+    auth_env: [MINIMAX_API_KEY, ANTHROPIC_AUTH_TOKEN]
+runtime_config:
+  model: claude-sonnet-4-6
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp []templateSummary
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(resp) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(resp))
+	}
+	got := resp[0].ProviderRegistry
+	if len(got) != 2 {
+		t.Fatalf("ProviderRegistry: want 2 entries, got %d (%+v)", len(got), got)
+	}
+	// Order preservation
+	if got[0].Name != "anthropic-oauth" {
+		t.Errorf("ProviderRegistry[0].Name: want %q, got %q", "anthropic-oauth", got[0].Name)
+	}
+	if got[1].Name != "minimax" {
+		t.Errorf("ProviderRegistry[1].Name: want %q, got %q", "minimax", got[1].Name)
+	}
+	// Field plumbing on the first (oauth) entry
+	if got[0].AuthMode != "oauth" {
+		t.Errorf("ProviderRegistry[0].AuthMode: want %q, got %q", "oauth", got[0].AuthMode)
+	}
+	if !reflect.DeepEqual(got[0].ModelAliases, []string{"sonnet", "opus", "haiku"}) {
+		t.Errorf("ProviderRegistry[0].ModelAliases: want sonnet/opus/haiku, got %v", got[0].ModelAliases)
+	}
+	if !reflect.DeepEqual(got[0].AuthEnv, []string{"CLAUDE_CODE_OAUTH_TOKEN"}) {
+		t.Errorf("ProviderRegistry[0].AuthEnv: want [CLAUDE_CODE_OAUTH_TOKEN], got %v", got[0].AuthEnv)
+	}
+	// Field plumbing on the second (third-party) entry — base_url is the
+	// distinguishing signal for compat providers; canvas uses it to render
+	// the "via Anthropic-compat endpoint" badge.
+	if got[1].BaseURL != "https://api.minimax.io/anthropic" {
+		t.Errorf("ProviderRegistry[1].BaseURL: want minimax url, got %q", got[1].BaseURL)
+	}
+	if !reflect.DeepEqual(got[1].ModelPrefixes, []string{"minimax-"}) {
+		t.Errorf("ProviderRegistry[1].ModelPrefixes: want [minimax-], got %v", got[1].ModelPrefixes)
+	}
+	if !reflect.DeepEqual(got[1].AuthEnv, []string{"MINIMAX_API_KEY", "ANTHROPIC_AUTH_TOKEN"}) {
+		t.Errorf("ProviderRegistry[1].AuthEnv: want [MINIMAX_API_KEY, ANTHROPIC_AUTH_TOKEN], got %v", got[1].AuthEnv)
+	}
+
+	// Wire-shape gate — canvas reads this as `provider_registry` (snake_case).
+	// A struct-tag rename would silently drop it from consumers; the typed
+	// assertions above can't catch a tag-only change because they decode via
+	// the same struct.
+	if !strings.Contains(w.Body.String(), `"provider_registry":[{"name":"anthropic-oauth"`) {
+		t.Errorf("response missing provider_registry JSON field with expected first entry: %s", w.Body.String())
+	}
+}
+
+// TestTemplatesList_OmitsProviderRegistryWhenAbsent pins the omitempty
+// behavior for the new field — templates without a top-level
+// `providers:` block (hermes today, langgraph, etc.) must NOT emit
+// `provider_registry: null`, which would break canvas's array-typed
+// parser (Array.isArray check returns false for null).
+func TestTemplatesList_OmitsProviderRegistryWhenAbsent(t *testing.T) {
+	setupTestDB(t)
+	setupTestRedis(t)
+
+	tmpDir := t.TempDir()
+	tmplDir := filepath.Join(tmpDir, "hermes-no-reg")
+	if err := os.MkdirAll(tmplDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configYaml := `name: Hermes
+runtime: hermes
+runtime_config:
+  model: nousresearch/hermes-4-70b
+  providers: [nous, openrouter]
+skills: []
+`
+	if err := os.WriteFile(filepath.Join(tmplDir, "config.yaml"), []byte(configYaml), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	handler := NewTemplatesHandler(tmpDir, nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/templates", nil)
+	handler.List(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if strings.Contains(w.Body.String(), `"provider_registry":`) {
+		t.Errorf("response should omit provider_registry when template has none, got: %s", w.Body.String())
+	}
+	// But the slug list must still surface — both shapes coexist.
+	if !strings.Contains(w.Body.String(), `"providers":["nous","openrouter"]`) {
+		t.Errorf("expected slug-list providers field still present: %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `provider_registry` field to `/templates` response, sourced from the template's TOP-LEVEL `providers:` block. Each entry carries `name`, `auth_mode`, `model_prefixes`, `model_aliases`, `base_url`, `auth_env`. Existing `providers` slug list (from `runtime_config.providers`) is unchanged — both shapes coexist and are independent.

## Why

Audit #253 (closed-at-code-merged failure mode audit) flagged task #235 as a HIGH-severity contract drift: marked completed, but `templates.go` only ever emitted the slug list — the structured ProviderEntry shape the description promised was never plumbed.

In production today:
- `claude-code` ships a top-level `providers:` block with 6+ structured entries (anthropic-oauth, anthropic-api, xiaomi-mimo, minimax, zai, moonshot…)
- `hermes` still uses `runtime_config.providers: [nous, openrouter, …]` slug list
- canvas's `ProviderModelSelector` derives provider taxonomy from per-model `required_env` because the structured payload was never surfaced

The canvas comment already anticipates this fix: *"Vendor is inferred via prefix rules below. Templates that ship explicit vendor metadata (future) should override the heuristic."* This PR makes that "future" the present — the canvas can optionally drop its prefix-inference fallback for registry-shipping templates in a separate PR.

## Backwards compat

Purely additive. The new field uses `omitempty` so templates without the top-level block emit nothing (not `null` — that would break Array.isArray on the canvas). Existing slug list (`providers`) is untouched, all 5 existing tests in `templates_test.go` still pass.

## Test plan

- [x] `TestTemplatesList_SurfacesProviderRegistry` — claude-code-shaped fixture, asserts:
  - 2 entries in declaration order
  - field plumbing on first (oauth) and second (third-party) entries
  - wire-shape gate (`provider_registry` JSON tag) to catch struct-tag renames
- [x] `TestTemplatesList_OmitsProviderRegistryWhenAbsent` — hermes-shaped fixture, asserts:
  - new field absent (omitempty)
  - existing `providers` slug list still present
- [x] All 9 `TestTemplatesList_*` tests pass locally
- [ ] CI: `Platform (Go)`

Closes #254 / reconciles #235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)