### PR TITLE
fix(ci): include event_name in runtime-prbuild-compat concurrency group

### DIFF
--- a/.github/workflows/runtime-prbuild-compat.yml
+++ b/.github/workflows/runtime-prbuild-compat.yml
@@ -43,7 +43,20 @@ on:
     types: [checks_requested]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.head.sha || github.sha }}
+  # Include event_name so a PR sync (event=pull_request) and the
+  # subsequent staging push (event=push) on the SAME merge SHA don't
+  # collide in one group. Without event_name, both runs hashed to
+  # the same key and cancel-in-progress=true cancelled whichever
+  # arrived second — usually the push run, which staging branch-
+  # protection then sees as a CANCELLED required check and refuses
+  # to mark merged. Caught 2026-05-05 across PR #2869's runs (run
+  # ids 25371863455 / 25371811486 / 25371078157 / 25370403142 — every
+  # staging push run cancelled, every matching PR run green).
+  #
+  # Per memory `feedback_concurrency_group_per_sha.md` — same drift
+  # class that broke auto-promote-staging on 2026-04-28. Pin invariant:
+  # event_name + sha is the minimum unique key for these workflows.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Closes the cancellation pattern you flagged. Every staging push run for \`runtime-prbuild-compat.yml\` over the last 4 SHAs was cancelled by the matching pull_request run because both fired into the same concurrency group:

\`\`\`yaml
group: \${{ github.workflow }}-\${{ ...sha }}
\`\`\`

Same SHA → same group → \`cancel-in-progress: true\` means the second arrival cancels the first. Empirically the push run lost the race every time; staging branch-protection then saw a CANCELLED required check and stalled.

## The pattern (8 runs, 4 SHAs)

| Time | SHA | event | conclusion |
|---|---|---|---|
| 10:46 | 1e8d7ae1 | pull_request | success |
| 10:46 | 1e8d7ae1 | **push** | **cancelled** |
| 10:45 | ecf5f6fb | pull_request | success |
| 10:45 | ecf5f6fb | **push** | **cancelled** |
| 10:28 | 471dff25 | pull_request | success |
| 10:28 | 471dff25 | **push** | **cancelled** |
| 10:12 | 9e678ccd | pull_request | success |
| 10:12 | 9e678ccd | **push** | **cancelled** |

Same shape every time. **Configuration drift, not a flake.**

## Fix

One-line addition to the group key — include \`event_name\`:

\`\`\`yaml
group: \${{ github.workflow }}-\${{ github.event_name }}-\${{ github.event.pull_request.head.sha || github.sha }}
\`\`\`

push and pull_request runs for the same SHA now hash to different groups. Both complete, both report SUCCESS to branch protection.

## Why this is the only workflow that needed it

Audited \`.github/workflows/\` — every other workflow either:
- doesn't set \`concurrency\` at all
- uses \`\${{ github.ref }}\`-scoped groups (event-neutral)
- already includes \`github.event_name\` (e.g., \`e2e-staging-canvas.yml\`, \`e2e-api.yml\`)

\`runtime-prbuild-compat.yml\` was the only outlier. Same drift class as the 2026-04-28 auto-promote-staging incident — captured in \`feedback_concurrency_group_per_sha.md\` memory.

## Test plan

- [x] yaml.safe_load passes
- [x] grep audit shows no other workflow has this shape
- [ ] Next staging push after merge: both push + pull_request runs complete green for the same SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)