### PR TITLE
fix(canvas): agent chat bubble dark-mode prose contrast (regression #2618)

### DIFF
--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -792,7 +792,18 @@ function MyChatPanel({ workspaceId, data }: Props) {
               }`}
             >
               {msg.content && (
-                <div className={`prose prose-sm max-w-none [&>p]:mb-1 [&>p:last-child]:mb-0 ${msg.role === "user" ? "prose-invert" : ""}`}>
+                <div
+                  className={`prose prose-sm max-w-none [&>p]:mb-1 [&>p:last-child]:mb-0 ${
+                    msg.role === "user"
+                      ? "prose-invert"
+                      // Agent bubbles use bg-zinc-700 in dark mode; without
+                      // prose-invert the Tailwind Typography plugin keeps
+                      // its default DARK body color → unreadable dark-on-dark.
+                      // Light mode keeps default prose colors against the
+                      // warm surface-card bg.
+                      : "dark:prose-invert"
+                  }`}
+                >
                   <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
                 </div>
               )}


### PR DESCRIPTION
## Regression from #2618

User screenshot shows empty-looking gray rectangles where agent replies should appear in dark mode.

## Root cause

PR #2618 set agent bubbles to \`dark:bg-zinc-700\` so they elevate against the dark panel. But the inner ReactMarkdown prose div only gets \`prose-invert\` for USER messages — so in dark mode the agent's markdown body text rendered in the Tailwind Typography plugin's **default DARK body color** on top of the new dark bg = invisible.

## Fix

Apply \`dark:prose-invert\` to agent bubbles so prose body text flips light alongside the bg. Light mode unchanged (default prose colors against the warm \`bg-surface-card\`).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Browser-verify: dark mode + light mode, agent message text readable in both

## Why this slipped #2618 review

I verified bubble bg/border contrast but didn't open a real chat in dark mode after the bg change. Lesson: contrast PRs that change bubble backgrounds need to also account for the inline content rendering layer (prose, syntax highlighting, etc.). Will adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)