### PR TITLE
fix(canvas): chat bubble + sub-tab contrast in light theme

### DIFF
--- a/canvas/src/components/SidePanel.tsx
+++ b/canvas/src/components/SidePanel.tsx
@@ -202,7 +202,7 @@ export function SidePanel() {
       {/* Tabs — relative wrapper lets the fade gradient position against the scroll container */}
       <div className="relative border-b border-line/40">
         {/* Right-edge fade: signals more tabs are hidden off-screen when the bar overflows */}
-        <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-zinc-950 to-transparent z-10" aria-hidden="true" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-surface to-transparent z-10" aria-hidden="true" />
       <div
         role="tablist"
         aria-label="Workspace panel tabs"
@@ -232,8 +232,8 @@ export function SidePanel() {
             onClick={() => setPanelTab(tab.id)}
             className={`shrink-0 px-3 py-2.5 text-[10px] font-medium tracking-wide transition-all rounded-t-lg mx-0.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/70 ${
               panelTab === tab.id
-                ? "text-ink bg-surface-card/40 border-b-2 border-accent"
-                : "text-ink-soft hover:text-ink hover:bg-surface-card/40"
+                ? "text-ink bg-surface-card border-b-2 border-accent"
+                : "text-ink-mid hover:text-ink hover:bg-surface-card/60"
             }`}
           >
             <span className="mr-1 opacity-50" aria-hidden="true">{tab.icon}</span>

--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -773,14 +773,14 @@ function MyChatPanel({ workspaceId, data }: Props) {
             <div
               className={`max-w-[85%] rounded-lg px-3 py-2 text-xs ${
                 msg.role === "user"
-                  ? "bg-accent-strong/30 text-blue-100 border border-accent/20"
+                  ? "bg-accent text-white border border-accent-strong"
                   : msg.role === "system"
-                    ? "bg-red-900/30 text-red-200 border border-red-800/30"
-                    : "bg-surface-card/80 text-ink border border-line/30"
+                    ? "bg-bad/10 text-bad border border-bad/40"
+                    : "bg-surface-card text-ink border border-line"
               }`}
             >
               {msg.content && (
-                <div className="prose prose-sm prose-invert max-w-none [&>p]:mb-1 [&>p:last-child]:mb-0">
+                <div className={`prose prose-sm max-w-none [&>p]:mb-1 [&>p:last-child]:mb-0 ${msg.role === "user" ? "prose-invert" : ""}`}>
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
                 </div>
               )}
@@ -796,7 +796,7 @@ function MyChatPanel({ workspaceId, data }: Props) {
                   ))}
                 </div>
               )}
-              <div className="text-[9px] text-ink-soft mt-1">
+              <div className={`text-[9px] mt-1 ${msg.role === "user" ? "text-white/70" : "text-ink-mid"}`}>
                 {new Date(msg.timestamp).toLocaleTimeString()}
               </div>
             </div>


### PR DESCRIPTION
## Summary

User reported pale-purple chat bubbles with washed-out text in canvas (screenshot). Root causes:

- **Chat user bubble** used `bg-accent-strong/30 text-blue-100` — translucent dark-blue overlay on warm-paper renders as pale lavender; light-blue text on top of that is borderline invisible. Switched to solid `bg-accent text-white`.
- **System/error bubble** had the same pattern with red. Migrated to `bg-bad/10 text-bad` so dark-mode tracks automatically.
- **Agent bubble** had `/80 + /30` alpha modifiers — solid `bg-surface-card text-ink border-line` gives WCAG AA contrast in both themes.
- **`prose-invert`** was unconditional. On agent/system bubbles in light mode the markdown body rendered as light text on a light surface. Now only applied on the user bubble (solid blue).
- **Timestamp** used `text-ink-soft` (3.5:1 on warm-paper). Bumped to `text-ink-mid` (7:1) for agent/system, `white/70` for user.

Sub-tab bar in `SidePanel.tsx`:
- Right-edge scroll-fade was hardcoded `from-zinc-950`. In light mode that paints a dark vertical strip — switched to `from-surface` so the gradient matches whichever theme is active.
- Inactive tab text was `text-ink-soft` (failing AA). Bumped to `text-ink-mid`.
- Active tab dropped the `/40` opacity on its bg-card so selection is unambiguous.

All semantic tokens already exist; no globals.css changes.

## Test plan
- [x] `pnpm build` clean
- [x] `npx tsc --noEmit` clean
- [ ] Browser-verify on staging tenant in both light + dark mode after deploy