### PR TITLE
fix(synth-e2e): branch MODEL_SLUG by runtime so langgraph gets colon-form

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -352,15 +352,42 @@ print(json.dumps({
 ")
 fi
 
-# Model slug MUST be provider-prefixed for hermes — the template's
-# derive-provider.sh parses the slug prefix (`openai/…`, `anthropic/…`,
-# `minimax/…`) to set HERMES_INFERENCE_PROVIDER at install time. A bare
-# "gpt-4o" has no prefix → provider falls back to hermes auto-detect →
-# picks Anthropic default → tries Anthropic API with the OpenAI key →
-# 401 on A2A. Same trap that trapped prod users in PR #1714. We pin
-# "openai/gpt-4o" here because the E2E's secret is always the OpenAI
-# key; non-hermes runtimes ignore the prefix.
-MODEL_SLUG="openai/gpt-4o"
+# Model slug format depends on the runtime — different model resolvers
+# parse it differently:
+#
+#   hermes      → "openai/gpt-4o"  (slash-form: derive-provider.sh splits
+#                                    on the prefix to set
+#                                    HERMES_INFERENCE_PROVIDER. Bare
+#                                    "gpt-4o" falls through to Anthropic
+#                                    default + 401, see PR #1714.)
+#
+#   langgraph   → "openai:gpt-4o"  (colon-form: langchain init_chat_model
+#                                    requires "<provider>:<model>".
+#                                    Slash-form was misinterpreted as
+#                                    OpenRouter routing → fell through
+#                                    without auth, surfaced 2026-05-03
+#                                    after the a2a-sdk v1 contract bugs
+#                                    PR #2558+#2563+#2567 cleared the
+#                                    masking layers.)
+#
+#   claude-code → "sonnet"         (entry-id form: claude-code template's
+#                                    config.yaml uses bare model names,
+#                                    auth comes via CLAUDE_CODE_OAUTH_TOKEN
+#                                    or ANTHROPIC_API_KEY rather than the
+#                                    slug.)
+#
+# When E2E_MODEL_SLUG is set, it overrides this dispatch — useful when an
+# operator dispatches the workflow to test a specific slug.
+if [ -n "${E2E_MODEL_SLUG:-}" ]; then
+  MODEL_SLUG="$E2E_MODEL_SLUG"
+else
+  case "$RUNTIME" in
+    hermes)      MODEL_SLUG="openai/gpt-4o" ;;
+    langgraph)   MODEL_SLUG="openai:gpt-4o" ;;
+    claude-code) MODEL_SLUG="sonnet" ;;
+    *)           MODEL_SLUG="openai/gpt-4o" ;;  # safest fallback (matches hermes)
+  esac
+fi
 
 log "5/11 Provisioning parent workspace (runtime=$RUNTIME)..."
 PARENT_RESP=$(tenant_call POST /workspaces \


### PR DESCRIPTION
## Summary

Synth-E2E workflow defaults `E2E_RUNTIME=langgraph` but the script hardcoded `MODEL_SLUG=\"openai/gpt-4o\"` (slash form). LangGraph's `init_chat_model` requires `<provider>:<model>` (colon) form — slash form falls through with no auth method, masking as \"Could not resolve authentication method\" at first message.

This was the next layer of progressive masking after PRs #2558, #2563, #2567:
- #2558 fixed task-enqueue contract
- #2563 fixed terminal Message routing via TaskUpdater
- #2567 wired the OpenAI key into the workflow env
- This PR: pick the right slug *format* per runtime

## Change

Branch `MODEL_SLUG` by `RUNTIME` in `tests/e2e/test_staging_full_saas.sh`:

| Runtime | Slug format | Reason |
|---|---|---|
| `langgraph` | `openai:gpt-4o` | LangChain `init_chat_model` parses colon form |
| `hermes` | `openai/gpt-4o` | derive-provider.sh expects slash form |
| `claude-code` | `sonnet` | Anthropic-only runtime, model-name only |

Operators can override via `E2E_MODEL_SLUG` for ad-hoc dispatch.

## Test plan

- [x] bash syntax check passes
- [x] shellcheck reports no new warnings
- [ ] Synth-E2E firing after merge goes green for the first time since the v1 migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)