### PR TITLE
fix(memory-plugin): bind to 127.0.0.1 by default

### DIFF
--- a/workspace-server/cmd/memory-plugin-postgres/config_test.go
+++ b/workspace-server/cmd/memory-plugin-postgres/config_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLoadConfig_DefaultListenAddrIsLoopback pins the default-bind contract.
+//
+// Why this matters: with the prior `:9100` default, the plugin listened on
+// every interface. Inside the container it didn't matter (no host port
+// mapping today), but a future change that publishes 9100 OR a cross-host
+// sidecar deploy would have exposed an unauth'd memory store. Loopback by
+// default is the least-privilege baseline; operators with a multi-host
+// topology override via MEMORY_PLUGIN_LISTEN_ADDR.
+func TestLoadConfig_DefaultListenAddrIsLoopback(t *testing.T) {
+	t.Setenv("MEMORY_PLUGIN_DATABASE_URL", "postgres://stub")
+	t.Setenv("MEMORY_PLUGIN_LISTEN_ADDR", "")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if !strings.HasPrefix(cfg.ListenAddr, "127.0.0.1:") {
+		t.Errorf("default ListenAddr must bind loopback-only, got %q "+
+			"(security regression — would expose plugin on every interface)",
+			cfg.ListenAddr)
+	}
+}
+
+func TestLoadConfig_ListenAddrEnvOverride(t *testing.T) {
+	t.Setenv("MEMORY_PLUGIN_DATABASE_URL", "postgres://stub")
+	t.Setenv("MEMORY_PLUGIN_LISTEN_ADDR", ":9100")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.ListenAddr != ":9100" {
+		t.Errorf("env override ignored: want :9100, got %q", cfg.ListenAddr)
+	}
+}
+
+func TestLoadConfig_MissingDatabaseURL(t *testing.T) {
+	t.Setenv("MEMORY_PLUGIN_DATABASE_URL", "")
+
+	if _, err := loadConfig(); err == nil {
+		t.Fatal("loadConfig must error when MEMORY_PLUGIN_DATABASE_URL is empty")
+	}
+}

--- a/workspace-server/cmd/memory-plugin-postgres/main.go
+++ b/workspace-server/cmd/memory-plugin-postgres/main.go
@@ -31,7 +31,13 @@ const (
 	envListenAddr  = "MEMORY_PLUGIN_LISTEN_ADDR"
 	envSkipMigrate = "MEMORY_PLUGIN_SKIP_MIGRATE"
 
-	defaultListenAddr = ":9100"
+	// Loopback-only by default (defense in depth). The platform talks to
+	// the plugin over `http://localhost:9100` from the same container, so
+	// binding to all interfaces would only widen the reachable surface
+	// without enabling any in-design caller. Operators running the plugin
+	// on a separate host override via MEMORY_PLUGIN_LISTEN_ADDR=:9100 (or
+	// some other interface).
+	defaultListenAddr = "127.0.0.1:9100"
 )
 
 func main() {


### PR DESCRIPTION
## Summary

Self-review of PR #2906 (memory-plugin sidecar bundle) flagged that `defaultListenAddr = \":9100\"` binds on every container interface. Inside today's deployment that's moot (no host port mapping, platform talks over loopback) but it's not least-privilege. A future Dockerfile edit that publishes the port, a misconfigured Fly machine, or a cross-host plugin topology would expose an unauthenticated memory store.

Change: default → `127.0.0.1:9100`. Operators with multi-host topology already override via `MEMORY_PLUGIN_LISTEN_ADDR` — that path is unchanged.

## Tests

- `TestLoadConfig_DefaultListenAddrIsLoopback` pins the new default
- `TestLoadConfig_ListenAddrEnvOverride` pins the operator-override path
- `TestLoadConfig_MissingDatabaseURL` covers existing fail-fast

No prior unit tests existed for `loadConfig` — `boot_e2e_test.go` always sets `MEMORY_PLUGIN_LISTEN_ADDR` explicitly, so the default was never exercised by tests. This PR closes that gap.

## Test plan

- [ ] CI green
- [ ] Auto-rebase + tenant fleet redeploy on main merge picks up the new bind

Refs RFC #2728. Hardening follow-up to PR #2906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)