### PR TITLE
fix(canvas): ApprovalBanner Approve/Deny button polish

### DIFF
--- a/canvas/src/components/ApprovalBanner.tsx
+++ b/canvas/src/components/ApprovalBanner.tsx
@@ -73,14 +73,19 @@ export function ApprovalBanner() {
                 <button
                   type="button"
                   onClick={() => handleDecide(approval, "approved")}
-                  className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-500 text-xs rounded-lg text-white font-medium transition-colors"
+                  // Hover DARKER not lighter — emerald-500 on white text
+                  // drops contrast vs emerald-700.
+                  className="px-3 py-1.5 bg-emerald-600 hover:bg-emerald-700 text-xs rounded-lg text-white font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-950 focus-visible:ring-emerald-400/70"
                 >
                   Approve
                 </button>
                 <button
                   type="button"
                   onClick={() => handleDecide(approval, "denied")}
-                  className="px-3 py-1.5 bg-surface-card hover:bg-surface-card text-xs rounded-lg text-ink-mid transition-colors"
+                  // Was a no-op hover (`bg-surface-card hover:bg-surface-card`).
+                  // Lift to surface-elevated on hover so the button visibly
+                  // responds before a destructive deny.
+                  className="px-3 py-1.5 bg-surface-card hover:bg-surface-elevated hover:text-ink text-xs rounded-lg text-ink-mid transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-amber-950 focus-visible:ring-amber-400/70"
                 >
                   Deny
                 </button>


### PR DESCRIPTION
## Summary

Same bug class as #2622 (ConfirmDialog), on a more critical surface — top-of-page banner asking the user to **approve / deny a real workspace permission request**.

1. **Deny was a no-op hover** (\`bg-surface-card hover:bg-surface-card\`) — zero feedback before a destructive action.
2. **Approve hover went LIGHTER** (\`emerald-600 → emerald-500\`) — white-text contrast dropped on hover.
3. **No focus rings on either button** — keyboard users couldn't tell which decision was focused before pressing Enter.

## Fix

- Deny: hover lifts to \`surface-elevated\` + brightens text
- Approve: hover darkens to \`emerald-700\` (preserves AA contrast)
- Both: \`focus-visible:ring-2\` with offset against the amber banner bg — emerald ring for Approve, amber ring for Deny so the choice is visually distinguishable on keyboard nav

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Browser-verify when an approval banner appears: hover Deny + Approve to see new feedback, tab between them to see distinct focus rings

🤖 Generated with [Claude Code](https://claude.com/claude-code)