### PR TITLE
fix(canvas): ConfigTab is single source of truth for tier/provider/model

### DIFF
--- a/canvas/src/components/ProviderModelSelector.tsx
+++ b/canvas/src/components/ProviderModelSelector.tsx
@@ -310,12 +310,26 @@ export function ProviderModelSelector({
       onChange({ providerId: "", model: "", envVars: [] });
       return;
     }
-    // When switching providers, default the model to the first concrete
-    // entry in that provider (or empty if wildcard). Avoids showing a
-    // stale model id from the previous provider.
+    // When switching providers:
+    //   - wildcard provider → empty (free-text input takes over)
+    //   - exactly 1 concrete model → auto-pick (no choice to make)
+    //   - 2+ concrete models → leave empty so the operator MUST pick
+    //
+    // Background: previously this defaulted to `next.models[0]` for any
+    // non-wildcard provider, which silently set the alphabetically-first
+    // model in the bucket. Bit a real user on 2026-05-03 — they picked
+    // the MiniMax provider intending `MiniMax-M2.7` but the form silently
+    // set `MiniMax-M2` (first in the list). They never saw the model
+    // dropdown change because the provider+model widgets are visually
+    // distinct, and the workspace deployed with the wrong model. Caller
+    // already disables Deploy/Save while `model.trim() === ""`, so the
+    // empty default forces an explicit pick without loosening any other
+    // gate.
     const defaultModel = next.wildcard
       ? ""
-      : next.models[0]?.id ?? "";
+      : next.models.length === 1
+        ? next.models[0]?.id ?? ""
+        : "";
     onChange({
       providerId: next.id,
       model: defaultModel,

--- a/canvas/src/components/__tests__/ProviderModelSelector.test.tsx
+++ b/canvas/src/components/__tests__/ProviderModelSelector.test.tsx
@@ -182,15 +182,38 @@ describe("<ProviderModelSelector>", () => {
     expect(modelSelect.disabled).toBe(true);
   });
 
-  it("picking provider emits onChange with default model + envVars", () => {
+  it("picking a multi-model provider emits onChange with empty model (forces explicit pick)", () => {
     const { onChange } = setup();
     const providerSelect = screen.getByTestId("provider-select");
     const catalog = buildProviderCatalog(CLAUDE_CODE_MODELS);
     const minimax = catalog.find((p) => p.vendor === "minimax")!;
+    // MiniMax bucket holds 2 models (MiniMax-M2 + MiniMax-M2.7). Auto-
+    // picking the first one used to bite a real user (2026-05-03):
+    // they wanted M2.7 but the silent default put M2 in the deploy
+    // payload. Now the model field must come back empty so the next
+    // dropdown is required-empty and Save/Deploy stay disabled until
+    // the user picks.
     fireEvent.change(providerSelect, { target: { value: minimax.id } });
     expect(onChange).toHaveBeenCalledWith({
       providerId: minimax.id,
-      model: "MiniMax-M2",
+      model: "",
+      envVars: ["ANTHROPIC_AUTH_TOKEN"],
+    });
+  });
+
+  it("picking a single-model provider auto-fills the model (no choice to make)", () => {
+    const { onChange } = setup();
+    const providerSelect = screen.getByTestId("provider-select");
+    const catalog = buildProviderCatalog(CLAUDE_CODE_MODELS);
+    // GLM-4.6 is the only model under the zai vendor in the fixture —
+    // a "0 vs many" boundary check. With only one option, forcing the
+    // user to re-pick adds friction without preventing any error.
+    const zai = catalog.find((p) => p.vendor === "zai")!;
+    expect(zai.models.length).toBe(1);
+    fireEvent.change(providerSelect, { target: { value: zai.id } });
+    expect(onChange).toHaveBeenCalledWith({
+      providerId: zai.id,
+      model: "GLM-4.6",
       envVars: ["ANTHROPIC_AUTH_TOKEN"],
     });
   });
@@ -250,7 +273,7 @@ describe("<ProviderModelSelector>", () => {
     expect(screen.getByText(/requires:/).textContent).toMatch(/CLAUDE_CODE_OAUTH_TOKEN/);
   });
 
-  it("switching provider resets model to first concrete option", () => {
+  it("switching to a multi-model provider clears the stale model id", () => {
     const catalog = buildProviderCatalog(CLAUDE_CODE_MODELS);
     const oauth = catalog.find((p) => p.vendor === "anthropic-oauth")!;
     const minimax = catalog.find((p) => p.vendor === "minimax")!;
@@ -260,9 +283,11 @@ describe("<ProviderModelSelector>", () => {
       onChange,
     });
     fireEvent.change(screen.getByTestId("provider-select"), { target: { value: minimax.id } });
+    // Empty rather than auto-picked — see "picking a multi-model
+    // provider …" test above for the user-facing rationale.
     expect(onChange).toHaveBeenCalledWith({
       providerId: minimax.id,
-      model: "MiniMax-M2",
+      model: "",
       envVars: ["ANTHROPIC_AUTH_TOKEN"],
     });
   });

--- a/canvas/src/components/tabs/ConfigTab.tsx
+++ b/canvas/src/components/tabs/ConfigTab.tsx
@@ -191,6 +191,16 @@ export function ConfigTab({ workspaceId }: Props) {
   // data, written into /configs/config.yaml on next provision too).
   const [provider, setProvider] = useState("");
   const [originalProvider, setOriginalProvider] = useState("");
+  // Track the model that loaded from the DB (workspace_secrets.MODEL_PROVIDER
+  // via /workspaces/:id/model) separately from the YAML's runtime_config.model.
+  // handleSave's diff used to compare nextModel against the YAML's value;
+  // after the loadConfig fix mirrors wsMetadataModel into runtime_config.model
+  // for display, that diff would always be non-zero (YAML default vs.
+  // overridden value) and trigger a /model PUT — which auto-restarts —
+  // on every Save. Comparing against the loaded MODEL_PROVIDER instead
+  // keeps unrelated saves (tier change, skill edit) from rebooting the
+  // workspace just because the template's YAML default differs.
+  const [originalModel, setOriginalModel] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
   useEffect(() => {
@@ -220,6 +230,7 @@ export function ConfigTab({ workspaceId }: Props) {
       const m = await api.get<{ model?: string }>(`/workspaces/${workspaceId}/model`);
       wsMetadataModel = (m.model || "").trim();
     } catch { /* non-fatal */ }
+    setOriginalModel(wsMetadataModel);
 
     // Load explicit provider override (Option B PR-5). Endpoint returns
     // {provider: "", source: "default"} when no override is set, so the
@@ -249,7 +260,17 @@ export function ConfigTab({ workspaceId }: Props) {
       // form doesn't contradict the node badge (issue: badge=T3, form=T2).
       const merged = { ...DEFAULT_CONFIG, ...parsed } as ConfigData;
       if (wsMetadataRuntime) merged.runtime = wsMetadataRuntime;
-      if (wsMetadataModel) merged.model = wsMetadataModel;
+      if (wsMetadataModel) {
+        // Single source of truth: MODEL_PROVIDER (DB) is the live runtime
+        // value. Override BOTH top-level + nested runtime_config.model so
+        // currentModelId (which reads runtime_config.model first) doesn't
+        // silently fall through to the template default. Without the
+        // nested override, a workspace deployed with `MiniMax-M2` shows
+        // the template's `runtime_config.model: sonnet` in the UI even
+        // though the container env (and chat) actually use MiniMax-M2.
+        merged.model = wsMetadataModel;
+        merged.runtime_config = { ...(merged.runtime_config ?? {}), model: wsMetadataModel };
+      }
       if (wsMetadataTier !== null) merged.tier = wsMetadataTier;
       setConfig(merged);
     } catch {
@@ -265,6 +286,10 @@ export function ConfigTab({ workspaceId }: Props) {
         ...DEFAULT_CONFIG,
         runtime: wsMetadataRuntime,
         model: wsMetadataModel,
+        // Mirror the merged-path fix above — keep top-level + nested in
+        // sync so currentModelId picks up wsMetadataModel even when the
+        // form falls into the no-config.yaml branch (hermes/external).
+        ...(wsMetadataModel ? { runtime_config: { model: wsMetadataModel } } : {}),
         ...(wsMetadataTier !== null ? { tier: wsMetadataTier } : {}),
       } as ConfigData);
     } finally {
@@ -415,6 +440,15 @@ export function ConfigTab({ workspaceId }: Props) {
       }
       if (Object.keys(dbPatch).length > 0) {
         await api.patch(`/workspaces/${workspaceId}`, dbPatch);
+        // Mirror the DB write into the canvas store node data so the
+        // header pill (TIER T2/T3, RUNTIME claude-code/hermes) and the
+        // node card update immediately. Without this push, the workspace
+        // row reflects the new tier but every UI surface that reads from
+        // useCanvasStore.nodes (header badge, ContextMenu, etc.) keeps
+        // showing the stale value until the next full hydrate. Bug
+        // surfaced 2026-05-03 — user picked T3, hit Save & Restart,
+        // database said tier=3, badge still said T2.
+        useCanvasStore.getState().updateNodeData(workspaceId, dbPatch);
       }
 
       // Model has its own endpoint (separate from the general workspace
@@ -436,21 +470,26 @@ export function ConfigTab({ workspaceId }: Props) {
       // configured" error in the chat. Caught 2026-04-30 on hongmingwang
       // hermes workspace 32993ee7-…cb9d75d112a5.
       const nextModelRaw = (nextSource.runtime_config as Record<string, unknown> | undefined)?.model;
-      const oldModelRaw = (oldParsed.runtime_config as Record<string, unknown> | undefined)?.model;
       const nextModel =
         typeof nextModelRaw === "string" && nextModelRaw
           ? nextModelRaw
           : typeof nextSource.model === "string"
             ? nextSource.model
             : "";
-      const oldModel =
-        typeof oldModelRaw === "string" && oldModelRaw
-          ? oldModelRaw
-          : (oldParsed.model as string) || "";
+      // Diff against the loaded MODEL_PROVIDER (the runtime source of
+      // truth), not the YAML's runtime_config.model. After loadConfig
+      // mirrors wsMetadataModel into runtime_config.model for display,
+      // nextModel always equals the loaded value on a no-op save —
+      // diffing against oldModelRaw (the unmirrored YAML default) would
+      // make every Save fire a /model PUT and trigger an auto-restart,
+      // even when the user only changed an unrelated field. Comparing
+      // against `originalModel` keeps the PUT scoped to actual user
+      // intent.
       let modelSaveError: string | null = null;
-      if (nextModel && nextModel !== oldModel) {
+      if (nextModel && nextModel !== originalModel) {
         try {
           await api.put(`/workspaces/${workspaceId}/model`, { model: nextModel });
+          setOriginalModel(nextModel);
         } catch (e) {
           modelSaveError = e instanceof Error ? e.message : "Model update was rejected";
         }

--- a/canvas/src/components/tabs/ConfigTab.tsx
+++ b/canvas/src/components/tabs/ConfigTab.tsx
@@ -191,15 +191,24 @@ export function ConfigTab({ workspaceId }: Props) {
   // data, written into /configs/config.yaml on next provision too).
   const [provider, setProvider] = useState("");
   const [originalProvider, setOriginalProvider] = useState("");
-  // Track the model that loaded from the DB (workspace_secrets.MODEL_PROVIDER
-  // via /workspaces/:id/model) separately from the YAML's runtime_config.model.
-  // handleSave's diff used to compare nextModel against the YAML's value;
-  // after the loadConfig fix mirrors wsMetadataModel into runtime_config.model
-  // for display, that diff would always be non-zero (YAML default vs.
-  // overridden value) and trigger a /model PUT — which auto-restarts —
-  // on every Save. Comparing against the loaded MODEL_PROVIDER instead
-  // keeps unrelated saves (tier change, skill edit) from rebooting the
-  // workspace just because the template's YAML default differs.
+  // Track the model the form first rendered, so handleSave can detect
+  // whether the user actually changed it (vs. only edited tier/skills/etc).
+  // Two field sources contribute:
+  //   1. wsMetadataModel — workspace_secrets.MODEL_PROVIDER (DB)
+  //   2. parsed.runtime_config.model — the template's YAML default
+  // Whichever was the live runtime value at load time is what currentModelId
+  // will display, and it's the value Save must diff against.
+  //
+  // Why not just diff the YAML directly: after loadConfig mirrors
+  // wsMetadataModel into runtime_config.model for display, the YAML diff
+  // is always non-zero on a no-op save, fires PUT /model, and triggers
+  // an auto-restart for unrelated edits. Why not diff against
+  // wsMetadataModel alone: on a hermes workspace where MODEL_PROVIDER
+  // was never set (pre-#240 workspaces, or workspaces created via direct
+  // API without going through the picker), wsMetadataModel="" but the
+  // form shows the YAML default — diffing against "" makes any first
+  // save propagate-and-restart even when the user didn't touch the model.
+  // Capturing the actual rendered value covers both.
   const [originalModel, setOriginalModel] = useState("");
   const successTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -230,7 +239,11 @@ export function ConfigTab({ workspaceId }: Props) {
       const m = await api.get<{ model?: string }>(`/workspaces/${workspaceId}/model`);
       wsMetadataModel = (m.model || "").trim();
     } catch { /* non-fatal */ }
-    setOriginalModel(wsMetadataModel);
+    // originalModel is set further down once the YAML has been parsed —
+    // we want it to reflect what the form ACTUALLY rendered, which may
+    // be the YAML's runtime_config.model fallback when MODEL_PROVIDER
+    // is empty. Setting it here from wsMetadataModel alone would be
+    // wrong for hermes/pre-#240 workspaces.
 
     // Load explicit provider override (Option B PR-5). Endpoint returns
     // {provider: "", source: "default"} when no override is set, so the
@@ -272,6 +285,12 @@ export function ConfigTab({ workspaceId }: Props) {
         merged.runtime_config = { ...(merged.runtime_config ?? {}), model: wsMetadataModel };
       }
       if (wsMetadataTier !== null) merged.tier = wsMetadataTier;
+      // Snapshot the rendered model so handleSave's diff stays scoped to
+      // user-initiated changes. mirrors the read precedence in
+      // currentModelId so an unrelated save (tier change) doesn't fire
+      // a /model PUT just because MODEL_PROVIDER was empty and the form
+      // showed the YAML default.
+      setOriginalModel(merged.runtime_config?.model || merged.model || "");
       setConfig(merged);
     } catch {
       // No platform-managed config.yaml. Some runtimes (hermes, external)
@@ -292,6 +311,11 @@ export function ConfigTab({ workspaceId }: Props) {
         ...(wsMetadataModel ? { runtime_config: { model: wsMetadataModel } } : {}),
         ...(wsMetadataTier !== null ? { tier: wsMetadataTier } : {}),
       } as ConfigData);
+      // Same snapshot as the merged-path branch above. Falls back to
+      // empty string when neither MODEL_PROVIDER nor a YAML model was
+      // present; handleSave's `nextModel && ...` guard then skips the
+      // PUT correctly.
+      setOriginalModel(wsMetadataModel);
     } finally {
       setLoading(false);
     }

--- a/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
@@ -38,10 +38,15 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
+// Shared store stub — `updateNodeData` is exposed so a test can assert the
+// node-data flush happens after a successful PATCH (regression: previously
+// the DB updated but the canvas badge stayed stale until full hydrate).
+const storeUpdateNodeData = vi.fn();
+const storeRestartWorkspace = vi.fn();
 vi.mock("@/store/canvas", () => ({
   useCanvasStore: Object.assign(
-    (selector: (s: unknown) => unknown) => selector({ restartWorkspace: vi.fn(), updateNodeData: vi.fn() }),
-    { getState: () => ({ restartWorkspace: vi.fn(), updateNodeData: vi.fn() }) },
+    (selector: (s: unknown) => unknown) => selector({ restartWorkspace: storeRestartWorkspace, updateNodeData: storeUpdateNodeData }),
+    { getState: () => ({ restartWorkspace: storeRestartWorkspace, updateNodeData: storeUpdateNodeData }) },
   ),
 }));
 
@@ -90,6 +95,8 @@ beforeEach(() => {
   apiGet.mockReset();
   apiPatch.mockReset();
   apiPut.mockReset();
+  storeUpdateNodeData.mockReset();
+  storeRestartWorkspace.mockReset();
 });
 
 describe("ConfigTab — Provider override (Option B PR-5)", () => {
@@ -332,5 +339,149 @@ describe("ConfigTab — Provider override (Option B PR-5)", () => {
       expect(providerCalls.length).toBe(1);
       expect(providerCalls[0][1]).toEqual({ provider: "" });
     });
+  });
+
+  // Display-vs-storage drift regression (2026-05-03 incident, workspace
+  // e13aebd8…). User deployed claude-code with MiniMax-M2 stored in
+  // MODEL_PROVIDER. The container env (MODEL=MiniMax-M2) and chat
+  // worked correctly, but the Config tab showed "Claude Code
+  // subscription / Claude Sonnet (OAuth)" — i.e. the template's
+  // runtime_config.model: sonnet default — because currentModelId
+  // reads runtime_config.model first and loadConfig was overriding
+  // only the top-level config.model field. The merged shape was:
+  //   { model: "MiniMax-M2", runtime_config: { model: "sonnet" } }
+  // and currentModelId picked "sonnet". Fix: loadConfig propagates
+  // wsMetadataModel into BOTH places so the form is a single source
+  // of truth (DB-backed MODEL_PROVIDER). Pinning the merged-path
+  // branch with the exact reproducing shape: claude-code template
+  // YAML has runtime_config.model: sonnet; live workspace's
+  // MODEL_PROVIDER is MiniMax-M2; tab must show the latter.
+  it("prefers MODEL_PROVIDER over the template's runtime_config.model on load", async () => {
+    wireApi({
+      workspaceRuntime: "claude-code",
+      workspaceModel: "MiniMax-M2",
+      configYamlContent: "name: ws\nruntime: claude-code\nruntime_config:\n  model: sonnet\n",
+      providerValue: "",
+      templates: [
+        {
+          id: "claude-code-default",
+          name: "Claude Code",
+          runtime: "claude-code",
+          models: [
+            { id: "sonnet", name: "Claude Sonnet (OAuth)", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+            { id: "MiniMax-M2", name: "MiniMax M2", required_env: ["MINIMAX_API_KEY"] },
+            { id: "MiniMax-M2.7", name: "MiniMax M2.7", required_env: ["MINIMAX_API_KEY"] },
+          ],
+        },
+      ],
+    });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const modelSelect = (await screen.findByTestId("model-select")) as HTMLSelectElement;
+    await waitFor(() => expect(modelSelect.value).toBe("MiniMax-M2"));
+
+    // Provider dropdown should also reflect MiniMax (back-derived from
+    // the model slug since LLM_PROVIDER is unset). Without the fix,
+    // the selector falls back to the first catalog entry whose first
+    // model matches "sonnet" → anthropic-oauth bucket → "Claude Code
+    // subscription".
+    const providerSelect = screen.getByTestId("provider-select") as HTMLSelectElement;
+    const selectedOption = providerSelect.options[providerSelect.selectedIndex];
+    expect(selectedOption.textContent ?? "").toMatch(/MiniMax/);
+  });
+
+  // Sibling pin to the display-fix above. The display fix mirrors
+  // wsMetadataModel into runtime_config.model so the selector renders
+  // the live value; that mirror means handleSave's old YAML-vs-form
+  // diff would always be non-zero on a no-op save (YAML default
+  // "sonnet" vs. mirrored "MiniMax-M2") and PUT /model — which
+  // server-side SetModel chains into an auto-restart. handleSave now
+  // diffs against the loaded MODEL_PROVIDER instead. Pin: an
+  // unrelated edit (tier change) must NOT touch /model when the
+  // model itself didn't change.
+  it("does not PUT /model on a no-op save when only an unrelated field changed", async () => {
+    wireApi({
+      workspaceRuntime: "claude-code",
+      workspaceModel: "MiniMax-M2",
+      configYamlContent: "name: ws\nruntime: claude-code\ntier: 2\nruntime_config:\n  model: sonnet\n",
+      providerValue: "",
+      templates: [
+        {
+          id: "claude-code-default",
+          name: "Claude Code",
+          runtime: "claude-code",
+          models: [
+            { id: "sonnet", name: "Claude Sonnet", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] },
+            { id: "MiniMax-M2", name: "MiniMax M2", required_env: ["MINIMAX_API_KEY"] },
+          ],
+        },
+      ],
+    });
+    apiPut.mockResolvedValue({});
+    apiPatch.mockResolvedValue({});
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const tierSelect = (await screen.findByLabelText(/tier/i)) as HTMLSelectElement;
+    fireEvent.change(tierSelect, { target: { value: "3" } });
+
+    const saveBtn = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      const tierPatches = apiPatch.mock.calls.filter(([path, body]) =>
+        path === "/workspaces/ws-test" && (body as { tier?: number }).tier === 3,
+      );
+      expect(tierPatches.length).toBe(1);
+    });
+    // Spurious /model PUT would fire here without the originalModel
+    // diff baseline. The model itself didn't change, so /model must
+    // stay untouched (otherwise SetModel auto-restarts).
+    const modelPuts = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/model");
+    expect(modelPuts.length).toBe(0);
+  });
+
+  // Save-then-stale-badge regression (2026-05-03 incident). User
+  // selected T3 in the Tier dropdown, hit Save & Restart, the workspace
+  // PATCH succeeded (`tier: 3` in DB), but the canvas header pill kept
+  // showing "TIER T2" until a full hydrate. Root cause: handleSave
+  // sent the PATCH to workspace-server but never pushed the same
+  // change into useCanvasStore.updateNodeData, so every UI surface
+  // reading from the store kept its stale value. Pin: a successful
+  // tier PATCH must mirror into the store so the badge updates
+  // synchronously with the response.
+  it("flushes the dbPatch into useCanvasStore.updateNodeData after a successful PATCH", async () => {
+    wireApi({
+      workspaceRuntime: "claude-code",
+      workspaceModel: "MiniMax-M2",
+      configYamlContent: "name: ws\nruntime: claude-code\ntier: 2\nruntime_config:\n  model: sonnet\n",
+      providerValue: "",
+      templates: [
+        {
+          id: "claude-code-default",
+          name: "Claude Code",
+          runtime: "claude-code",
+          models: [{ id: "sonnet", name: "Sonnet", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] }],
+        },
+      ],
+    });
+    apiPatch.mockResolvedValue({ status: "updated" });
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const tierSelect = (await screen.findByLabelText(/tier/i)) as HTMLSelectElement;
+    fireEvent.change(tierSelect, { target: { value: "3" } });
+
+    const saveBtn = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(apiPatch.mock.calls.some(([p]) => p === "/workspaces/ws-test")).toBe(true);
+    });
+    // Without the store flush, the badge would keep reading tier=2
+    // from useCanvasStore.nodes until a full hydrate. Pin: handleSave
+    // pushes the same fields it PATCHed.
+    expect(storeUpdateNodeData).toHaveBeenCalledWith(
+      "ws-test",
+      expect.objectContaining({ tier: 3 }),
+    );
   });
 });

--- a/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ConfigTab.provider.test.tsx
@@ -484,4 +484,91 @@ describe("ConfigTab — Provider override (Option B PR-5)", () => {
       expect.objectContaining({ tier: 3 }),
     );
   });
+
+  // Failure-gating sibling pin to the store-flush test above. The
+  // production code places `updateNodeData` AFTER `await api.patch(...)`
+  // inside the same `if (Object.keys(dbPatch).length > 0)` block, so a
+  // PATCH rejection should throw before the store call. Without this
+  // pin, a future refactor that wraps the PATCH in try/catch and
+  // unconditionally calls updateNodeData would ship green — and then
+  // the badge would lie when the server actually rejected the change.
+  // Codified review feedback from PR #2545 (Agent 2).
+  it("does NOT flush into useCanvasStore.updateNodeData when the PATCH rejects", async () => {
+    wireApi({
+      workspaceRuntime: "claude-code",
+      workspaceModel: "MiniMax-M2",
+      configYamlContent: "name: ws\nruntime: claude-code\ntier: 2\nruntime_config:\n  model: sonnet\n",
+      providerValue: "",
+      templates: [
+        {
+          id: "claude-code-default",
+          name: "Claude Code",
+          runtime: "claude-code",
+          models: [{ id: "sonnet", name: "Sonnet", required_env: ["CLAUDE_CODE_OAUTH_TOKEN"] }],
+        },
+      ],
+    });
+    apiPatch.mockRejectedValue(new Error("500 from workspace-server"));
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const tierSelect = (await screen.findByLabelText(/tier/i)) as HTMLSelectElement;
+    fireEvent.change(tierSelect, { target: { value: "3" } });
+
+    const saveBtn = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(saveBtn);
+
+    // Wait for handleSave to settle (succeeds-or-fails). PATCH must
+    // have been attempted; the error swallow inside handleSave keeps
+    // saving=false in finally.
+    await waitFor(() => {
+      expect(apiPatch.mock.calls.some(([p]) => p === "/workspaces/ws-test")).toBe(true);
+    });
+    // Critically: the store must NOT have been told about the failed
+    // change. Otherwise the badge would lie about a write the server
+    // rejected.
+    const tierFlushes = storeUpdateNodeData.mock.calls.filter(([, body]) =>
+      typeof (body as { tier?: number }).tier === "number",
+    );
+    expect(tierFlushes.length).toBe(0);
+  });
+
+  // Pin the hermes/pre-#240 edge case: workspace where MODEL_PROVIDER
+  // was never written but YAML has runtime_config.model: "something".
+  // originalModel must reflect the rendered baseline (the YAML value),
+  // not the empty MODEL_PROVIDER, so an unrelated save (tier change)
+  // doesn't fire a /model PUT and trigger an auto-restart. Codified
+  // review feedback from PR #2545 (Agent 1, "Important").
+  it("does not PUT /model when MODEL_PROVIDER is empty and the user only edited an unrelated field", async () => {
+    wireApi({
+      workspaceRuntime: "hermes",
+      workspaceModel: "", // legacy workspace — never went through the picker
+      configYamlContent:
+        "name: ws\nruntime: hermes\ntier: 2\nruntime_config:\n  model: nousresearch/hermes-4-70b\n",
+      providerValue: "",
+      templates: [
+        {
+          id: "hermes",
+          name: "Hermes",
+          runtime: "hermes",
+          models: [{ id: "nousresearch/hermes-4-70b", name: "Hermes 4 70B", required_env: ["HERMES_API_KEY"] }],
+          providers: ["nous"],
+        },
+      ],
+    });
+    apiPut.mockResolvedValue({});
+    apiPatch.mockResolvedValue({});
+
+    render(<ConfigTab workspaceId="ws-test" />);
+    const tierSelect = (await screen.findByLabelText(/tier/i)) as HTMLSelectElement;
+    fireEvent.change(tierSelect, { target: { value: "3" } });
+
+    const saveBtn = screen.getByRole("button", { name: /^save$/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(apiPatch.mock.calls.some(([p]) => p === "/workspaces/ws-test")).toBe(true);
+    });
+    const modelPuts = apiPut.mock.calls.filter(([path]) => path === "/workspaces/ws-test/model");
+    expect(modelPuts.length).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

User-reported regression on 2026-05-03: deployed a claude-code workspace with MiniMax-M2.7 picked from the dropdown. Container env was correct (`MODEL=MiniMax-M2`, chat worked) but the Config tab showed *Claude Code subscription / Claude Sonnet (OAuth)* — the template's YAML defaults — and changing the Tier dropdown to T3 + Save & Restart updated the DB to tier=3 but the header pill stayed at T2 until a full hydrate.

Same root pattern in three places: form display, save-side diff, and canvas store all read or write from different copies of the same data, so what the user sees and what the runtime uses can diverge silently.

### Bugs fixed

1. **Display drift** — `currentModelId = config.runtime_config?.model || config.model` reads `runtime_config.model` first; `loadConfig` overrode only the top-level `config.model` field with `wsMetadataModel`. With template YAML `runtime_config.model: sonnet` and live `MODEL_PROVIDER=MiniMax-M2`, the form rendered the template default and ignored the live value. Fix: `loadConfig` mirrors `wsMetadataModel` into BOTH `config.model` AND `config.runtime_config.model` (both branches: with and without config.yaml).

2. **Spurious /model PUT after (1)** — `handleSave` diffed `nextModel` (form value, now mirrored to live MODEL_PROVIDER) against `oldModelRaw` (YAML default `sonnet`). After (1), every no-op save would have non-zero diff and PUT `/model` — which server-side `SetModel` chains into auto-restart. New `originalModel` state tracks the loaded `MODEL_PROVIDER` and is the diff baseline; `setOriginalModel(nextModel)` after a successful PUT advances it.

3. **Stale tier badge after Save** — `handleSave` PATCHed the workspace row with `{tier: 3}` but never pushed the change into `useCanvasStore.updateNodeData`, so the header pill kept reading `tier=2` from the store until the next full hydrate. Fix: mirror `dbPatch` into the store after a successful PATCH.

### Bonus: silent model auto-default

`ProviderModelSelector.handleProviderChange` defaulted the model to `next.models[0]` (alphabetically first) on every provider switch. The user picked the MiniMax provider intending `MiniMax-M2.7`; the form silently set `MiniMax-M2` (first in the bucket) and the workspace deployed with the wrong model. Now: empty default for multi-model buckets to force an explicit pick. Single-model buckets still auto-fill (no choice to make). Save/Deploy already gated on `model.trim() === ""` so this loosens nothing.

## Test plan

- [x] 3 new regression tests in `ConfigTab.provider.test.tsx` (display drift, no spurious PUT, store flush)
- [x] 2 ProviderModelSelector tests updated, 1 added for the single-model-auto-pick boundary
- [x] All 1212 canvas tests pass
- [x] Live-verified on local workspace `e13aebd8…`: Config tab now reads MiniMax / MiniMax-M2 from MODEL_PROVIDER instead of the template's `sonnet` default

🤖 Generated with [Claude Code](https://claude.com/claude-code)