### PR TITLE
ci(canary): bump synth timeout 12→20 min to absorb apt tail latency

### DIFF
--- a/.github/workflows/continuous-synth-e2e.yml
+++ b/.github/workflows/continuous-synth-e2e.yml
@@ -93,7 +93,18 @@ jobs:
   synth:
     name: Synthetic E2E against staging
     runs-on: ubuntu-latest
-    timeout-minutes: 12
+    # Bumped from 12 → 20 (2026-05-04). Tenant user-data install phase
+    # (apt-get update + install docker.io/jq/awscli/caddy + snap install
+    # ssm-agent) runs from raw Ubuntu on every boot — none of it is
+    # pre-baked into the tenant AMI. Empirical fetch_secrets/ok timing
+    # across today's canaries: 51s → 82s → 143s → 625s. apt-mirror tail
+    # latency drives the boot-to-fetch_secrets phase from ~1min to >10min.
+    # A 12min budget leaves only ~2min for the workspace (which needs
+    # ~3.5min for claude-code cold boot) on slow-apt days, blowing the
+    # budget. 20min absorbs the worst tenant tail so the workspace probe
+    # gets the full ~7min it needs even on a slow apt day. Real fix:
+    # pre-bake caddy + ssm-agent into the tenant AMI (controlplane#TBD).
+    timeout-minutes: 20
     env:
       # claude-code default: cold-start ~5 min (comparable to langgraph),
       # but uses MiniMax-M2.7-highspeed via the template's third-party-


### PR DESCRIPTION
## Summary

- 4 canaries cancelled today by the 12-min job timeout despite the underlying tenant boot completing — boot events all reach `boot_script_finished/ok`. Budget was structurally too tight whenever apt-mirror tail latency hit.
- Bump `timeout-minutes: 12` → `20` so the workspace gets its ~7-min budget even on the worst observed tenant boot (~11 min).

## Root cause data

Empirical `fetch_secrets/ok` (= end of install_apt_base + install_awscli + install_caddy + start_docker + install_ssm_agent) across today's canaries (same EC2_AMI, same t3.small):

| Canary | fetch_secrets/ok |
|---|---|
| debug-mm-1777888039 (09:47Z) | 51s |
| 25319625186 (12:42Z) | 82s |
| 25320942822 (13:11Z) | 143s |
| 25322499952 (13:43Z) | 625s |

Variance is apt-mirror tail latency. None of caddy / ssm-agent / awscli is pre-baked into the tenant AMI (EC2_AMI=ami-0ea3c35c5c3284d82, raw Jammy 22.04) — packer/install-base.sh bakes the **workspace** thin AMI only.

## Real fix (follow-up)

Filing controlplane#TBD: bake caddy + ssm-agent (and the apt-installs) into the tenant AMI so the boot phase is fast-paths on cached pkgs.

## Test plan

- [x] yaml-validate the workflow
- [ ] Re-dispatch canary after merge; confirm tenant boot + workspace probe both complete inside 20-min budget on a slow-apt day