### PR TITLE
fix(canvas): align tier text contracts with 4-tier reality (T1/T2/T3/T4)

### DIFF
--- a/canvas/src/components/Legend.tsx
+++ b/canvas/src/components/Legend.tsx
@@ -1,10 +1,22 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { STATUS_CONFIG } from "@/lib/design-tokens";
+import { STATUS_CONFIG, TIER_CONFIG } from "@/lib/design-tokens";
 import { useCanvasStore } from "@/store/canvas";
 
 const LEGEND_STATUSES = ["online", "provisioning", "degraded", "failed", "paused", "offline"] as const;
+
+// Tier descriptions kept in sync with CreateWorkspaceDialog.tsx (the
+// source of truth for what each tier means semantically). Colors come
+// from TIER_CONFIG so the legend swatch matches the badge actually
+// rendered on every WorkspaceNode — drift here misled users into
+// thinking the legend documented a different tier than the one shown.
+const LEGEND_TIERS: ReadonlyArray<{ tier: number; label: string }> = [
+  { tier: 1, label: "Sandboxed" },
+  { tier: 2, label: "Standard" },
+  { tier: 3, label: "Privileged" },
+  { tier: 4, label: "Full Access" },
+];
 
 // Persist the user's choice across sessions. Default is "open" so
 // first-time users still see the symbol key; once dismissed we
@@ -102,9 +114,9 @@ export function Legend() {
       <div className="mb-2">
         <div className="text-[11px] text-ink-soft font-medium mb-1">Tier</div>
         <div className="flex flex-wrap gap-x-3 gap-y-1">
-          <TierItem tier={1} label="Sandboxed" color="text-sky-300 bg-sky-950/40 border-sky-700/30" />
-          <TierItem tier={2} label="Standard" color="text-violet-300 bg-violet-950/40 border-violet-700/30" />
-          <TierItem tier={3} label="Full Access" color="text-warm bg-amber-950/40 border-amber-700/30" />
+          {LEGEND_TIERS.map(({ tier, label }) => (
+            <TierItem key={tier} tier={tier} label={label} color={TIER_CONFIG[tier].border} />
+          ))}
         </div>
       </div>
 

--- a/canvas/src/components/tabs/ConfigTab.tsx
+++ b/canvas/src/components/tabs/ConfigTab.tsx
@@ -655,7 +655,8 @@ export function ConfigTab({ workspaceId }: Props) {
                 >
                   <option value={1}>T1 — Sandboxed</option>
                   <option value={2}>T2 — Standard</option>
-                  <option value={3}>T3 — Full Access</option>
+                  <option value={3}>T3 — Privileged</option>
+                  <option value={4}>T4 — Full Access</option>
                 </select>
               </div>
             </div>

--- a/canvas/src/lib/tenant.ts
+++ b/canvas/src/lib/tenant.ts
@@ -59,8 +59,8 @@ export function getTenantSlug(): string {
  * isSaaSTenant reports whether the canvas is running as the UI for a
  * SaaS tenant (served at <slug>.moleculesai.app). Use for client-side
  * UX branches that should behave differently on SaaS vs self-hosted —
- * e.g. the workspace tier picker hides T1/T2 sandbox tiers because every
- * SaaS workspace gets its own EC2 VM (inherently T3 Full Access).
+ * e.g. the workspace tier picker hides T1/T2/T3 sandbox tiers because
+ * every SaaS workspace gets its own EC2 VM (inherently T4 Full Access).
  *
  * SSR-safe: returns false on the server to avoid hydration drift; call
  * sites should tolerate a flip from false→true on first client render.


### PR DESCRIPTION
## Summary

Surfaced from a screenshot of `hongming.moleculesai.app` showing a workspace with a **T4** badge (orange) but the chrome Legend documenting only T1/T2/T3 with T3 mislabeled "Full Access". Two chrome surfaces had stale 3-tier text:

| Surface | Before | After |
|---|---|---|
| Legend (bottom-left chrome) | T1 Sandboxed / T2 Standard / **T3 Full Access** | T1 Sandboxed / T2 Standard / **T3 Privileged** / **T4 Full Access** |
| ConfigTab tier dropdown | T1 / T2 / **T3 Full Access** (no T4) | T1 / T2 / **T3 Privileged** / **T4 Full Access** |
| `tenant.ts` doc comment | "SaaS hides T1/T2 → T3 Full Access" | "SaaS hides T1/T2/T3 → T4 Full Access" |

`CreateWorkspaceDialog.tsx` and `design-tokens.ts` already use the 4-tier scheme (T3 = Privileged, T4 = Full Access). These two surfaces were the last drift.

## Bonus cleanup

The Legend's previous tier swatches were hardcoded sky/violet/amber, but `WorkspaceNode` renders badges with `TIER_CONFIG.color` (gray/sky/violet/amber). So the Legend's swatch for "T1" was sky while actual T1 badges render gray — visually misleading. Switched Legend to source colors from `TIER_CONFIG[tier].border` so the swatch matches the rendered badge.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 1214/1214 passing
- [ ] Visual: load a SaaS tenant canvas, confirm T4 workspace card badge color matches the new Legend T4 swatch