### PR TITLE
ci(redeploy): fix stale canary_slug default 'hongmingwang' → 'hongming'

### DIFF
--- a/.github/workflows/redeploy-tenants-on-main.yml
+++ b/.github/workflows/redeploy-tenants-on-main.yml
@@ -17,7 +17,7 @@ name: redeploy-tenants-on-main
 #   1. publish-workspace-server-image completes → new :latest in GHCR.
 #   2. This workflow fires via workflow_run, waits 30s for GHCR's
 #      CDN to propagate the new tag to the region the tenants pull from.
-#   3. Calls redeploy-fleet with canary_slug=hongmingwang and a 60s
+#   3. Calls redeploy-fleet with canary_slug=hongming and a 60s
 #      soak. Canary proves the image boots; batches follow.
 #   4. Any failure aborts the rollout and leaves older tenants on the
 #      prior image — safer default than half-and-half state.
@@ -56,7 +56,12 @@ on:
         description: 'Tenant slug to deploy first + soak (empty = skip canary, fan out immediately).'
         required: false
         type: string
-        default: 'hongmingwang'
+        # Must be an actual prod tenant slug (current: hongming,
+        # chloe-dong, reno-stars). The previous default 'hongmingwang'
+        # didn't match any tenant — CP soft-skipped the missing canary
+        # and the fleet rolled out without the soak gate, defeating the
+        # whole point of canary-first.
+        default: 'hongming'
       soak_seconds:
         description: 'Seconds to wait after canary before fanning out.'
         required: false
@@ -148,7 +153,7 @@ jobs:
           CP_URL: ${{ vars.CP_URL || 'https://api.moleculesai.app' }}
           CP_ADMIN_API_TOKEN: ${{ secrets.CP_ADMIN_API_TOKEN }}
           TARGET_TAG: ${{ steps.tag.outputs.target_tag }}
-          CANARY_SLUG: ${{ inputs.canary_slug || 'hongmingwang' }}
+          CANARY_SLUG: ${{ inputs.canary_slug || 'hongming' }}
           SOAK_SECONDS: ${{ inputs.soak_seconds || '60' }}
           BATCH_SIZE: ${{ inputs.batch_size || '3' }}
           DRY_RUN: ${{ inputs.dry_run || false }}


### PR DESCRIPTION
## Summary

The `redeploy-tenants-on-main.yml` workflow_dispatch input default and the workflow_run env fallback both pointed at `hongmingwang`, which doesn't match any current prod tenant (real slugs are `hongming`, `chloe-dong`, `reno-stars`). CP silently skipped the missing canary and put every tenant in batch-1 in parallel, defeating the canary-first soak gate.

## Concrete example

Today's c0838d6 redeploy at 11:53Z (run 25278434388):
- Body sent: `{"target_tag":"staging-c0838d6","canary_slug":"hongmingwang","soak_seconds":60,"batch_size":3,"dry_run":false}`
- CP response: all 3 prod tenants reported `"phase":"batch-1"` — no `canary` phase, no soak.

The deploy happened to be safe (canvas warm-paper React Flow `colorMode` fix). But a broken image would have hit hongming + chloe-dong + reno-stars simultaneously instead of failing on hongming alone after a 60s soak.

## Changes

Three sites in `.github/workflows/redeploy-tenants-on-main.yml`:
- Runtime-ordering comment (line 20)
- `workflow_dispatch.inputs.canary_slug.default` (line 59)
- `env.CANARY_SLUG` fallback used by the `workflow_run` trigger (line 151)

Added an inline comment documenting the rationale so the next slug rename doesn't silently regress this again.

## Test plan

- [x] YAML lint passes
- [ ] Next prod redeploy (staging→main code change) — verify CP response shows `"phase":"canary"` for hongming, then `"batch-1"` for chloe-dong + reno-stars after the 60s soak