### PR TITLE
test(e2e): canary classifies provider-quota 429 as operator-action, not platform regression

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -517,6 +517,7 @@ fi
 #   "Encrypted content is not supported" → hermes codex_responses API misroute (#14)
 #   "Unknown provider"               → bridge misconfigured PROVIDER= (regression of #13 fix)
 #   "hermes-agent unreachable"       → gateway process died
+#   "exceeded your current quota"    → MOLECULE_STAGING_OPENAI_KEY billing (NOT a platform regression — #2578)
 #
 # Fail LOUD with the specific pattern so CI log + alert channel makes the
 # regression unambiguous.
@@ -541,6 +542,16 @@ fi
 # "error|exception" catch-all below, so they'd slip through.
 if echo "$AGENT_TEXT" | grep -qF "Invalid API key"; then
   fail "A2A — REGRESSION: tenant auth chain returned 'Invalid API key'. Likely CP boot-event 401 race (CP #238) or stale OPENAI_API_KEY in the runtime env. Raw: $AGENT_TEXT"
+fi
+# Provider quota exhausted — distinguish from a platform regression so
+# the canary alert names the operator action directly instead of falling
+# through to the generic "error-shaped response" message. Steps 0-7 having
+# passed means the platform itself is healthy (CP up, tenant provisioned,
+# workspace online, A2A delivery end-to-end). When the agent comes back
+# with a provider-side 429, that is a billing event on the configured
+# OpenAI key, not a platform regression. Tracked in #2578.
+if echo "$AGENT_TEXT" | grep -qiE "exceeded your current quota|insufficient_quota"; then
+  fail "A2A — PROVIDER QUOTA EXHAUSTED (NOT a platform regression). Operator action: top up MOLECULE_STAGING_OPENAI_KEY billing or rotate to a higher-quota org at Settings → Secrets and Variables → Actions. Tracked in #2578. Raw: $AGENT_TEXT"
 fi
 # Generic catch-all — falls through if none of the known regressions hit.
 if echo "$AGENT_TEXT" | grep -qiE "error|exception"; then


### PR DESCRIPTION
## Summary

The staging canary's A2A step has a ladder of specific regression classifiers (\`hermes-agent error 401\`, \`model_not_found\`, \`Encrypted content is not supported\`, \`Unknown provider\`, \`hermes-agent unreachable\`, \`Invalid API key\`) followed by a generic \`error|exception\` catch-all. **Provider-side OpenAI 429 quota errors fall through to the catch-all** — the canary issue body and CI log just say \"A2A returned an error-shaped response,\" which is true but obscures the actual operator action.

This adds a 7th classifier above the catch-all that matches \`exceeded your current quota\` and \`insufficient_quota\` (both terms appear in OpenAI's quota-exhaustion 429). When matched, the failure names the operator action directly:

> A2A — PROVIDER QUOTA EXHAUSTED (NOT a platform regression). Operator action: top up \`MOLECULE_STAGING_OPENAI_KEY\` billing or rotate to a higher-quota org at Settings → Secrets and Variables → Actions. Tracked in #2578.

## Why this is correct, not \"lowering the bar\"

- Steps 0–7 cover **full platform health**: CP reachable, tenant provisioned, DNS+TLS up, workspace booted, A2A delivered end-to-end.
- Reaching step 8 with a provider-side 429 means the platform **is** healthy — the failure is downstream of every platform invariant.
- The canary still **exits 1** (CI stays red, threshold-3 alarm still fires); **only the failure message changes**.
- All 6 existing specific classifiers run BEFORE the new one, so any real platform regression is still caught with its specific message.

## Verification

- Regex tested against the actual 429 string from canary run 25291517608:
  > \`API call failed after 3 retries: HTTP 429: You exceeded your current quota, please check your plan and billing details.\`
  → matches ✅
- Negative tests: \`PONG\` (benign reply), \`hermes-agent unreachable\` (a real platform regression that has its own classifier) → no match ✅
- \`bash -n\` syntax check clean
- \`shellcheck -S error\` clean

## Tracking

- #2593 — \"🔴 Canary failing: staging SaaS smoke\" (the alert)
- #2578 — \"Synth E2E (staging): MOLECULE_STAGING_OPENAI_KEY account is over quota — needs billing top-up\" (root cause)

Both stay open until the operator tops up the key — this PR doesn't close either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)