### PR TITLE
fix(preflight): skip required_env check in MOLECULE_SMOKE_MODE

### DIFF
--- a/workspace/preflight.py
+++ b/workspace/preflight.py
@@ -180,16 +180,38 @@ def run_preflight(config: WorkspaceConfig, config_path: str) -> PreflightReport:
                 required_env = list(entry.get("required_env") or [])
             break
 
+    # Smoke mode skips the auth-env block: the boot smoke (CI publish-image,
+    # issue #2275) exercises executor.execute() against stub deps, never
+    # hits the real provider, and CI cannot enumerate every adapter's auth
+    # env without forming a maintenance treadmill. Hermes 2026-05-03 outage:
+    # template smoke crashed for two cycles because molecule-ci injected
+    # CLAUDE_CODE_OAUTH_TOKEN/ANTHROPIC_API_KEY/etc. but not HERMES_API_KEY.
+    # Bypass here means new templates can ship without the workflow
+    # learning their env names.
+    smoke_mode = os.environ.get("MOLECULE_SMOKE_MODE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
     for env_var in required_env:
-        if not os.environ.get(env_var):
-            report.failures.append(
+        if os.environ.get(env_var):
+            continue
+        if smoke_mode:
+            report.warnings.append(
                 PreflightIssue(
-                    severity="fail",
+                    severity="warn",
                     title="Required env",
-                    detail=f"Missing required environment variable: {env_var}",
-                    fix=f"Set {env_var} via the secrets API (global or workspace-level).",
+                    detail=f"Missing {env_var} (skipped — MOLECULE_SMOKE_MODE)",
+                    fix="",
                 )
             )
+            continue
+        report.failures.append(
+            PreflightIssue(
+                severity="fail",
+                title="Required env",
+                detail=f"Missing required environment variable: {env_var}",
+                fix=f"Set {env_var} via the secrets API (global or workspace-level).",
+            )
+        )
 
     # Backward compat: if legacy auth_token_file is set, warn but don't block
     # if the token is available via required_env or auth_token_env.

--- a/workspace/tests/test_preflight.py
+++ b/workspace/tests/test_preflight.py
@@ -286,6 +286,55 @@ def test_required_env_empty_list_passes(tmp_path):
     assert report.ok is True
 
 
+def test_required_env_skipped_in_smoke_mode(tmp_path, monkeypatch):
+    """MOLECULE_SMOKE_MODE=1 demotes Required-env failures to warnings.
+
+    Boot smoke (issue #2275) exercises executor.execute() against stub
+    deps and never hits the real provider, so missing auth env is not
+    a real blocker. Without this bypass, every adapter that introduces
+    a new auth env var (HERMES_API_KEY, OPENROUTER_API_KEY, etc.)
+    would silently break the publish-image gate until molecule-ci's
+    fake-env list catches up — the 2026-05-03 hermes outage. The
+    warning still surfaces in the report so unset env doesn't go
+    completely silent.
+    """
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.setenv("MOLECULE_SMOKE_MODE", "1")
+
+    config = make_config(
+        runtime_config=RuntimeConfig(required_env=["HERMES_API_KEY"]),
+    )
+
+    report = run_preflight(config, str(tmp_path))
+
+    assert report.ok is True
+    assert any(
+        issue.title == "Required env" and "HERMES_API_KEY" in issue.detail
+        for issue in report.warnings
+    ), "smoke-mode bypass should still warn so unset env stays visible"
+    assert not any(
+        issue.title == "Required env" for issue in report.failures
+    )
+
+
+def test_required_env_smoke_mode_off_still_fails(tmp_path, monkeypatch):
+    """Sanity: smoke bypass is OFF when MOLECULE_SMOKE_MODE is unset."""
+    monkeypatch.delenv("HERMES_API_KEY", raising=False)
+    monkeypatch.delenv("MOLECULE_SMOKE_MODE", raising=False)
+
+    config = make_config(
+        runtime_config=RuntimeConfig(required_env=["HERMES_API_KEY"]),
+    )
+
+    report = run_preflight(config, str(tmp_path))
+
+    assert report.ok is False
+    assert any(
+        issue.title == "Required env" and "HERMES_API_KEY" in issue.detail
+        for issue in report.failures
+    )
+
+
 # ---------- Per-model required_env (models[] override) ----------
 
 


### PR DESCRIPTION
## Summary

Boot smoke (#2275) exercises `executor.execute()` against stub deps and never hits the real provider, so missing auth env is not a real blocker. Without this bypass, every adapter that introduces a new auth env var must be mirrored into `molecule-ci`'s fake-env injection list — a maintenance treadmill that just bit hermes-template.

## Why now

- 2026-05-03 09:47 UTC: hermes-template publish-image started failing
- Cause: shared workflow injects `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `OPENAI_API_KEY` but not `HERMES_API_KEY` (or `OPENROUTER_API_KEY`)
- preflight rejects boot before smoke-mode short-circuit fires (main.py:84 → SystemExit before line 162's `is_smoke_mode()` check)
- Failed for at least 3 cascade cycles before being caught by the synth-E2E investigation

## What

`workspace/preflight.py` now demotes `Required env` failures to warnings when `MOLECULE_SMOKE_MODE` is truthy. Production paths are unchanged (unset env → fail).

The unset env still surfaces as a warning in the preflight report so debugging stays possible.

## Test plan

- [x] `pytest tests/test_preflight.py` — 31 passed (29 existing + 2 new regression tests)
- [x] `test_required_env_skipped_in_smoke_mode` covers the bypass + warning surfacing
- [x] `test_required_env_smoke_mode_off_still_fails` pins the production path
- [x] Diff verified before push (workspace/preflight.py + workspace/tests/test_preflight.py only, +76/-5)

## Impact

- Hermes template publish-image will turn green on next cascade
- Future templates can ship new auth envs without molecule-ci changes
- Synth-E2E should clear once the cascade rebuilds + the workspace runtime upgrade reaches the staging tenants

🤖 Generated with [Claude Code](https://claude.com/claude-code)