### PR TITLE
e2e: bump A2A timeout from 30s → 90s for cold MiniMax workspace

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -534,7 +534,17 @@ print(json.dumps({
     }
 }))
 ")
+# Override CURL_COMMON's --max-time 30 for THIS call only. Each canary
+# creates a fresh org → workspace, so the A2A POST hits a cold model:
+# claude-code adapter starts its event loop, opens TLS to the LLM
+# endpoint, ships the first prompt, waits for first token. With MiniMax
+# (which is the canary default since #2710) cold-call latency
+# routinely exceeds 30s on the first request after workspace boot.
+# 90s gives ~3x headroom over observed cold-call P95 (~25-30s).
+# Subsequent A2A turns hit the same workspace and are sub-second, so
+# this only widens the window for step 8/11 of the canary's first turn.
 A2A_RESP=$(tenant_call POST "/workspaces/$PARENT_ID/a2a" \
+  --max-time 90 \
   -H "Content-Type: application/json" \
   -d "$A2A_PAYLOAD")
 AGENT_TEXT=$(echo "$A2A_RESP" | python3 -c "


### PR DESCRIPTION
## Summary

After the MiniMax repo secret landed at 2026-05-04 08:37Z (final unblock for the canary chain shipped in #2710 + #2714), the next dispatched canary (run 25309323698) cleared every previous failure point but timed out at step 8/11 with:

\`curl: (28) Operation timed out after 30002 milliseconds with 0 bytes received\`

## Root cause

The canary creates a fresh org per run → every A2A POST hits a cold workspace + cold MiniMax endpoint. Cold-call P95 lands ~25-30s on \`MiniMax-M2.7-highspeed\`; the 30s \`CURL_COMMON --max-time\` is right on the edge.

## Fix

Override \`--max-time\` for the canary's A2A POST only → 90s (3x headroom). Subsequent A2A turns to the same workspace are sub-second, so this only widens step 8/11 of the canary's first turn. Other curls (provision, register, terminal, peers, teardown) keep the shared 30s timeout where 30s is right.

## Test plan

- [x] Shell syntax validated
- [x] Verified the actual failure mode in run 25309323698
- [ ] After merge: dispatch canary, expect green within ~10min

## Refs

- #2710 — canary migration to claude-code+MiniMax
- #2714 — direct-Anthropic third path
- #2578 — original OpenAI quota issue (resolved by MiniMax migration + secret-set 08:37Z)

🤖 Generated with [Claude Code](https://claude.com/claude-code)