### PR TITLE
fix(chat-history): correct docstring inversion + pin empty-history JSON shape (#2485)

### DIFF
--- a/workspace/a2a_tools.py
+++ b/workspace/a2a_tools.py
@@ -559,9 +559,10 @@ async def tool_chat_history(peer_id: str, limit: int = 20, before_ts: str = "") 
 
     Hits ``/workspaces/<self>/activity?peer_id=<peer>&limit=<N>``
     against the workspace-server, which returns activity rows where
-    this workspace is either the sender (``source_id=peer``) or the
-    recipient (``target_id=peer``) of an A2A turn — both sides of the
-    conversation in chronological order.
+    the peer is either the sender (``source_id=peer`` — they sent us
+    the message) or the recipient (``target_id=peer`` — we sent to
+    them) of an A2A turn — both sides of the conversation in
+    chronological order.
 
     Args:
         peer_id: The other workspace's UUID. Same value the agent

--- a/workspace/tests/test_a2a_tools_impl.py
+++ b/workspace/tests/test_a2a_tools_impl.py
@@ -1050,6 +1050,27 @@ class TestChatHistory:
 
         assert mc.get.call_args.kwargs["params"]["before_ts"] == "2026-05-01T00:00:00Z"
 
+    async def test_empty_history_returns_empty_json_list(self):
+        """Pin the happy-path-with-no-rows shape: server returns 200
+        with an empty list, the wheel returns the JSON literal ``"[]"``.
+
+        Without this pin the surrounding tests all pre-populate rows;
+        none verify what an agent sees when there's literally no chat
+        history with this peer yet (a fresh A2A peering, or a peer
+        whose history was rotated out). #2485.
+        """
+        import a2a_tools
+
+        mc = _make_http_mock(get_resp=_resp(200, []))
+        with patch("a2a_tools.httpx.AsyncClient", return_value=mc):
+            result = await a2a_tools.tool_chat_history(peer_id=_PEER)
+
+        # Exact-equality on the JSON literal (per assert-exact memory) —
+        # substring "[]" would also match `{"items": []}` or any number
+        # of envelope shapes, only `result == "[]"` discriminates the
+        # bare-list contract callers depend on.
+        assert result == "[]"
+
     async def test_reverses_desc_response_to_chronological(self):
         """Server returns DESC (newest first); the wheel reverses to
         chronological so the agent reads the chat top-down — same


### PR DESCRIPTION
Closes #2485.

## 1. Docstring inversion

`workspace/a2a_tools.py:tool_chat_history` doc said `source_id=peer` means "this workspace is the sender." That's backwards — `source_id` is where the activity *came from*, so `source_id=peer` means the **peer** is the sender. Reframed to match the SQL semantics: "where the peer is either the sender or the recipient."

## 2. Empty-history test

`TestChatHistory` had 10 tests covering errors, paging, ordering, but no `200+[]` happy-path pin. Added one with exact-equality on the bare-list JSON literal `"[]"` (substring match would have accepted envelope shapes like `{"items": []}` too — only `result == "[]"` discriminates the contract callers depend on).

## Out of scope

Pure docs + test addition. No production behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)