### PR TITLE
fix(canvas): add role=status + aria-live to remaining loading states

### DIFF
--- a/canvas/src/app/page.tsx
+++ b/canvas/src/app/page.tsx
@@ -54,7 +54,7 @@ export default function Home() {
   if (hydrating) {
     return (
       <div className="fixed inset-0 flex items-center justify-center bg-surface">
-        <div className="flex flex-col items-center gap-3">
+        <div role="status" aria-live="polite" className="flex flex-col items-center gap-3">
           <Spinner size="lg" />
           <span className="text-xs text-ink-soft">Loading canvas...</span>
         </div>

--- a/canvas/src/components/settings/OrgTokensTab.tsx
+++ b/canvas/src/components/settings/OrgTokensTab.tsx
@@ -182,7 +182,7 @@ export function OrgTokensTab() {
 
       {/* Token list */}
       {loading ? (
-        <div className="flex items-center justify-center gap-2 py-6 text-ink-soft text-xs">
+        <div role="status" aria-live="polite" className="flex items-center justify-center gap-2 py-6 text-ink-soft text-xs">
           <Spinner /> Loading keys...
         </div>
       ) : tokens.length === 0 ? (

--- a/canvas/src/components/settings/TokensTab.tsx
+++ b/canvas/src/components/settings/TokensTab.tsx
@@ -129,7 +129,7 @@ export function TokensTab({ workspaceId }: TokensTabProps) {
 
       {/* Token list */}
       {loading ? (
-        <div className="flex items-center justify-center gap-2 py-6 text-ink-soft text-xs">
+        <div role="status" aria-live="polite" className="flex items-center justify-center gap-2 py-6 text-ink-soft text-xs">
           <Spinner /> Loading tokens...
         </div>
       ) : tokens.length === 0 ? (


### PR DESCRIPTION
## Summary

Three canvas loading-state divs were missing the \`role=\"status\"\` + \`aria-live=\"polite\"\` pattern that \`TemplatePalette.tsx\` (lines 266, 511) and \`EmptyState.tsx\` already follow. Screen readers got no signal that the page was waiting.

| File | Loader |
|---|---|
| \`canvas/src/app/page.tsx\` | \"Loading canvas…\" — full-screen, first paint of the entire app |
| \`canvas/src/components/settings/TokensTab.tsx\` | \"Loading tokens…\" |
| \`canvas/src/components/settings/OrgTokensTab.tsx\` | \"Loading keys…\" |

Each gets one minimal addition on the wrapping div:

\`\`\`diff
- <div className=\"flex items-center …\">
+ <div role=\"status\" aria-live=\"polite\" className=\"flex items-center …\">
\`\`\`

Visual rendering unchanged. \`Spinner\` itself stays \`aria-hidden=\"true\"\` — the visible text label provides the accessible name, the wrapper provides the live-region announcement.

## Test plan
- [x] \`tsc --noEmit\` — clean
- [x] \`pnpm test\` — 1214/1214 pass
- [ ] Live verify on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)