### PR TITLE
fix(auto-promote): treat E2E completed/cancelled as defer, not failure

### DIFF
--- a/.github/workflows/auto-promote-on-e2e.yml
+++ b/.github/workflows/auto-promote-on-e2e.yml
@@ -186,7 +186,7 @@ jobs:
               echo "proceed=true" >> "$GITHUB_OUTPUT"
               echo "::notice::E2E green for this SHA — proceeding with promote"
               ;;
-            completed/failure|completed/cancelled|completed/timed_out)
+            completed/failure|completed/timed_out)
               echo "proceed=false" >> "$GITHUB_OUTPUT"
               {
                 echo "## ❌ Auto-promote aborted — E2E Staging SaaS failed"
@@ -197,6 +197,27 @@ jobs:
                 echo "If the failure was a flake, manually dispatch this workflow with the same sha to override."
               } >> "$GITHUB_STEP_SUMMARY"
               exit 1
+              ;;
+            completed/cancelled)
+              # cancelled ≠ failure. Per-SHA concurrency cancels older E2E
+              # runs when a newer push lands (memory:
+              # feedback_concurrency_group_per_sha) — the newer SHA will
+              # have its own E2E + promote chain. Treat the same as
+              # in_progress: defer without aborting, let the next E2E run
+              # promote when it lands.
+              #
+              # Caught 2026-05-05 02:03 on sha 31f9a5e — auto-promote
+              # blocked the whole chain because this case fell through to
+              # exit 1 instead of clean defer.
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              {
+                echo "## ⏭ Auto-promote deferred — E2E Staging SaaS was cancelled"
+                echo
+                echo "E2E Staging SaaS for \`${SHA:0:7}\`: \`$RESULT\`"
+                echo "Likely per-SHA concurrency (newer push superseded this E2E run)."
+                echo "The newer SHA's E2E will fire its own promote when it lands."
+                echo "If you need this specific SHA promoted, manually dispatch."
+              } >> "$GITHUB_STEP_SUMMARY"
               ;;
             in_progress/*|queued/*|requested/*|waiting/*|pending/*)
               echo "proceed=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
The auto-promote :latest workflow's case statement grouped \`completed/failure | completed/cancelled | completed/timed_out\` into the same abort-with-exit-1 branch. **cancelled ≠ failure** — when per-SHA concurrency (memory \`feedback_concurrency_group_per_sha\`) cancels an older E2E because a newer push landed, the workflow was blocking the whole auto-promote chain on a non-failure.

**Caught 2026-05-05 02:03 on sha \`31f9a5e\`:** E2E got cancelled by concurrency, auto-promote :latest aborted with exit 1, the next auto-promote-staging cycle had to clean up.

## Fix
Split: \`failure/timed_out\` keep the abort path. \`cancelled\` gets its own clean-defer branch (same shape as \`in_progress\`) — \`proceed=false\` without \`exit 1\`, with a step-summary explaining likely concurrency supersession + pointing operators at manual dispatch if they need that specific SHA promoted.

## Test plan
- [x] YAML valid (\`yaml.safe_load\` clean)
- [x] Case order verified: cancelled fallthrough to specific branch before \`*)\`
- [ ] Live: next concurrency-supersession event won't break auto-promote chain