### PR TITLE
fix(synth-e2e): correct curl status-code parse in 7c gate

### DIFF
--- a/tests/e2e/test_staging_full_saas.sh
+++ b/tests/e2e/test_staging_full_saas.sh
@@ -530,13 +530,22 @@ runtime: ${RUNTIME}
 "
 for wid in $WS_TO_CHECK; do
   PUT_BODY=$(python3 -c "import json,sys; print(json.dumps({'content': sys.stdin.read()}))" <<< "$CONFIG_PAYLOAD")
-  PUT_RESP=$(tenant_call PUT "/workspaces/$wid/files/config.yaml" \
+  # Capture body to a tempfile so curl's -w '%{http_code}' is the only
+  # thing on stdout. The first version used `-w '\n%{http_code}\n'` and
+  # parsed via `tail -n 2 | head -n 1`, which broke because bash $(...)
+  # strips the trailing newline → only 2 lines remain in the captured
+  # value → head -n 1 returned the body, not the status code. Caught
+  # post-merge by E2E Staging SaaS at 22:06 UTC: a 200-with-body got
+  # misreported as "PUT returned <body>".
+  PUT_TMP=$(mktemp -t synth_put.XXXXXX)
+  PUT_CODE=$(tenant_call PUT "/workspaces/$wid/files/config.yaml" \
     -H "Content-Type: application/json" \
     -d "$PUT_BODY" \
-    -w $'\n%{http_code}\n' \
-    2>/dev/null || printf '\n500\n')
-  PUT_CODE=$(echo "$PUT_RESP" | tail -n 2 | head -n 1)
-  PUT_BODY_OUT=$(echo "$PUT_RESP" | sed '$d' | sed '$d')
+    -o "$PUT_TMP" \
+    -w '%{http_code}' \
+    2>/dev/null || echo "000")
+  PUT_BODY_OUT=$(cat "$PUT_TMP" 2>/dev/null || echo "")
+  rm -f "$PUT_TMP"
   if [ "$PUT_CODE" != "200" ] && [ "$PUT_CODE" != "204" ]; then
     fail "Workspace $wid Files API PUT config.yaml returned $PUT_CODE: $PUT_BODY_OUT — likely a path-map or permission regression in workspace-server template_files_eic.go"
   fi


### PR DESCRIPTION
Hotfix for #2773.

## What broke

The 7c gate captured curl output with \`-w '\n%{http_code}\n'\` and parsed via \`tail -n 2 | head -n 1\`. \`bash \$(...)\` strips the trailing newline, leaving only 2 lines:
\`\`\`
line 1: <response body>
line 2: <status code>
\`\`\`
\`tail -n 2 | head -n 1\` returned line 1 (the body), not the status code. The gate misreported 200-with-JSON-body responses (\`{"path":"config.yaml","status":"saved"}\`) as \"PUT returned <body>\" and failed E2E Staging SaaS at 22:06 UTC.

## Fix

Write body to a tempfile via \`-o "\$PUT_TMP"\` and use \`-w '%{http_code}'\` as the sole stdout. Status code is unambiguously the captured value; body is read separately from the tempfile.

## Verification

- \`bash -n\` clean
- shellcheck clean on the modified block
- Next continuous-synth-e2e firing exercises the corrected gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)