### PR TITLE
fix(publish-runtime): re-add 5 templates wrongly removed from cascade — fixes #2566

### DIFF
--- a/.github/workflows/publish-runtime.yml
+++ b/.github/workflows/publish-runtime.yml
@@ -327,13 +327,19 @@ jobs:
             echo "::error::publish job did not expose a version output — cascade cannot fan out"
             exit 1
           fi
-          # Source of truth: manifest.json workspace_templates (PR #2536 pruned
-          # to 4 actively-supported runtimes: claude-code, hermes, openclaw, codex).
-          # Removed langgraph/crewai/autogen/deepagents/gemini-cli (deprecated, no
-          # shipping images); added codex (had been missing since #2512).
-          # Long-term: derive this list from manifest.json so the cascade can't
-          # drift again — tracked in RFC #388 as a Phase-1 invariant.
-          TEMPLATES="claude-code hermes openclaw codex"
+          # All 9 active workspace template repos. The PR #2536 pruning
+          # ("deprecated, no shipping images") was empirically wrong:
+          # continuous-synth-e2e.yml defaults to langgraph as its primary
+          # canary (line 44), and every excluded template had successful
+          # publish-image runs as of 2026-05-03 — none were dormant.
+          # Symptom of the prune: today's a2a-sdk strict-mode fix
+          # (#2566 / commit e1628c4) cascaded to 4 templates but never
+          # reached langgraph, so the synth-E2E correctly canary'd a fix
+          # that had landed but not deployed. Re-added the 5 templates.
+          # Long-term: derive this list from manifest.json so cascade
+          # scope can't drift from E2E scope — tracked in RFC #388 as a
+          # Phase-1 invariant.
+          TEMPLATES="claude-code hermes openclaw codex langgraph crewai autogen deepagents gemini-cli"
           FAILED=""
           for tpl in $TEMPLATES; do
             REPO="Molecule-AI/molecule-ai-workspace-template-$tpl"

--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,12 @@
     {"name": "claude-code-default", "repo": "Molecule-AI/molecule-ai-workspace-template-claude-code", "ref": "main"},
     {"name": "hermes", "repo": "Molecule-AI/molecule-ai-workspace-template-hermes", "ref": "main"},
     {"name": "openclaw", "repo": "Molecule-AI/molecule-ai-workspace-template-openclaw", "ref": "main"},
-    {"name": "codex", "repo": "Molecule-AI/molecule-ai-workspace-template-codex", "ref": "main"}
+    {"name": "codex", "repo": "Molecule-AI/molecule-ai-workspace-template-codex", "ref": "main"},
+    {"name": "langgraph", "repo": "Molecule-AI/molecule-ai-workspace-template-langgraph", "ref": "main"},
+    {"name": "crewai", "repo": "Molecule-AI/molecule-ai-workspace-template-crewai", "ref": "main"},
+    {"name": "autogen", "repo": "Molecule-AI/molecule-ai-workspace-template-autogen", "ref": "main"},
+    {"name": "deepagents", "repo": "Molecule-AI/molecule-ai-workspace-template-deepagents", "ref": "main"},
+    {"name": "gemini-cli", "repo": "Molecule-AI/molecule-ai-workspace-template-gemini-cli", "ref": "main"}
   ],
   "org_templates": [
     {"name": "molecule-dev", "repo": "Molecule-AI/molecule-ai-org-template-molecule-dev", "ref": "main"},


### PR DESCRIPTION
## Summary

Re-add `langgraph`, `crewai`, `autogen`, `deepagents`, `gemini-cli` to the `publish-runtime.yml` cascade `TEMPLATES` list. They were removed by #2536 with the rationale "deprecated, no shipping images" — empirically wrong.

## Why this fixes #2566

`continuous-synth-e2e.yml` defaults to **langgraph** as its primary canary (line 44, "fastest, default"). When today's a2a-sdk strict-mode fix landed (commit `e1628c4` at 11:06), `publish-runtime` fired at 11:13 and cascaded — but only to `claude-code, hermes, openclaw, codex`. langgraph was excluded, so its image stayed on the broken runtime.

So #2566 was actually a cascade-scope drift bug masquerading as an a2a regression. The a2a fix is correct and deployed in PyPI 0.1.94; it just never made it into the langgraph image.

## Verified all 5 are still alive

Per `gh run list --workflow publish-image --limit 1` per repo, every "deprecated" template had successful publish-image runs within the past 24h. None are dormant.

## Followup (out of scope here)

The original comment proposed: "Long-term: derive this list from manifest.json so the cascade can't drift again — tracked in RFC #388 as a Phase-1 invariant." Still the right move — this PR re-adds the data manually, but the structural fix lives in RFC #388.

## Test plan

- [x] YAML validates
- [ ] After merge, watch publish-runtime cascade to all 9 templates
- [ ] langgraph publish-image succeeds  
- [ ] continuous-synth-e2e goes green within 1 cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)