### PR TITLE
fix(canvas/chat): instant-scroll to bottom on first mount

### DIFF
--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -286,6 +286,14 @@ function MyChatPanel({ workspaceId, data }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
+  // First-mount scroll-to-bottom needs `behavior: "instant"` — long
+  // conversations smooth-animate for ~300ms which any concurrent
+  // re-render can interrupt, leaving the user stuck mid-conversation
+  // when the chat tab opens. Subsequent appends (new agent messages)
+  // keep `smooth` for the visual "landing" feel. Flipped the first
+  // time messages.length goes positive, so a workspace switch (which
+  // remounts ChatTab) gets a fresh instant jump too.
+  const hasInitialScrollRef = useRef(false);
   // Lazy-load older history on scroll-up.
   // - containerRef = the scrollable messages viewport
   // - topRef       = sentinel above the messages list; IO observes it
@@ -543,6 +551,15 @@ function MyChatPanel({ workspaceId, data }: Props) {
     ) {
       container.scrollTop = container.scrollHeight - anchor.savedDistanceFromBottom;
       scrollAnchorRef.current = null;
+      return;
+    }
+    // Instant on first arrival of messages — smooth-scroll on a long
+    // conversation gets interrupted by concurrent renders and leaves
+    // the user stuck in the middle. After the first jump, subsequent
+    // appends animate as before.
+    if (!hasInitialScrollRef.current && messages.length > 0) {
+      hasInitialScrollRef.current = true;
+      bottomRef.current?.scrollIntoView({ behavior: "instant" as ScrollBehavior });
       return;
     }
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
## Why

Reported: \"right now when chat box opens it opens in the middle, but it should be at the end of conversation.\"

Root cause: \`ChatTab.tsx:548\` fires \`bottomRef.scrollIntoView({ behavior: \"smooth\" })\` on every messages-update. On initial mount with N messages already loaded, the ~300ms smooth-scroll animation gets interrupted by any concurrent re-render (agent push landing, theme toggle, sidepanel resize), leaving the user stuck mid-conversation.

## Fix

Track first-mount via \`hasInitialScrollRef\`. Use \`behavior: \"instant\"\` for the initial jump (deterministic, no animation interruption), then \`smooth\` for subsequent appends (the new-message-landing visual stays).

Behavior matrix:
- Initial open of chat tab: instant jump to bottom ✓
- New agent message arrives: smooth scroll into view ✓
- Workspace switch (ChatTab remounts): fresh ref, gets instant again ✓
- loadOlder prepend: anchor-restore path unchanged, still pins user's reading position ✓

## Test plan

- [x] \`pnpm test --run ChatTab.lazyHistory.test.tsx\` — 8 pass (existing lazy-history tests untouched)
- [x] \`npx tsc --noEmit\` clean
- [ ] Manual on hongming.moleculesai.app: open a busy chat (mac laptop, ~50 messages), confirm view lands at the latest bubble, not mid-scroll. Switch to another workspace + back → instant again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)