### PR TITLE
fix(retarget): skip PRs whose head is staging (auto-promote PRs)

### DIFF
--- a/.github/workflows/retarget-main-to-staging.yml
+++ b/.github/workflows/retarget-main-to-staging.yml
@@ -26,11 +26,22 @@ jobs:
     runs-on: ubuntu-latest
     # Only fire for bot-authored PRs. Human CEO PRs (staging→main promotion)
     # are intentional and pass through.
+    #
+    # Head-ref guard: never retarget a PR whose head IS `staging` — those
+    # are the auto-promote staging→main PRs (opened by molecule-ai[bot]
+    # since #2586 switched to an App token, which now passes the bot
+    # filter below). Retargeting head=staging onto base=staging fails
+    # with HTTP 422 "no new commits between base 'staging' and head
+    # 'staging'", which used to surface as a noisy red workflow run on
+    # every auto-promote (caught 2026-05-03 on PR #2588).
     if: >-
-      github.event.pull_request.user.type == 'Bot'
-      || endsWith(github.event.pull_request.user.login, '[bot]')
-      || github.event.pull_request.user.login == 'app/molecule-ai'
-      || github.event.pull_request.user.login == 'molecule-ai[bot]'
+      github.event.pull_request.head.ref != 'staging'
+      && (
+        github.event.pull_request.user.type == 'Bot'
+        || endsWith(github.event.pull_request.user.login, '[bot]')
+        || github.event.pull_request.user.login == 'app/molecule-ai'
+        || github.event.pull_request.user.login == 'molecule-ai[bot]'
+      )
     steps:
       - name: Retarget PR base to staging
         id: retarget


### PR DESCRIPTION
## Summary

\`Retarget main PRs to staging\` started failing on every auto-promote PR since #2586 merged at 14:25 UTC. The new App-token-using auto-promote workflow opens its staging→main PR as \`molecule-ai[bot]\`, which passes the retarget filter; then the PATCH \`base=staging\` request fails with:

\`\`\`
HTTP 422: There are no new commits between base branch 'staging' and head branch 'staging'
\`\`\`

…because the auto-promote PR's \`head\` is already \`staging\`. Live caught on PR #2588 (run #25281848820).

## Fix

Add \`head.ref != 'staging'\` to the job-level \`if\` condition. Auto-promote PRs short-circuit before the PATCH attempt; everything else (canvas-bot PRs, dependabot, etc.) keeps current behaviour.

The existing 422 \"duplicate base\" detector is unchanged — it covers a different case (bot opens main-PR while another open PR on the same head already targets staging).

## Test plan
- [x] \`yaml.safe_load\` clean
- [ ] Live verify: next auto-promote PR should leave the retarget workflow either skipped (\`if\` evaluates false) or untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)