### PR TITLE
fix(publish-runtime): align cascade list to 4 supported runtimes

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -327,7 +327,13 @@ jobs:
             echo "::error::publish job did not expose a version output — cascade cannot fan out"
             exit 1
           fi
-          TEMPLATES="claude-code langgraph crewai autogen deepagents hermes gemini-cli openclaw"
+          # Source of truth: manifest.json workspace_templates (PR #2536 pruned
+          # to 4 actively-supported runtimes: claude-code, hermes, openclaw, codex).
+          # Removed langgraph/crewai/autogen/deepagents/gemini-cli (deprecated, no
+          # shipping images); added codex (had been missing since #2512).
+          # Long-term: derive this list from manifest.json so the cascade can't
+          # drift again — tracked in RFC #388 as a Phase-1 invariant.
+          TEMPLATES="claude-code hermes openclaw codex"
           FAILED=""
           for tpl in $TEMPLATES; do
             REPO="Molecule-AI/molecule-ai-workspace-template-$tpl"


### PR DESCRIPTION
## Summary

The cascade `TEMPLATES` list at [`publish-runtime.yml:330`](https://github.com/Molecule-AI/molecule-core/blob/staging/.github/workflows/publish-runtime.yml#L330) had drifted from `manifest.json`:

| | Templates |
|---|---|
| **Cascade dispatches today** | `claude-code, langgraph, crewai, autogen, deepagents, hermes, gemini-cli, openclaw` (8) |
| **manifest.json supports** (after #2536) | `claude-code, hermes, openclaw, codex` (4) |

Two consequences of the drift:

1. **`codex` was never in the cascade** — added to manifest in #2512 but the cascade list wasn't updated. Fresh runtime publishes did not trigger a codex template rebuild; codex stayed pinned to whatever runtime version it last saw at its own image-build time. **Likely root cause of any "codex stuck on stale runtime" symptoms.**
2. **5 deprecated templates** (`langgraph, crewai, autogen, deepagents, gemini-cli`) — pruned from manifest by #2536 — were still receiving cascade dispatches. Wasted API calls, and green CI on dead repos masks "this template is dead, stop maintaining it."

After this PR, `TEMPLATES="claude-code hermes openclaw codex"` matches `manifest.json` workspace_templates exactly.

Surfaced during the RFC #388 (fast workspace provision) prior-art audit.

## Long-term

The data fix alone leaves the underlying drift hazard — manifest changes still need a manual cascade-list update. RFC #388 captures the structural fix (derive `TEMPLATES` from `manifest.json` so this can't drift again) as a Phase-1 invariant of the bake pipeline. Don't bundle that here — keep this PR focused on the immediate data correction.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Diff is data + comment only; no job/step structure changes
- [ ] CI green on this branch
- [ ] On merge to staging: confirm next runtime auto-publish dispatches to exactly 4 repos (claude-code, hermes, openclaw, codex), no others
- [ ] Verify codex template image rebuilds against the new runtime version (was previously skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)