### PR TITLE
ci(synth-e2e): wire MOLECULE_STAGING_OPENAI_KEY into provisioned tenant

### DIFF
--- a/.github/workflows/continuous-synth-e2e.yml
+++ b/.github/workflows/continuous-synth-e2e.yml
@@ -88,6 +88,15 @@ jobs:
       E2E_KEEP_ORG: ${{ github.event.inputs.keep_org == 'true' && '1' || '' }}
       MOLECULE_CP_URL: ${{ vars.STAGING_CP_URL || 'https://staging-api.moleculesai.app' }}
       MOLECULE_ADMIN_TOKEN: ${{ secrets.CP_STAGING_ADMIN_API_TOKEN }}
+      # Provisioned tenant's default model (langgraph: openai:gpt-4.1-mini)
+      # needs OPENAI_API_KEY at first call. Sibling workflows
+      # e2e-staging-saas.yml + canary-staging.yml use the same secret;
+      # without this wire-up the tenant boots, accepts a2a messages,
+      # then returns "Could not resolve authentication method" — masked
+      # earlier by the a2a-sdk task-mode contract bugs PR #2558+#2563
+      # fixed. tests/e2e/test_staging_full_saas.sh:325 reads this and
+      # persists it as a workspace_secret on tenant create.
+      E2E_OPENAI_API_KEY: ${{ secrets.MOLECULE_STAGING_OPENAI_KEY }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 


### PR DESCRIPTION
## Summary

Synth-E2E (#2342) provisioned a langgraph tenant but never gave it credentials for its default model (\`openai:gpt-4.1-mini\`). The provisioner script reads \`E2E_OPENAI_API_KEY\` from the workflow env and persists it as a workspace_secret — but the workflow forgot to set it.

## Why now

PR #2558 + #2563 cleared the a2a-sdk v0→v1 contract violations that were masking this gap. First synth-E2E firing after both fixes (11:39 UTC today) returned:

> \`Agent error: \"Could not resolve authentication method. Expected either api_key or auth_token to be set.\"\`

That's the LLM call inside the langgraph adapter failing — a2a wire shape is now correct (state=failed, structured Task response), but the agent itself crashes on first model call.

## Fix

One-line wire-up of an existing secret. Mirrors:
- \`e2e-staging-saas.yml:89\`
- \`canary-staging.yml:63\`

Both already use \`MOLECULE_STAGING_OPENAI_KEY\` for the same purpose. The synth-E2E was the outlier.

## Verification path

After merge → next synth-E2E firing should show the agent successfully echoing back text instead of returning the auth error. The cron is every ~20 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)