### PR TITLE
canvas/Toaster: Esc dismiss + focus ring + bigger touch target

### DIFF
--- a/canvas/src/components/Toaster.tsx
+++ b/canvas/src/components/Toaster.tsx
@@ -38,6 +38,18 @@ export function Toaster() {
     };
   }, []);
 
+  // Esc dismisses the newest toast — keyboard parity with the × button.
+  // Errors never auto-expire, so without this a keyboard-only user has to
+  // tab through the entire app to reach the dismiss button on a stuck error.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      setToasts((prev) => (prev.length === 0 ? prev : prev.slice(0, -1)));
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   const toastCls = (type: Toast["type"]) =>
     `flex items-center gap-2 pl-4 pr-2 py-2.5 rounded-xl shadow-2xl shadow-black/40 text-sm backdrop-blur-md animate-in slide-in-from-bottom duration-200 ${
       type === "success"
@@ -46,6 +58,17 @@ export function Toaster() {
         ? "bg-red-950/90 border border-red-700/40 text-red-200"
         : "bg-surface-sunken/90 border border-line/40 text-ink"
     }`;
+
+  // Success/error toasts are intentionally dark in both themes (high-vis).
+  // Info uses the semantic surface that flips with theme — so the dismiss
+  // button needs a tint that stays visible on a light bg in light mode.
+  const dismissCls = (type: Toast["type"]) => {
+    const base =
+      "ml-1 w-7 h-7 inline-flex items-center justify-center text-base leading-none rounded transition-colors opacity-70 hover:opacity-100 focus-visible:opacity-100 focus:outline-none focus-visible:ring-2 shrink-0";
+    return type === "info"
+      ? `${base} hover:bg-ink/10 focus-visible:ring-accent/60`
+      : `${base} hover:bg-white/15 focus-visible:ring-white/70`;
+  };
 
   const pos =
     "fixed bottom-16 left-1/2 -translate-x-1/2 z-[80] flex flex-col gap-2 items-center";
@@ -66,7 +89,7 @@ export function Toaster() {
                 type="button"
                 onClick={() => dismiss(toast.id)}
                 aria-label="Dismiss notification"
-                className="ml-1 p-1 rounded hover:bg-surface-card/50 transition-colors opacity-70 hover:opacity-100 shrink-0"
+                className={dismissCls(toast.type)}
               >
                 ×
               </button>
@@ -94,7 +117,7 @@ export function Toaster() {
                 type="button"
                 onClick={() => dismiss(toast.id)}
                 aria-label="Dismiss notification"
-                className="ml-1 p-1 rounded hover:bg-surface-card/50 transition-colors opacity-70 hover:opacity-100 shrink-0"
+                className={dismissCls(toast.type)}
               >
                 ×
               </button>

--- a/canvas/src/components/__tests__/Toaster.test.tsx
+++ b/canvas/src/components/__tests__/Toaster.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
+import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
+import { Toaster, showToast } from "../Toaster";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe("Toaster keyboard a11y", () => {
+  it("Esc dismisses the most recent toast", () => {
+    render(<Toaster />);
+    act(() => {
+      showToast("first", "info");
+      showToast("second", "info");
+    });
+    expect(screen.getByText("first")).toBeTruthy();
+    expect(screen.getByText("second")).toBeTruthy();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(screen.queryByText("second")).toBeNull();
+    expect(screen.getByText("first")).toBeTruthy();
+  });
+
+  it("Esc dismisses persistent error toasts", () => {
+    render(<Toaster />);
+    act(() => {
+      showToast("boom", "error");
+    });
+    expect(screen.getByText("boom")).toBeTruthy();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    expect(screen.queryByText("boom")).toBeNull();
+  });
+
+  it("Esc with no toasts is a no-op", () => {
+    render(<Toaster />);
+    act(() => {
+      fireEvent.keyDown(window, { key: "Escape" });
+    });
+    // no throw, nothing rendered
+    expect(screen.queryAllByRole("button", { name: "Dismiss notification" })).toHaveLength(0);
+  });
+
+  it("dismiss button has accessible label and is keyboard reachable", () => {
+    render(<Toaster />);
+    act(() => {
+      showToast("hi", "info");
+    });
+    const btn = screen.getByRole("button", { name: "Dismiss notification" });
+    expect(btn).toBeTruthy();
+    // Native <button> defaults to keyboard-focusable; explicit assertion guards
+    // against a future regression where someone adds tabindex=-1.
+    expect(btn.getAttribute("tabindex")).not.toBe("-1");
+  });
+
+  it("dismiss button click removes that specific toast", () => {
+    render(<Toaster />);
+    act(() => {
+      showToast("a", "info");
+      showToast("b", "info");
+    });
+    const buttons = screen.getAllByRole("button", { name: "Dismiss notification" });
+    expect(buttons).toHaveLength(2);
+
+    // Click the first dismiss → "a" goes away, "b" stays
+    act(() => {
+      fireEvent.click(buttons[0]);
+    });
+    expect(screen.queryByText("a")).toBeNull();
+    expect(screen.getByText("b")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Three small a11y fixes for the global toast surface (canvas).

- **Esc dismisses the newest toast.** Errors never auto-expire, so without this a keyboard-only user had to tab through the entire app to reach the × button on a stuck error toast.
- **Dismiss button gets a focus-visible ring + theme-aware tint.** The previous \`opacity-70 hover:opacity-100\` gave no visible focus indicator (WCAG 2.4.7). Info toasts flip with theme, so info gets an accent ring, while success/error (always dark) get a white ring.
- **Touch target bumps** from \`p-1\` (~24×24) to \`w-7 h-7\` (28×28) toward WCAG 2.5.5's 44×44 AAA ideal.

## Test plan

- [x] 5 new vitest cases (Esc on info, Esc on error, no-op on empty queue, accessible label, per-toast click)
- [x] Full canvas suite: 1219 tests pass
- [x] \`tsc --noEmit\` clean
- [ ] Browser-verify Esc on stuck error in light + dark mode after deploy