### PR TITLE
canvas/{Schedule,Channels}Tab: fix accent-LIGHTER hover + Cancel no-op

### DIFF
--- a/canvas/src/components/tabs/ChannelsTab.tsx
+++ b/canvas/src/components/tabs/ChannelsTab.tsx
@@ -365,8 +365,12 @@ export function ChannelsTab({ workspaceId }: Props) {
             <p className="text-[10px] text-bad">{formError}</p>
           )}
           <button
+            type="button"
             onClick={handleCreate}
-            className="w-full text-xs py-1.5 rounded bg-accent-strong hover:bg-accent text-white transition"
+            // Was bg-accent-strong hover:bg-accent — accent is the
+            // LIGHTER variant; same AA contrast trap fixed in
+            // ScheduleTab/MemoryTab/OnboardingWizard.
+            className="w-full text-xs py-1.5 rounded bg-accent hover:bg-accent-strong text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
           >
             Connect Channel
           </button>

--- a/canvas/src/components/tabs/ScheduleTab.tsx
+++ b/canvas/src/components/tabs/ScheduleTab.tsx
@@ -269,15 +269,23 @@ export function ScheduleTab({ workspaceId }: Props) {
           {error && <div className="text-[10px] text-bad">{error}</div>}
           <div className="flex gap-2">
             <button
+              type="button"
               onClick={handleSubmit}
               disabled={!formCron || !formPrompt}
-              className="text-[11px] px-3 py-1 bg-accent-strong text-white rounded hover:bg-accent disabled:opacity-40 transition-colors"
+              // Was bg-accent-strong hover:bg-accent — accent is the
+              // LIGHTER variant, so this hovered lighter on white text
+              // and dropped contrast below AA. Same trap fixed in
+              // OnboardingWizard, ConfirmDialog, ApprovalBanner.
+              className="text-[11px] px-3 py-1 bg-accent text-white rounded hover:bg-accent-strong disabled:opacity-40 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/60 focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
             >
               {editId ? "Update" : "Create"}
             </button>
             <button
+              type="button"
               onClick={resetForm}
-              className="text-[11px] px-3 py-1 bg-surface-card text-ink-mid rounded hover:bg-surface-card transition-colors"
+              // Was hover:bg-surface-card on top of bg-surface-card —
+              // silent no-op hover. Lift to surface-elevated.
+              className="text-[11px] px-3 py-1 bg-surface-card text-ink-mid rounded hover:bg-surface-elevated hover:text-ink transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/40 focus-visible:ring-offset-1 focus-visible:ring-offset-surface"
             >
               Cancel
             </button>


### PR DESCRIPTION
## Summary

Three button fixes — same AA contrast trap I've fixed on OnboardingWizard/MemoryTab/ConfirmDialog/ApprovalBanner.

**ScheduleTab** (Create/Update):
- \`bg-accent-strong hover:bg-accent\` (accent is LIGHTER → AA drop on white text) → \`bg-accent hover:bg-accent-strong\`
- Cancel: \`bg-surface-card hover:bg-surface-card\` no-op → \`hover:bg-surface-elevated\`

**ChannelsTab** (Connect Channel):
- Same accent-LIGHTER trap → flipped.

All three buttons get focus-visible:ring-accent.

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Full canvas suite: 1222/1222
- [ ] Create/Update + Cancel + Connect Channel — visibly darker hover, no contrast drop, accent ring on Tab focus