### PR TITLE
feat(handlers): migrate Pause loop to StopWorkspaceAuto — #2799 Phase 3 (closes #2799)

### DIFF
--- a/workspace-server/internal/handlers/workspace_provision_auto_test.go
+++ b/workspace-server/internal/handlers/workspace_provision_auto_test.go
@@ -894,6 +894,32 @@ func TestRunRestartCycle_UsesProvisionWorkspaceAutoSync(t *testing.T) {
 	}
 }
 
+// TestPauseHandler_UsesStopWorkspaceAuto — Phase 3 of #2799 source-level
+// pin. Pause's per-workspace stop call must route through
+// StopWorkspaceAuto so SaaS tenants terminate the EC2 instead of leaking
+// it (same drift class as the team-collapse leak #2813 and the
+// workspace-delete leak #2814 closed by PR #2824).
+//
+// Pause-specific bookkeeping (mark paused, clear keys, broadcast)
+// stays in the Pause handler — only the "stop the running workload"
+// step delegates to the dispatcher. This pin asserts the dispatcher
+// is called from the Pause loop with `ws.id`.
+func TestPauseHandler_UsesStopWorkspaceAuto(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	src, err := os.ReadFile(filepath.Join(wd, "workspace_restart.go"))
+	if err != nil {
+		t.Fatalf("read workspace_restart.go: %v", err)
+	}
+	stripped := stripGoComments(src)
+	if !bytes.Contains(stripped, []byte("h.StopWorkspaceAuto(ctx, ws.id)")) {
+		t.Errorf("workspace_restart.go must call StopWorkspaceAuto from the Pause loop with `ws.id` — current code does not. " +
+			"Phase 3 of #2799 migrated this site; do not regress to the inline `if h.provisioner != nil { Stop }` dispatch.")
+	}
+}
+
 // stripGoComments removes // line comments and /* */ block comments
 // from Go source. Imperfect (doesn't handle comments-inside-strings)
 // but adequate for the source-level pin tests in this file — none of

--- a/workspace-server/internal/handlers/workspace_restart.go
+++ b/workspace-server/internal/handlers/workspace_restart.go
@@ -613,10 +613,18 @@ func (h *WorkspaceHandler) Pause(c *gin.Context) {
 		}
 	}
 
-	// Stop containers and mark all as paused
+	// Stop containers and mark all as paused. StopWorkspaceAuto routes
+	// to whichever backend is wired (CP for SaaS, Docker for self-hosted)
+	// — pre-2026-05-05 this site inlined `if h.provisioner != nil { Stop }`,
+	// which silently leaked EC2s on every SaaS Pause (same drift class as
+	// the team-collapse leak #2813 and the workspace-delete leak #2814,
+	// both closed by PR #2824). StopWorkspaceAuto returns nil on no-backend
+	// (no-op), so the Pause-specific bookkeeping (mark paused, clear keys,
+	// broadcast) still fires regardless of whether anything was actually
+	// stopped — matches the pre-fix behavior on misconfigured deployments.
 	for _, ws := range toPause {
-		if h.provisioner != nil {
-			h.provisioner.Stop(ctx, ws.id)
+		if err := h.StopWorkspaceAuto(ctx, ws.id); err != nil {
+			log.Printf("Pause: stop %s failed: %v — orphan sweeper will reconcile", ws.id, err)
 		}
 		db.DB.ExecContext(ctx,
 			`UPDATE workspaces SET status = $1, url = '', updated_at = now() WHERE id = $2`, models.StatusPaused, ws.id)


### PR DESCRIPTION
Phase 3 of #2799 — last open site. Pause's per-workspace stop now routes through \`StopWorkspaceAuto\`.

## What changes

| Site | Before | After |
|---|---|---|
| Pause loop (Site 5) | inline \`if h.provisioner != nil { h.provisioner.Stop(ctx, ws.id) }\` | \`h.StopWorkspaceAuto(ctx, ws.id)\` |

Pause-specific bookkeeping (mark paused, clear workspace keys, broadcast \`WORKSPACE_PAUSED\`) stays inline in the handler. Only the "stop the running workload" step delegates to the dispatcher.

## Why no new \`PauseWorkspaceAuto\` verb

PR #2843's audit suggested Phase 3 might need a new dispatcher verb. On closer reading, Pause's stop step is identical to Stop — only the surrounding bookkeeping is Pause-specific. Reusing \`StopWorkspaceAuto\` avoids unnecessary surface and keeps the dispatcher trio (provision/stop/restart) tight.

\`StopWorkspaceAuto\`'s no-backend → no-op semantics match the pre-fix behavior on misconfigured deployments (the bookkeeping still runs even if there's nothing to stop).

## Closing the silent-drop bug class

Pre-fix the Pause loop was \`if h.provisioner != nil { Stop }\` — same drift class as:
- #2813 (team-collapse Stop is Docker-only)
- #2814 (workspace delete \`stopAndRemove\` early-returns when Docker nil)

Both closed by PR #2824. Pause was the third instance of the same pattern.

## After this PR + #2847 land

\`workspace_restart.go\` has no remaining inline if-cpProv-else dispatch in any user-facing code path. The remaining direct backend calls inside the file are in \`stopForRestart\` and \`cpStopWithRetry\` — both internal helpers that ARE the dispatcher's underlying primitives, not new bypasses.

This closes #2799 in full.

## Tests

- \`TestPauseHandler_UsesStopWorkspaceAuto\` — source-level pin against regression to the inline dispatch.
- All existing handler + race-detector tests pass.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] All handler tests pass (\`go test ./internal/handlers/...\`)
- [x] Race detector clean (\`go test -race\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)