### PR TITLE
ci(synth-e2e): move cron off :00 to dodge GH scheduler drops (closes #273)

### DIFF
--- a/.github/workflows/continuous-synth-e2e.yml
+++ b/.github/workflows/continuous-synth-e2e.yml
@@ -32,10 +32,20 @@ name: Continuous synthetic E2E (staging)
 
 on:
   schedule:
-    # Every 20 minutes, on the :00 :20 :40. Offsets the existing :15
-    # sweep-cf-orphans and :45 sweep-cf-tunnels so the three
-    # operations don't all hit Cloudflare/AWS at the same minute.
-    - cron: '0,20,40 * * * *'
+    # Every 20 minutes, on :10 :30 :50. Two constraints:
+    #   1. Stay off the top-of-hour. GitHub Actions scheduler drops
+    #      :00 firings under high load (own docs:
+    #      https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule).
+    #      Empirical 2026-05-03: cron was '0,20,40 * * * *' but actual
+    #      firings landed at :08, :03, :01, :03 with :20 + :40 silently
+    #      dropped — only the :00-region run survived. Detection
+    #      latency degraded from claimed 20 min to actual ~60 min.
+    #      :10/:30/:50 sit far enough from :00 that GH-load skips
+    #      stop dropping us.
+    #   2. Avoid colliding with the existing :15 sweep-cf-orphans
+    #      and :45 sweep-cf-tunnels — both hit the CF API and we
+    #      don't want to fight for rate-limit tokens.
+    - cron: '10,30,50 * * * *'
   workflow_dispatch:
     inputs:
       runtime:


### PR DESCRIPTION
## Summary

GitHub Actions scheduler de-prioritises :00 cron firings during high load. Empirical evidence on 2026-05-03:

| Scheduled | Actual | Status |
|-----------|--------|--------|
| 20:00 | 20:08 | landed (8min late) |
| 20:20 | — | DROPPED |
| 20:40 | — | DROPPED |
| 21:00 | 21:03 | landed |
| 21:20 | — | DROPPED |
| 21:40 | — | DROPPED |
| 22:00 | 22:01 | landed |
| 22:20 | — | DROPPED |
| 22:40 | — | DROPPED |
| 23:00 | 23:03 | landed |
| 23:20 | — | DROPPED |
| 23:40 | — | DROPPED |
| 00:00 | (still pending at 00:01) | DROPPED |

Pattern: only one firing per hour (the :00-region one) actually runs. Detection latency on regressions degraded from the claimed **20 min** to actual **~60 min worst case**.

## Fix

Move cron from `0,20,40 * * * *` → `10,30,50 * * * *`. Same 20-min cadence; just shifts phase by 10 min so we sit clear of the top-of-hour load peak. Also keeps the original 5-min separation from sweep-cf-orphans (:15) and sweep-cf-tunnels (:45) that the previous comment justified.

## Test plan

- [x] YAML lint clean (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Cron expression parses to every-20-min cadence
- [ ] After merge: confirm next 3 firings land at :10/:30/:50 ± a few min (vs current pattern of dropping 2-of-3)

## Closes

#273

🤖 Generated with [Claude Code](https://claude.com/claude-code)