### PR TITLE
feat(canvas): add Hermes/Codex/OpenClaw tabs to ExternalConnectModal + default to Universal MCP

### DIFF
--- a/canvas/src/components/ExternalConnectModal.tsx
+++ b/canvas/src/components/ExternalConnectModal.tsx
@@ -40,6 +40,22 @@ export interface ExternalConnectionInfo {
   // + inbound. Optional for backward compat with platforms that
   // haven't shipped PR #2413 yet.
   universal_mcp_snippet?: string;
+  // Hermes channel snippet — for operators whose external agent IS a
+  // hermes-agent session. Routes A2A traffic into the hermes gateway
+  // via the molecule-channel plugin (Molecule-AI/hermes-channel-molecule).
+  // Long-poll based (no tunnel) — same UX shape as the Claude Code
+  // channel tab. Gives hermes true push parity. Optional for backward
+  // compat with platforms that haven't shipped this PR yet.
+  hermes_channel_snippet?: string;
+  // Codex MCP config snippet — wires the molecule MCP server into
+  // ~/.codex/config.toml so codex agents can call platform tools.
+  // Outbound-tools-only today (codex's MCP client doesn't route
+  // notifications/*); push parity would need a separate bridge daemon.
+  codex_snippet?: string;
+  // OpenClaw MCP config snippet — wires molecule MCP + starts the
+  // openclaw gateway on loopback. Outbound-tools-only today; push
+  // parity on an external openclaw needs a sessions.steer bridge.
+  openclaw_snippet?: string;
 }
 
 interface Props {
@@ -47,13 +63,21 @@ interface Props {
   onClose: () => void;
 }
 
-type Tab = "python" | "curl" | "claude" | "mcp" | "fields";
+type Tab = "python" | "curl" | "claude" | "mcp" | "hermes" | "codex" | "openclaw" | "fields";
 
 export function ExternalConnectModal({ info, onClose }: Props) {
-  // Default to Claude Code when the platform offers it — that's the
-  // newest + simplest path (no tunnel needed). Falls back to Python
-  // for older platform builds that don't ship the snippet.
-  const initialTab: Tab = info?.claude_code_channel_snippet ? "claude" : "python";
+  // Default to Universal MCP when the platform offers it — runtime-
+  // agnostic outbound tool path that works for any MCP-aware runtime
+  // (Claude Code, hermes, codex, etc.) and lets operators inspect the
+  // primitives before picking a runtime-specific tab. Python SDK is
+  // the fallback for platforms predating the universal_mcp_snippet
+  // field. Pre-2026-05-03 the default was "claude" (Claude Code first)
+  // but operators using non-Claude runtimes opened to a tab they had
+  // to skip past — universal MCP works for everyone as a starting
+  // point and the runtime-specific tabs are still one click away.
+  const initialTab: Tab = info?.universal_mcp_snippet
+    ? "mcp"
+    : "python";
   const [tab, setTab] = useState<Tab>(initialTab);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
@@ -108,6 +132,24 @@ export function ExternalConnectModal({ info, onClose }: Props) {
     'MOLECULE_WORKSPACE_TOKEN="<paste from create response>"',
     `MOLECULE_WORKSPACE_TOKEN="${info.auth_token}"`,
   );
+  // Hermes channel snippet uses MOLECULE_WORKSPACE_TOKEN (same env-var
+  // name as Universal MCP). Stamp the auth_token in so the operator's
+  // copy-paste is fully ready-to-run.
+  const filledHermes = info.hermes_channel_snippet?.replace(
+    'MOLECULE_WORKSPACE_TOKEN="<paste from create response>"',
+    `MOLECULE_WORKSPACE_TOKEN="${info.auth_token}"`,
+  );
+  // Codex + OpenClaw snippets carry the placeholder inside the
+  // generated config block (TOML / JSON respectively). Stamp the
+  // token in so the copy-paste is one less manual edit.
+  const filledCodex = info.codex_snippet?.replace(
+    'MOLECULE_WORKSPACE_TOKEN = "<paste from create response>"',
+    `MOLECULE_WORKSPACE_TOKEN = "${info.auth_token}"`,
+  );
+  const filledOpenClaw = info.openclaw_snippet?.replace(
+    'WORKSPACE_TOKEN="<paste from create response>"',
+    `WORKSPACE_TOKEN="${info.auth_token}"`,
+  );
 
   return (
     <Dialog.Root open onOpenChange={(o) => !o && onClose()}>
@@ -135,10 +177,18 @@ export function ExternalConnectModal({ info, onClose }: Props) {
               // SDK second (full register+heartbeat+inbound); Universal
               // MCP third (any MCP-aware runtime, outbound-only); curl
               // for one-shot register; Fields for raw values.
+              // Tab order: Universal MCP first (default, runtime-
+              // agnostic primitives), then runtime-specific channel/
+              // SDK tabs, then curl + Fields. Each runtime tab only
+              // appears when the platform supplies the snippet — no
+              // dead "tab missing snippet" UX.
               const tabs: Tab[] = [];
-              if (filledChannel) tabs.push("claude");
-              tabs.push("python");
               if (filledUniversalMcp) tabs.push("mcp");
+              tabs.push("python");
+              if (filledChannel) tabs.push("claude");
+              if (filledHermes) tabs.push("hermes");
+              if (filledCodex) tabs.push("codex");
+              if (filledOpenClaw) tabs.push("openclaw");
               tabs.push("curl", "fields");
               return tabs;
             })().map((t) => (
@@ -156,6 +206,12 @@ export function ExternalConnectModal({ info, onClose }: Props) {
               >
                 {t === "claude"
                   ? "Claude Code"
+                  : t === "hermes"
+                  ? "Hermes"
+                  : t === "codex"
+                  ? "Codex"
+                  : t === "openclaw"
+                  ? "OpenClaw"
                   : t === "python"
                   ? "Python SDK"
                   : t === "mcp"
@@ -203,6 +259,33 @@ export function ExternalConnectModal({ info, onClose }: Props) {
                 copyKey="mcp"
                 copied={copiedKey === "mcp"}
                 onCopy={() => copy(filledUniversalMcp, "mcp")}
+              />
+            )}
+            {tab === "hermes" && filledHermes && (
+              <SnippetBlock
+                value={filledHermes}
+                label="Hermes channel — bridges this workspace's A2A traffic into your hermes-agent session as platform messages (push parity with Claude Code). Long-poll based; no tunnel needed."
+                copyKey="hermes"
+                copied={copiedKey === "hermes"}
+                onCopy={() => copy(filledHermes, "hermes")}
+              />
+            )}
+            {tab === "codex" && filledCodex && (
+              <SnippetBlock
+                value={filledCodex}
+                label="Codex MCP config — wires the molecule MCP server into ~/.codex/config.toml. Outbound tools today; inbound A2A push needs the Python SDK tab paired in (codex's MCP runtime doesn't route arbitrary notifications/* yet)."
+                copyKey="codex"
+                copied={copiedKey === "codex"}
+                onCopy={() => copy(filledCodex, "codex")}
+              />
+            )}
+            {tab === "openclaw" && filledOpenClaw && (
+              <SnippetBlock
+                value={filledOpenClaw}
+                label="OpenClaw MCP config — wires the molecule MCP server via openclaw mcp set + starts the gateway on loopback. Outbound tools today; inbound A2A push on an external openclaw needs the Python SDK tab paired in (a sessions.steer bridge daemon is future work)."
+                copyKey="openclaw"
+                copied={copiedKey === "openclaw"}
+                onCopy={() => copy(filledOpenClaw, "openclaw")}
               />
             )}
             {tab === "fields" && (

--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -186,3 +186,169 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 `
+
+// externalHermesChannelTemplate — install snippet for operators whose
+// external agent IS a hermes-agent session. Routes the workspace's
+// A2A traffic into the running hermes gateway as platform messages
+// via the molecule-channel plugin.
+//
+// The plugin (Molecule-AI/hermes-channel-molecule) is a hermes
+// platform adapter that:
+//   1. Spawns ``python -m molecule_runtime.a2a_mcp_server`` as a
+//      stdio MCP subprocess (separate from any hermes-side MCP
+//      client connection).
+//   2. Long-polls ``wait_for_message`` on the platform's inbox.
+//   3. Dispatches each inbound activity into the hermes gateway as a
+//      MessageEvent — same code path Telegram/Discord use.
+//   4. Outbound replies route via ``send_message_to_user`` (canvas
+//      user) or ``delegate_task`` (peer agent) MCP tool calls.
+//
+// Result: hermes gets push parity with Claude Code / codex / openclaw —
+// canvas messages and peer A2A arrive as conversation turns mid-session,
+// not just at the start of a new ``hermes`` invocation.
+//
+// Plugin uses the upstream ``register_platform`` API shipped by
+// NousResearch/hermes-agent#17751 (merged 2026-04-30) and falls back
+// to the legacy ``register_platform_adapter`` shape on older forks —
+// same wheel installs cleanly on stock or patched hermes-agent.
+const externalHermesChannelTemplate = `# Hermes channel — bridges this workspace's A2A traffic into your
+# hermes-agent session. No tunnel/public URL needed (long-poll based,
+# same shape as the Claude Code channel).
+#
+# Prereq: a hermes-agent install on the target machine. Latest builds
+# (post #17751) ship the platform-plugin API natively; older ones are
+# also supported via the plugin's dual-mode fallback.
+#
+# 1. Install the runtime + plugin:
+pip install molecule-ai-workspace-runtime
+pip install 'git+https://github.com/Molecule-AI/hermes-channel-molecule.git'
+
+# 2. Export the workspace credentials:
+export MOLECULE_WORKSPACE_ID={{WORKSPACE_ID}}
+export MOLECULE_PLATFORM_URL={{PLATFORM_URL}}
+export MOLECULE_WORKSPACE_TOKEN="<paste from create response>"
+export MOLECULE_ORG_ID="<your org id>"
+
+# 3. Enable the platform in ~/.hermes/config.yaml. Add (or merge):
+cat >> ~/.hermes/config.yaml <<'EOF'
+gateway:
+  plugin_platforms:
+    molecule:
+      enabled: true
+EOF
+
+# 4. Restart the hermes gateway:
+hermes gateway --replace
+
+# Inbound canvas messages + peer A2A now arrive as MessageEvents —
+# same dispatch path Telegram/Discord/Slack use. The agent replies via
+# send_message_to_user / delegate_task MCP tool calls (already wired
+# by the plugin's molecule_runtime MCP subprocess).
+#
+# Source + issue tracker:
+# https://github.com/Molecule-AI/hermes-channel-molecule
+`
+
+// externalCodexTemplate — for operators whose external agent is a
+// codex CLI (@openai/codex) session. Wires the molecule_runtime A2A
+// MCP server into codex's config.toml so the agent can call
+// list_peers / delegate_task / send_message_to_user / commit_memory.
+//
+// Push parity caveat: codex's MCP client doesn't forward arbitrary
+// notifications/* from configured MCP servers (verified by reading
+// codex-rs/codex-mcp/src/connection_manager.rs in openai/codex). So
+// this snippet gives outbound tools but NOT mid-turn push from
+// inbound A2A. For full push parity on a codex external, the
+// equivalent of hermes-channel-molecule would be needed — a bridge
+// daemon that long-polls the platform inbox and calls codex's
+// turn/steer RPC. Tracked separately; this snippet is the
+// outbound-tool-only first cut.
+const externalCodexTemplate = `# Codex MCP config — outbound tool path. For operators whose external
+# agent is a codex CLI (@openai/codex) session.
+#
+# This wires the molecule platform's A2A MCP server into codex so
+# the agent can call list_peers / delegate_task / send_message_to_user
+# / commit_memory. Inbound A2A (canvas messages, peer-initiated tasks)
+# does NOT push into the running codex turn yet — codex's MCP runtime
+# doesn't route arbitrary notifications/* from configured MCP servers.
+# For inbound delivery into a codex session, pair with the Python SDK
+# tab for now.
+
+# 1. Install codex CLI + the workspace runtime wheel:
+npm install -g @openai/codex@^0.57
+pip install molecule-ai-workspace-runtime
+
+# 2. Add the molecule MCP server to codex's config. {{PLATFORM_URL}}
+# and {{WORKSPACE_ID}} are stamped server-side; paste the auth token
+# for MOLECULE_WORKSPACE_TOKEN before saving.
+mkdir -p ~/.codex
+cat >> ~/.codex/config.toml <<'EOF'
+[mcp_servers.molecule]
+command = "python3"
+args = ["-m", "molecule_runtime.a2a_mcp_server"]
+startup_timeout_sec = 30
+env_vars = ["MOLECULE_INBOUND_SECRET", "PYTHONPATH"]
+
+[mcp_servers.molecule.env]
+WORKSPACE_ID = "{{WORKSPACE_ID}}"
+PLATFORM_URL = "{{PLATFORM_URL}}"
+MOLECULE_WORKSPACE_TOKEN = "<paste from create response>"
+MOLECULE_ORG_ID = "<your org id>"
+EOF
+
+# 3. Run codex — the molecule tools are now available to the agent:
+codex
+`
+
+// externalOpenClawTemplate — for operators whose external agent is an
+// openclaw session. Wires the molecule MCP server via openclaw's
+// `mcp set` config + starts the openclaw gateway on loopback.
+//
+// Like the codex tab, this is outbound-only. Full push parity on an
+// external openclaw would need a sessions.steer bridge daemon (the
+// equivalent of hermes-channel-molecule for openclaw). Tracked
+// separately; outbound tools is the first cut.
+const externalOpenClawTemplate = `# OpenClaw MCP config — outbound tool path. For operators whose
+# external agent is an openclaw session.
+#
+# This wires the molecule platform's A2A MCP server into openclaw's
+# gateway so the agent can call list_peers / delegate_task /
+# send_message_to_user / commit_memory. Inbound A2A push into a
+# running openclaw run is not wired here yet — the platform-side
+# openclaw template (template-openclaw) implements the full
+# sessions.steer push path; an external setup would need the same
+# bridge daemon the template uses. For inbound delivery on an
+# external machine today, pair with the Python SDK tab.
+
+# 1. Install openclaw CLI + the workspace runtime wheel:
+npm install -g openclaw@latest
+pip install molecule-ai-workspace-runtime
+
+# 2. Onboard openclaw against your provider (sets up auth-profiles +
+# the workspace dir). Skip if already done on this host.
+openclaw onboard --non-interactive
+
+# 3. Wire the molecule MCP server. {{WORKSPACE_ID}} + {{PLATFORM_URL}}
+# are stamped server-side; paste the auth token before running.
+WORKSPACE_TOKEN="<paste from create response>"
+MOLECULE_ORG_ID="<your org id>"
+openclaw mcp set molecule "$(cat <<EOF
+{
+  "command": "python3",
+  "args": ["-m", "molecule_runtime.a2a_mcp_server"],
+  "env": {
+    "WORKSPACE_ID": "{{WORKSPACE_ID}}",
+    "PLATFORM_URL": "{{PLATFORM_URL}}",
+    "MOLECULE_WORKSPACE_TOKEN": "$WORKSPACE_TOKEN",
+    "MOLECULE_ORG_ID": "$MOLECULE_ORG_ID"
+  }
+}
+EOF
+)"
+
+# 4. Start the openclaw gateway (loopback-bound; no pairing required):
+openclaw gateway --dev --port 18789 --bind loopback &
+
+# 5. Run an agent turn — molecule tools are now available:
+openclaw agent --message "list my peers"
+`

--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -229,13 +229,19 @@ export MOLECULE_PLATFORM_URL={{PLATFORM_URL}}
 export MOLECULE_WORKSPACE_TOKEN="<paste from create response>"
 export MOLECULE_ORG_ID="<your org id>"
 
-# 3. Enable the platform in ~/.hermes/config.yaml. Add (or merge):
-cat >> ~/.hermes/config.yaml <<'EOF'
-gateway:
-  plugin_platforms:
-    molecule:
-      enabled: true
-EOF
+# 3. Edit ~/.hermes/config.yaml — under your existing top-level
+#    gateway: block, add a plugin_platforms entry:
+#
+#      gateway:
+#        # ...your existing gateway settings...
+#        plugin_platforms:
+#          molecule:
+#            enabled: true
+#
+#    If you don't yet have a gateway: block, create one with just
+#    that plugin_platforms entry. Don't append blindly — YAML
+#    rejects duplicate top-level keys, so a second gateway: block
+#    will silently break hermes config loading.
 
 # 4. Restart the hermes gateway:
 hermes gateway --replace
@@ -278,23 +284,29 @@ const externalCodexTemplate = `# Codex MCP config — outbound tool path. For op
 npm install -g @openai/codex@^0.57
 pip install molecule-ai-workspace-runtime
 
-# 2. Add the molecule MCP server to codex's config. {{PLATFORM_URL}}
-# and {{WORKSPACE_ID}} are stamped server-side; paste the auth token
-# for MOLECULE_WORKSPACE_TOKEN before saving.
-mkdir -p ~/.codex
-cat >> ~/.codex/config.toml <<'EOF'
-[mcp_servers.molecule]
-command = "python3"
-args = ["-m", "molecule_runtime.a2a_mcp_server"]
-startup_timeout_sec = 30
-env_vars = ["MOLECULE_INBOUND_SECRET", "PYTHONPATH"]
+# 2. Edit ~/.codex/config.toml and add the block below. {{PLATFORM_URL}}
+#    and {{WORKSPACE_ID}} are stamped server-side; paste your auth
+#    token for MOLECULE_WORKSPACE_TOKEN before saving.
+#
+#    Don't append blindly — TOML rejects duplicate
+#    [mcp_servers.molecule] tables, so re-running on an existing
+#    config will break codex parsing. If [mcp_servers.molecule]
+#    already exists (e.g. you set this up before), replace the
+#    existing block instead of appending.
 
-[mcp_servers.molecule.env]
-WORKSPACE_ID = "{{WORKSPACE_ID}}"
-PLATFORM_URL = "{{PLATFORM_URL}}"
-MOLECULE_WORKSPACE_TOKEN = "<paste from create response>"
-MOLECULE_ORG_ID = "<your org id>"
-EOF
+mkdir -p ~/.codex
+# (then open ~/.codex/config.toml in your editor and paste:)
+#
+# [mcp_servers.molecule]
+# command = "python3"
+# args = ["-m", "molecule_runtime.a2a_mcp_server"]
+# startup_timeout_sec = 30
+#
+# [mcp_servers.molecule.env]
+# WORKSPACE_ID = "{{WORKSPACE_ID}}"
+# PLATFORM_URL = "{{PLATFORM_URL}}"
+# MOLECULE_WORKSPACE_TOKEN = "<paste from create response>"
+# MOLECULE_ORG_ID = "<your org id>"
 
 # 3. Run codex — the molecule tools are now available to the agent:
 codex
@@ -324,9 +336,14 @@ const externalOpenClawTemplate = `# OpenClaw MCP config — outbound tool path. 
 npm install -g openclaw@latest
 pip install molecule-ai-workspace-runtime
 
-# 2. Onboard openclaw against your provider (sets up auth-profiles +
-# the workspace dir). Skip if already done on this host.
-openclaw onboard --non-interactive
+# 2. Onboard openclaw against your model provider (one-time setup).
+#    --non-interactive needs an explicit --provider + --model so it
+#    doesn't prompt; pick what matches your API key. Skip step 2 if
+#    you've already onboarded on this host.
+#
+#    openclaw onboard --non-interactive \
+#      --provider openai \
+#      --model gpt-5
 
 # 3. Wire the molecule MCP server. {{WORKSPACE_ID}} + {{PLATFORM_URL}}
 # are stamped server-side; paste the auth token before running.
@@ -346,8 +363,13 @@ openclaw mcp set molecule "$(cat <<EOF
 EOF
 )"
 
-# 4. Start the openclaw gateway (loopback-bound; no pairing required):
-openclaw gateway --dev --port 18789 --bind loopback &
+# 4. Start the openclaw gateway as a durable background process.
+#    A bare '&' dies when the terminal closes; nohup + log file keeps
+#    the gateway alive across logout. For systemd-managed hosts,
+#    register a unit instead.
+nohup openclaw gateway --dev --port 18789 --bind loopback \
+  > ~/.openclaw/gateway.log 2>&1 &
+disown
 
 # 5. Run an agent turn — molecule tools are now available:
 openclaw agent --message "list my peers"

--- a/workspace-server/internal/handlers/workspace.go
+++ b/workspace-server/internal/handlers/workspace.go
@@ -454,6 +454,41 @@ func (h *WorkspaceHandler) Create(c *gin.Context) {
 						"{{PLATFORM_URL}}", platformURL),
 					"{{WORKSPACE_ID}}", id,
 				),
+				// Hermes channel snippet — for operators whose external
+				// agent IS a hermes-agent session. Routes A2A traffic
+				// into the hermes gateway via the molecule-channel
+				// plugin (Molecule-AI/hermes-channel-molecule). Long-
+				// poll based (no tunnel) — same UX as the Claude Code
+				// channel tab. Gives hermes true push parity with the
+				// other runtime templates.
+				"hermes_channel_snippet": strings.ReplaceAll(
+					strings.ReplaceAll(externalHermesChannelTemplate,
+						"{{PLATFORM_URL}}", platformURL),
+					"{{WORKSPACE_ID}}", id,
+				),
+				// Codex MCP config snippet — for operators whose
+				// external agent is a codex CLI (@openai/codex)
+				// session. Wires the molecule MCP server into
+				// ~/.codex/config.toml. Outbound-tools-only today;
+				// codex's MCP client doesn't route arbitrary
+				// notifications/* so push parity needs a separate
+				// bridge daemon (future work).
+				"codex_snippet": strings.ReplaceAll(
+					strings.ReplaceAll(externalCodexTemplate,
+						"{{PLATFORM_URL}}", platformURL),
+					"{{WORKSPACE_ID}}", id,
+				),
+				// OpenClaw MCP config snippet — for operators whose
+				// external agent is an openclaw session. Wires the
+				// molecule MCP server via `openclaw mcp set` + starts
+				// the gateway on loopback. Outbound-tools-only today;
+				// full push parity needs a sessions.steer bridge
+				// daemon (future work).
+				"openclaw_snippet": strings.ReplaceAll(
+					strings.ReplaceAll(externalOpenClawTemplate,
+						"{{PLATFORM_URL}}", platformURL),
+					"{{WORKSPACE_ID}}", id,
+				),
 			}
 		}
 		c.JSON(http.StatusCreated, resp)


### PR DESCRIPTION
## Summary

External Connect modal previously had tabs for Python SDK / curl / Claude Code channel / Universal MCP. Operators using hermes / codex / openclaw as their external runtime had no copy-paste — they pieced together WORKSPACE_ID + PLATFORM_URL + auth_token into config files by reading docs.

Adds three runtime-specific snippets stamped server-side, gated on the platform supplying the field (older platform builds without it don't surface empty tabs).

## Hermes tab

Installs `molecule-ai-workspace-runtime` + the `hermes-channel-molecule` plugin, exports the 4 env vars, writes the `gateway.plugin_platforms.molecule` block into `~/.hermes/config.yaml`. Same long-poll-based push semantics the Claude Code channel tab delivers (push parity with the in-tree `template-hermes` adapter).

## Codex tab

Wires the molecule_runtime A2A MCP server into `~/.codex/config.toml` (`[mcp_servers.molecule]` block with env_vars passthrough + literal env values). **Outbound-tools-only today** — codex's MCP client doesn't route arbitrary `notifications/*` (verified by reading `codex-rs/codex-mcp/src/connection_manager.rs`); push parity on external codex would need a separate bridge daemon (future work). Snippet calls this out so operators know to pair with Python SDK if they need inbound delivery.

## OpenClaw tab

Installs openclaw + onboards, wires the molecule MCP server via `openclaw mcp set`, starts the gateway on loopback. Same outbound-tools-only caveat as codex. The in-tree `template-openclaw` adapter implements the full `sessions.steer` push path, but an external setup would need the same bridge daemon to translate platform inbox events into `sessions.steer` calls (future work).

## Default tab change

Pre-2026-05-03 the modal defaulted to Claude Code. Operators using non-Claude runtimes opened to a tab they had to skip past. Changed to Universal MCP — runtime-agnostic, works as a starting point for any operator. Runtime-specific tabs are still one click away.

## Tab order

Universal MCP → Python SDK → Claude Code → Hermes → Codex → OpenClaw → curl → Fields

## Test plan

- [x] `go build ./internal/handlers/...` clean
- [x] Canvas TypeScript clean (`tsc --noEmit`)
- [ ] Manual: provision a `runtime=external` workspace on staging, verify modal shows all 6 runtime tabs + Universal MCP opens by default + token auto-stamping works on each new tab
- [ ] Each new tab's copy-paste runs end-to-end against a real workspace (paste, follow steps, verify the runtime can call `list_peers` / receive A2A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)