### PR TITLE
a11y(canvas): Tooltip Esc-to-dismiss (WCAG 1.4.13)

### DIFF
--- a/canvas/src/components/Tooltip.tsx
+++ b/canvas/src/components/Tooltip.tsx
@@ -22,6 +22,24 @@ export function Tooltip({ text, children }: Props) {
 
   useEffect(() => () => clearTimeout(timerRef.current), []);
 
+  // WCAG 1.4.13 (Content on Hover or Focus) — Dismissible: a mechanism
+  // is available to dismiss the additional content WITHOUT moving
+  // pointer hover or keyboard focus. Esc dismisses while the trigger
+  // stays focused/hovered, so a screen-magnifier user can read what
+  // the tooltip was covering without losing their place.
+  useEffect(() => {
+    if (!show) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        clearTimeout(timerRef.current);
+        setShow(false);
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [show]);
+
   const enter = useCallback(() => {
     timerRef.current = setTimeout(() => {
       if (triggerRef.current) {


### PR DESCRIPTION
## Summary

WCAG 1.4.13 (Content on Hover or Focus) requires tooltip content to be **dismissible** without moving pointer hover or keyboard focus. Our Tooltip had no escape hatch — once a keyboard user tabbed onto a control with a tooltip, the tooltip stayed visible until they tabbed away.

This is a real problem for:
- Screen-magnifier users where the tooltip can cover content they need to read.
- Keyboard-only users who want to confirm what a control is, then keep working without losing their place.

## Fix

Add a window-level \`keydown\` listener (capture phase) that's active only while a tooltip is shown. Pressing **Esc** clears the tooltip without moving focus or breaking the hover state.

Capture phase so we beat any modal/dialog Esc handler that might also be listening — the tooltip belongs to the focused control, not the modal it sits inside.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [ ] Browser-verify: hover over any tooltip → press Esc → tooltip dismisses, mouse position unchanged
- [ ] Browser-verify: Tab onto a tooltip-decorated button → press Esc → tooltip dismisses, focus stays on button

🤖 Generated with [Claude Code](https://claude.com/claude-code)