### PR TITLE
test(handlers): allowlist INSERT INTO workspaces sites (#2867 class 1)

### DIFF
--- a/workspace-server/internal/handlers/workspaces_insert_allowlist_test.go
+++ b/workspace-server/internal/handlers/workspaces_insert_allowlist_test.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestINSERTworkspacesAllowlist enumerates every function in this
+// package that emits an `INSERT INTO workspaces (` SQL literal, and
+// pins the result against an explicit allowlist. New entries fail the
+// build until a reviewer adds them — forcing the question "what
+// makes this INSERT idempotent?" at PR-review time, not after the
+// next bulk-create leak.
+//
+// Pairs with TestCreateWorkspaceTree_CallsLookupBeforeInsert (the
+// behavior pin for the one bulk path). Together they close the
+// regression class: this test catches "did a new function start
+// inserting workspaces?", that test catches "did the existing bulk
+// path drop its idempotency check?". Either fires immediately when
+// drift happens.
+//
+// Why allowlist rather than pure behavior gate (per memory
+// feedback_behavior_based_ast_gates.md): the bulk-create leak class
+// is small + stable (1 path today), and a behavior gate would have
+// to disambiguate "iterating a YAML array of workspaces" from the
+// many other `for ... range` patterns in a Create handler (config
+// lines, secrets map, channels). Type-info-aware AST analysis would
+// catch the YAML-iteration shape but is heavy. Allowlisting is the
+// minimum-viable pin: any PR that adds a new INSERT site is forced
+// to pause, add an entry here, and document the safety mechanism in
+// the comment alongside.
+//
+// RFC #2867 class 1.
+func TestINSERTworkspacesAllowlist(t *testing.T) {
+	// expected[key] = safety mechanism. Keep the comment pinned to
+	// what makes that function safe — if the safety changes, the
+	// allowlist must be re-reviewed.
+	expected := map[string]string{
+		// org_import.createWorkspaceTree: lookupExistingChild
+		// before INSERT (#2868 phase 3). Also pinned by
+		// TestCreateWorkspaceTree_CallsLookupBeforeInsert.
+		"org_import.go:createWorkspaceTree": "lookup-then-insert via lookupExistingChild",
+		// registry.Register: external workspace registers itself with
+		// its known UUID; INSERT is idempotent via ON CONFLICT (id)
+		// DO UPDATE — re-registration upserts, never duplicates.
+		"registry.go:Register": "ON CONFLICT (id) DO UPDATE",
+		// workspace.Create: single-workspace POST /workspaces from a
+		// human or automation. No iteration; payload describes one
+		// workspace; UUID is server-generated. Caller intent IS to
+		// create, so no idempotency check is needed.
+		"workspace.go:Create": "single-workspace POST, server-generated UUID",
+	}
+
+	actual := map[string]string{}
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	entries, err := os.ReadDir(wd)
+	if err != nil {
+		t.Fatalf("readdir %s: %v", wd, err)
+	}
+	for _, ent := range entries {
+		name := ent.Name()
+		if ent.IsDir() {
+			continue
+		}
+		if !strings.HasSuffix(name, ".go") {
+			continue
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(wd, name)
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", path, err)
+		}
+		// For each top-level FuncDecl, walk its body and check for an
+		// `INSERT INTO workspaces (` SQL literal in any CallExpr arg.
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			var foundInsert bool
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				lit, ok := n.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				raw := lit.Value
+				if unq, err := strconv.Unquote(raw); err == nil {
+					raw = unq
+				}
+				if workspacesInsertRE.MatchString(raw) {
+					foundInsert = true
+					return false
+				}
+				return true
+			})
+			if foundInsert {
+				key := name + ":" + fn.Name.Name
+				actual[key] = "(observed via AST walk)"
+			}
+		}
+	}
+
+	// Compute set diffs so failures point at the specific drift.
+	missing := []string{}
+	unexpected := []string{}
+	for k := range expected {
+		if _, ok := actual[k]; !ok {
+			missing = append(missing, k)
+		}
+	}
+	for k := range actual {
+		if _, ok := expected[k]; !ok {
+			unexpected = append(unexpected, k)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(unexpected)
+
+	if len(unexpected) > 0 {
+		t.Errorf(`new function(s) emit `+"`INSERT INTO workspaces (`"+` and aren't in the allowlist:
+  %s
+
+If this is a legitimate addition, add an entry to expected[] in this test
+with the safety mechanism pinned in the comment alongside (lookup-then-
+insert / ON CONFLICT / single-workspace path / etc.). The bulk-create
+regression class needs explicit per-handler review, not silent drift.
+
+Reference: RFC #2867 class 1, sibling test
+TestCreateWorkspaceTree_CallsLookupBeforeInsert.`,
+			strings.Join(unexpected, "\n  "))
+	}
+	if len(missing) > 0 {
+		t.Errorf(`expected function(s) no longer emit `+"`INSERT INTO workspaces (`"+`:
+  %s
+
+Either the function was renamed/deleted (update the allowlist) or the
+INSERT was moved out (verify the new home is also covered). Don't just
+delete the entry — confirm the safety mechanism is still in place
+elsewhere or that the workspace-create path was intentionally
+restructured.`,
+			strings.Join(missing, "\n  "))
+	}
+}


### PR DESCRIPTION
## Summary

Closes RFC #2867 class 1 — adds an explicit allowlist gate for every function in \`workspace-server/internal/handlers/\` that emits an \`INSERT INTO workspaces (\` SQL literal. Pairs with the behavior pin from #2895 (lookup-before-insert on the one bulk path).

The two gates together close the bulk-create regression class:
- **This test** catches "did a new function start inserting workspaces?" — a PR adding a new bulk handler without idempotency fails until the reviewer pauses, adds an allowlist entry, and documents the safety mechanism.
- **TestCreateWorkspaceTree_CallsLookupBeforeInsert** catches "did the existing bulk path drop its idempotency check?" — already shipped in #2895.

## Allowlist

Three entries today, each with the safety mechanism named:

| Function | Safety mechanism |
|---|---|
| \`org_import.go:createWorkspaceTree\` | lookup-then-insert via \`lookupExistingChild\` (#2868) |
| \`registry.go:Register\` | \`ON CONFLICT (id) DO UPDATE\` (primary-key upsert) |
| \`workspace.go:Create\` | single-workspace \`POST /workspaces\`, server-generated UUID, no iteration |

## Why allowlist rather than pure behavior gate

Per memory \`feedback_behavior_based_ast_gates.md\`, behavior gates are usually preferable. In this case, the bulk-create surface is small (1 path) + the relevant invariant is hard to AST-detect without type info — \"iterating a YAML array of workspaces\" requires distinguishing a \`for ... range payload.SubWorkspaces\` from \`for ... range strings.Split(cfgData, \"\\n\")\`, both legitimate in different handlers.

The allowlist forces explicit per-handler review at PR time, which is cheap (3 entries today, expected to grow rarely). When the surface grows, splitting into a typed-AST behavior gate is a clean follow-up.

## Test plan

- [x] \`go test ./internal/handlers/ -run TestINSERTworkspacesAllowlist -count 1\` — green
- [x] **Mutation test**: drop a synthetic \`tempBulkLeakTest\` with an unsafe loop+INSERT into the package → gate fails with clear file:func diagnostic. Per memory \`feedback_assert_exact_not_substring.md\` (verify tightened test FAILS on bug shape).
- [x] Restore tree → gate returns to green.
- [x] \`go vet ./internal/handlers/\` clean
- [ ] CI green
- [ ] Approver: \`hongmingwang-moleculeai\`

## Follow-ups

- **Class 2** (separate PR): Prometheus gauge \`molecule_workspace_ec2_duplicates\` from CP-side SQL invariant query on \`tenant_resources\` (CP repo).
- **Class 3** (separate PR): structured logging on every workspace create — JSON event with org_id / parent_id / name / source so the next leak class is diagnosable in minutes instead of hours.

Refs #2867, #2895, #2868, #2857