### PR TITLE
fix(external-templates): unpin codex CLI from stale ^0.57

### DIFF
--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -312,7 +312,7 @@ const externalCodexTemplate = `# Codex external setup — outbound tools (MCP) +
 # session.
 
 # 1. Install codex CLI, the workspace runtime, and the bridge daemon:
-npm install -g @openai/codex@^0.57
+npm install -g @openai/codex@latest
 pip install molecule-ai-workspace-runtime
 pip install codex-channel-molecule
 


### PR DESCRIPTION
## Summary
- The codex tab snippet pins \`@openai/codex@^0.57\`, which only allows 0.57.x. Current codex CLI is **0.128**, and the API moved between (notably \`exec --resume <sid>\` → \`exec resume <sid>\` subcommand).
- Operators following the snippet today either get a 6-month-old codex with the legacy flag (where the bridge daemon worked) OR install latest manually and find the bridge daemon couldn't drive it. Both bad.
- codex-channel-molecule **0.1.2** (just published) handles the new subcommand shape, so this PR aligns the snippet with the daemon's tested compat: always install the latest codex.

## Test plan
- [x] \`go test ./internal/handlers/ -run TestExternalTemplates -count=1\` — green (no MOLECULE_ORG_ID, no git+ URL drift).

## Compat note
codex-channel-molecule 0.1.2 covers:
- \`exec resume <SID>\` subcommand (new)
- launchd / systemd PATH augmentation (codex bin shim is \`#!/usr/bin/env node\`, daemon now prepends bindir to subprocess PATH)
- molecule_runtime inbox poller activation (was missing — wait_for_message had been a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)