### PR TITLE
chore(workspace): remove dead defensive block in load_skills AST gate

### DIFF
--- a/workspace/tests/test_load_skills_call_sites.py
+++ b/workspace/tests/test_load_skills_call_sites.py
@@ -96,11 +96,6 @@ def test_every_runtime_load_skills_call_passes_current_runtime():
             continue
 
         for call in _find_load_skills_calls(tree):
-            if call.func.__class__.__name__ == "Name" and call.func.id == "load_skills":
-                # Skip the function DEFINITION itself (it appears as a
-                # FunctionDef, not a Call — but the Call check ensures
-                # we only trip on actual invocations). Defensive.
-                pass
             if not _has_current_runtime_kwarg(call):
                 violations.append((py.relative_to(WORKSPACE_DIR.parent), call.lineno))
 


### PR DESCRIPTION
## Summary

Self-review of #2553 (#119 PR-4) caught an unreachable defensive block at `test_load_skills_call_sites.py:99-103`:

```python
for call in _find_load_skills_calls(tree):
    if call.func.__class__.__name__ == "Name" and call.func.id == "load_skills":
        # Skip the function DEFINITION itself (it appears as a
        # FunctionDef, not a Call — but the Call check ensures
        # we only trip on actual invocations). Defensive.
        pass
    if not _has_current_runtime_kwarg(call):
```

The inner check guarded against `FunctionDef`, but `_find_load_skills_calls` already restricts its return type to `ast.Call` — a `FunctionDef` cannot reach that loop body. The block is a no-op `pass` with a misleading comment that implies the check matters for correctness when it doesn't.

Removing keeps the gate behaviorally identical; both tests still pass (`pytest workspace/tests/test_load_skills_call_sites.py` → 2 passed).

The five-axis review that turned this up also approved the substantive logic of #2553 — this is the only follow-up cleanup it surfaced.

## Test plan

- [x] `pytest workspace/tests/test_load_skills_call_sites.py` → 2 passed
- [x] Diff is `-5` lines, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)