### PR TITLE
chore(canvas): remove Expand-to-Team right-click button (#2858, Phase 2 of #2857)

### DIFF
--- a/canvas/src/components/ContextMenu.tsx
+++ b/canvas/src/components/ContextMenu.tsx
@@ -215,16 +215,6 @@ export function ContextMenu() {
     closeContextMenu();
   }, [contextMenu, selectNode, setPanelTab, closeContextMenu]);
 
-  const handleExpand = useCallback(async () => {
-    if (!contextMenu) return;
-    try {
-      await api.post(`/workspaces/${contextMenu.nodeId}/expand`, {});
-    } catch (e) {
-      showToast("Expand failed", "error");
-    }
-    closeContextMenu();
-  }, [contextMenu, closeContextMenu]);
-
   const setCollapsed = useCanvasStore((s) => s.setCollapsed);
   const handleCollapse = useCallback(async () => {
     if (!contextMenu) return;
@@ -295,7 +285,7 @@ export function ContextMenu() {
           },
           { label: "Zoom to Team", icon: "⊕", action: handleZoomToTeam },
         ]
-      : [{ label: "Expand to Team", icon: "▷", action: handleExpand }]),
+      : []),
     { label: "", icon: "", action: () => {}, divider: true },
     ...(isPaused
       ? [{ label: "Resume", icon: "▶", action: handleResume }]

--- a/canvas/src/components/Toolbar.tsx
+++ b/canvas/src/components/Toolbar.tsx
@@ -316,7 +316,7 @@ export function Toolbar() {
             <div className="space-y-2">
               <HelpRow shortcut="⌘K" text="Search workspaces and jump straight into Details or Chat." />
               <HelpRow shortcut="Palette" text="Open the template palette to deploy a new workspace." />
-              <HelpRow shortcut="Right-click" text="Use node actions for expand, duplicate, export, restart, or delete." />
+              <HelpRow shortcut="Right-click" text="Use node actions for duplicate, export, restart, or delete." />
               <HelpRow shortcut="Chat" text="If a task is still running, the chat tab resumes that session automatically." />
               <HelpRow shortcut="Config" text="Use the Config tab for skills, model, secrets, and runtime settings." />
               <HelpRow shortcut="Dbl-click / Z" text="Zoom canvas to fit a team node and all its sub-workspaces." />

--- a/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
+++ b/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
@@ -228,4 +228,34 @@ describe("ContextMenu — keyboard accessibility", () => {
     );
     expect(closeContextMenu).toHaveBeenCalled();
   });
+
+  // The "Expand to Team" right-click action was removed in Phase 2 of
+  // RFC #2857 — every workspace can already have children via the
+  // regular CreateWorkspace flow with parent_id, so a separate
+  // backend bulk-create handler (which was non-idempotent and leaked
+  // EC2s on every duplicate call) was deleted in PR #2856 and the
+  // canvas affordance is gone with it.
+  it("'Expand to Team' menu item is gone (childless workspace)", () => {
+    // Default mockStore.nodes = [] → no children → workspace is childless.
+    render(<ContextMenu />);
+    const items = screen.getAllByRole("menuitem");
+    const labels = items.map((el) => el.textContent?.trim() ?? "");
+    expect(labels).not.toContain(expect.stringMatching(/Expand to Team/));
+    // Sanity: childless menu still has the regular actions.
+    expect(labels.some((l) => l.includes("Delete"))).toBe(true);
+    expect(labels.some((l) => l.includes("Restart"))).toBe(true);
+  });
+
+  it("'Collapse Team' is still present when the workspace HAS children", () => {
+    // Mark a child belonging to ws-1 so hasChildren() returns true.
+    mockStore.nodes = [{ id: "child-1", data: { parentId: "ws-1" } }];
+    render(<ContextMenu />);
+    const items = screen.getAllByRole("menuitem");
+    const labels = items.map((el) => el.textContent?.trim() ?? "");
+    expect(labels.some((l) => /Collapse Team|Expand Team/.test(l))).toBe(true);
+    expect(labels.some((l) => l.includes("Arrange Children"))).toBe(true);
+    expect(labels.some((l) => l.includes("Zoom to Team"))).toBe(true);
+    // Cleanup for other tests.
+    mockStore.nodes = [];
+  });
 });


### PR DESCRIPTION
## Why

Pairs with #2856 which removed the backend \`POST /workspaces/:id/expand\` route. With the backend gone the canvas button hits a 404. Remove the button + callback so the affordance matches the API surface.

## Changes

- **ContextMenu.tsx**: delete \`handleExpand\` (8 lines) + the \"Expand to Team\" entry from the childless-workspace menu array. Childless workspaces show only the regular actions now (Extract from Team / Export Bundle / Duplicate / Pause / Restart / Delete).
- **Toolbar.tsx**: drop \`expand,\` from the right-click help-text shortcut.
- **ContextMenu.keyboard.test.tsx**: 2 new pinning cases — childless menu does NOT include \"Expand to Team\"; parent-with-children menu still has Collapse Team + Arrange Children + Zoom to Team.

## How users create children now

The existing \`+ New Workspace\` dialog (\`CreateWorkspaceDialog.tsx\`) already has a parent picker. No new UI needed — every workspace can be a parent via the regular Create flow with \`parent_id\` set.

## Test plan

- [x] \`pnpm test --run src/components/__tests__/ContextMenu.keyboard.test.tsx\` — 17 passed (including the 2 new ones)
- [x] \`npx tsc --noEmit\` clean
- [x] \`pnpm build\` clean (Next.js production build)
- [ ] Staging E2E (after Vercel deploys staging branch):
  - Open canvas at \`https://demo-prep.staging.moleculesai.app\`
  - Right-click on a childless workspace card → confirm \"Expand to Team\" is GONE
  - Create a child via \`+ New Workspace\` with parent picker → confirm parent-child wiring still works (child appears nested on canvas)
  - Right-click parent → \"Collapse Team\" still works (visual toggle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)