### PR TITLE
fix(canvas/tests): pin Expand-to-Team absence with literal assertion

### DIFF
--- a/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
+++ b/canvas/src/components/__tests__/ContextMenu.keyboard.test.tsx
@@ -240,7 +240,11 @@ describe("ContextMenu — keyboard accessibility", () => {
     render(<ContextMenu />);
     const items = screen.getAllByRole("menuitem");
     const labels = items.map((el) => el.textContent?.trim() ?? "");
-    expect(labels).not.toContain(expect.stringMatching(/Expand to Team/));
+    // Literal absence — vitest's toContain uses Object.is/===, so the
+    // earlier `.not.toContain(expect.stringMatching(...))` shape passed
+    // for ANY string array (asymmetric matchers only work with toEqual /
+    // arrayContaining). Pin the production string verbatim.
+    expect(labels.some((l) => l.includes("Expand to Team"))).toBe(false);
     // Sanity: childless menu still has the regular actions.
     expect(labels.some((l) => l.includes("Delete"))).toBe(true);
     expect(labels.some((l) => l.includes("Restart"))).toBe(true);


### PR DESCRIPTION
## Why

Multi-model review of #2862 caught a non-load-bearing assertion. The test used:

\`\`\`ts
expect(labels).not.toContain(expect.stringMatching(/Expand to Team/));
\`\`\`

But vitest's \`toContain\` uses \`Object.is/===\`, so \`expect.stringMatching\` (a plain object) never \`===\` any string in the array. **The assertion silently passed for ANY string array, including arrays that DID contain \"Expand to Team\".** The test would have green-lit the unfixed code.

## Fix

Switch to the literal-substring shape the rest of this file already uses:

\`\`\`ts
expect(labels.some((l) => l.includes(\"Expand to Team\"))).toBe(false);
\`\`\`

## Verification — assertion is load-bearing

1. Reintroduced \`{ label: \"Expand to Team\", ... }\` into the childless-workspace branch of \`ContextMenu.tsx\`
2. Ran the test — **failed** at the new assertion line as expected
3. Reverted the regression — test passes again

Per memory \`feedback_assert_exact_not_substring.md\`: assertions must fail on the old code path before merging. This one never did.

## Follow-ups (separate PRs)

- Issue tracking: 6+ doc files still reference the deleted \`POST /workspaces/:id/expand\` route, including the MCP \`expand_team\` tool mapping in \`docs/guides/mcp-server-setup.md\`
- TeamHandler.Collapse appears unreachable from the canvas UI (canvas calls \`PATCH /workspaces/:id { collapsed }\`, not \`POST /collapse\`) — candidate for full deletion alongside docs cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)