### PR TITLE
fix(workflows): preserve curl stderr in 8 status-capture sites (PR #2810 follow-up)

### DIFF
--- a/.github/workflows/canary-staging.yml
+++ b/.github/workflows/canary-staging.yml
@@ -302,7 +302,7 @@ jobs:
               -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
               -H "Authorization: Bearer $ADMIN_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "{\"confirm\":\"$slug\"}" >/tmp/canary-cleanup.code 2>/dev/null
+              -d "{\"confirm\":\"$slug\"}" >/tmp/canary-cleanup.code
             set -e
             code=$(cat /tmp/canary-cleanup.code 2>/dev/null || echo "000")
             if [ "$code" = "200" ] || [ "$code" = "204" ]; then

--- a/.github/workflows/e2e-staging-canvas.yml
+++ b/.github/workflows/e2e-staging-canvas.yml
@@ -199,7 +199,7 @@ jobs:
             -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
             -H "Authorization: Bearer $ADMIN_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"confirm\":\"$slug\"}" >/tmp/canvas-cleanup.code 2>/dev/null
+            -d "{\"confirm\":\"$slug\"}" >/tmp/canvas-cleanup.code
           set -e
           code=$(cat /tmp/canvas-cleanup.code 2>/dev/null || echo "000")
           if [ "$code" = "200" ] || [ "$code" = "204" ]; then

--- a/.github/workflows/e2e-staging-external.yml
+++ b/.github/workflows/e2e-staging-external.yml
@@ -166,7 +166,7 @@ jobs:
                 -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
                 -H "Authorization: Bearer $ADMIN_TOKEN" \
                 -H "Content-Type: application/json" \
-                -d "{\"confirm\":\"$slug\"}" >/tmp/external-cleanup.code 2>/dev/null
+                -d "{\"confirm\":\"$slug\"}" >/tmp/external-cleanup.code
               set -e
               code=$(cat /tmp/external-cleanup.code 2>/dev/null || echo "000")
               if [ "$code" = "200" ] || [ "$code" = "204" ]; then

--- a/.github/workflows/e2e-staging-saas.yml
+++ b/.github/workflows/e2e-staging-saas.yml
@@ -231,7 +231,7 @@ jobs:
               -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
               -H "Authorization: Bearer $ADMIN_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "{\"confirm\":\"$slug\"}" >/tmp/saas-cleanup.code 2>/dev/null
+              -d "{\"confirm\":\"$slug\"}" >/tmp/saas-cleanup.code
             set -e
             code=$(cat /tmp/saas-cleanup.code 2>/dev/null || echo "000")
             if [ "$code" = "200" ] || [ "$code" = "204" ]; then

--- a/.github/workflows/e2e-staging-sanity.yml
+++ b/.github/workflows/e2e-staging-sanity.yml
@@ -155,7 +155,7 @@ jobs:
               -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
               -H "Authorization: Bearer $ADMIN_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "{\"confirm\":\"$slug\"}" >/tmp/sanity-cleanup.code 2>/dev/null
+              -d "{\"confirm\":\"$slug\"}" >/tmp/sanity-cleanup.code
             set -e
             code=$(cat /tmp/sanity-cleanup.code 2>/dev/null || echo "000")
             if [ "$code" = "200" ] || [ "$code" = "204" ]; then

--- a/.github/workflows/redeploy-tenants-on-main.yml
+++ b/.github/workflows/redeploy-tenants-on-main.yml
@@ -200,8 +200,11 @@ jobs:
             -H "Authorization: Bearer $CP_ADMIN_API_TOKEN" \
             -H "Content-Type: application/json" \
             -X POST "$CP_URL/cp/admin/tenants/redeploy-fleet" \
-            -d "$BODY" >"$HTTP_CODE_FILE" 2>/dev/null
+            -d "$BODY" >"$HTTP_CODE_FILE"
           set -e
+          # Stderr from curl (e.g. dial errors with -sS) goes to the runner
+          # log so operators can see WHY a connection failed. Stdout is
+          # captured to $HTTP_CODE_FILE because that's where -w writes.
           HTTP_CODE=$(cat "$HTTP_CODE_FILE" 2>/dev/null || echo "000")
           [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
 

--- a/.github/workflows/redeploy-tenants-on-staging.yml
+++ b/.github/workflows/redeploy-tenants-on-staging.yml
@@ -160,8 +160,10 @@ jobs:
             -H "Authorization: Bearer $CP_STAGING_ADMIN_API_TOKEN" \
             -H "Content-Type: application/json" \
             -X POST "$CP_URL/cp/admin/tenants/redeploy-fleet" \
-            -d "$BODY" >"$HTTP_CODE_FILE" 2>/dev/null
+            -d "$BODY" >"$HTTP_CODE_FILE"
           set -e
+          # Stderr from curl (-sS shows dial errors etc.) goes to the
+          # runner log so operators can see WHY a connection failed.
           HTTP_CODE=$(cat "$HTTP_CODE_FILE" 2>/dev/null || echo "000")
           [ -z "$HTTP_CODE" ] && HTTP_CODE="000"
 

--- a/.github/workflows/sweep-stale-e2e-orgs.yml
+++ b/.github/workflows/sweep-stale-e2e-orgs.yml
@@ -167,8 +167,9 @@ jobs:
               -X DELETE "$MOLECULE_CP_URL/cp/admin/tenants/$slug" \
               -H "Authorization: Bearer $ADMIN_TOKEN" \
               -H "Content-Type: application/json" \
-              -d "{\"confirm\":\"$slug\"}" >/tmp/del_code 2>/dev/null
+              -d "{\"confirm\":\"$slug\"}" >/tmp/del_code
             set -e
+            # Stderr from curl (-sS shows dial errors etc.) goes to runner log.
             http_code=$(cat /tmp/del_code 2>/dev/null || echo "000")
             if [ "$http_code" = "200" ] || [ "$http_code" = "204" ]; then
               deleted=$((deleted+1))


### PR DESCRIPTION
## Self-review caught a regression
PR #2810 added \`2>/dev/null\` to every curl invocation, suppressing stderr. The original \`|| echo \"000\"\` shape only swallowed exit codes — stderr (curl's \`-sS\`-shown dial errors, timeouts, DNS failures) still went to the runner log so operators could see WHY a connection failed.

After #2810 the next deploy failure would log only the bare HTTP code with no context — exactly the diagnostic loss that makes outages take longer to triage.

## Fix
Drop \`2>/dev/null\` from each curl line (keep it on the \`cat\` fallback, which legitimately suppresses "no such file" when curl crashed before -w ran). The \`>tempfile\` redirect alone captures curl's stdout (where -w writes) without touching stderr.

## Files (same 8 as #2810)
\`redeploy-tenants-on-{main,staging}\`, \`sweep-stale-e2e-orgs\`, \`e2e-staging-{sanity,saas,external,canvas}\`, \`canary-staging\`.

## Verified
- All 8 still pass the \`lint-curl-status-capture\` gate from #2810
- YAML still valid
- Self-caught during /code-review-and-quality on PR #2810

8 lines changed (one per file), +6 comment lines explaining stderr behavior. ~14 LOC net.