### PR TITLE
feat(external-templates): codex tab uses plain pip install

### DIFF
--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -314,7 +314,7 @@ const externalCodexTemplate = `# Codex external setup — outbound tools (MCP) +
 # 1. Install codex CLI, the workspace runtime, and the bridge daemon:
 npm install -g @openai/codex@^0.57
 pip install molecule-ai-workspace-runtime
-pip install 'git+https://github.com/Molecule-AI/codex-channel-molecule.git'
+pip install codex-channel-molecule
 
 # 2. Wire the molecule MCP server into codex's config.toml — this is
 #    the OUTBOUND path (codex calls list_peers / delegate_task /


### PR DESCRIPTION
## Summary
- `codex-channel-molecule` 0.1.0 is now on PyPI ([project page](https://pypi.org/project/codex-channel-molecule/0.1.0/)) — flip the codex tab snippet from the `git+https://...` URL workaround to plain `pip install codex-channel-molecule`.
- Follow-up to #2809 (which shipped the snippet with the git+ URL because the wheel hadn't published yet).

## Test plan
- [x] `go test ./internal/handlers/ -run TestExternalTemplates -count=1` — green (no MOLECULE_ORG_ID, no git+ URL drift).
- [x] Smoke-installed from PyPI in a clean venv: `pip install codex-channel-molecule` resolves; `codex-channel-molecule --help` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)