### PR TITLE
fix(harness): stub platform_auth with *args lambdas (#2743 fallout)

### DIFF
--- a/tests/harness/replays/peer-discovery-404.sh
+++ b/tests/harness/replays/peer-discovery-404.sh
@@ -75,9 +75,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Stub platform_auth so a2a_client imports cleanly without requiring a
 # real workspace token file. The helper's auth_headers() only matters
 # when going through the network; we're feeding it a mock response.
+#
+# Both stubs accept *args, **kwargs because the multi-workspace work
+# (#2739, #2743) added optional ``workspace_id`` parameters to
+# ``auth_headers`` and made ``self_source_headers`` 1-arg-required.
+# The stubs need to accept whatever the helpers pass without caring.
 _pa = types.ModuleType("platform_auth")
-_pa.auth_headers = lambda: {}
-_pa.self_source_headers = lambda: {}
+_pa.auth_headers = lambda *a, **kw: {}
+_pa.self_source_headers = lambda *a, **kw: {}
 sys.modules.setdefault("platform_auth", _pa)
 
 sys.path.insert(0, sys.argv[1])


### PR DESCRIPTION
## Summary

Unblocks the auto-promote staging→main PR (#2737) by fixing the harness regression PR #2743 (multi-workspace MCP PR-2) exposed.

PR #2743 made \`auth_headers\` accept an optional \`workspace_id\` arg. The \`peer-discovery-404\` harness replay stubbed \`platform_auth.auth_headers\` with a 0-arg lambda, so the helper call inside the replay raised \`TypeError: <lambda>() takes 0 positional arguments but 1 was given\`.

Both stubs now use \`*args, **kwargs\` so they accept any call shape.

## Test plan

- [x] \`bash -n peer-discovery-404.sh\` clean
- [ ] CI replay green: \"PASS: peer-discovery (a) wire returns 404, (b) helper produces actionable diagnostic\"
- [ ] PR #2737 \`Harness Replays\` check turns SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)