### PR TITLE
fix(harness): disable memory-plugin sidecar in harness tenants

### DIFF
--- a/tests/harness/compose.yml
+++ b/tests/harness/compose.yml
@@ -94,6 +94,13 @@ services:
       CP_UPSTREAM_URL: "http://cp-stub:9090"
       RATE_LIMIT: "1000"
       CANVAS_PROXY_URL: "http://localhost:3000"
+      # Memory v2 sidecar (PR #2906) bundles the plugin into the
+      # tenant image and starts it before the main server. The plugin
+      # runs `CREATE EXTENSION vector` on first boot, which fails on
+      # the harness's plain postgres:15-alpine (no pgvector). The
+      # harness doesn't exercise memory features, so disable the
+      # sidecar via the entrypoint's documented escape hatch.
+      MEMORY_PLUGIN_DISABLE: "1"
     networks: [harness-net]
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://localhost:8080/health || exit 1"]
@@ -142,6 +149,13 @@ services:
       CP_UPSTREAM_URL: "http://cp-stub:9090"
       RATE_LIMIT: "1000"
       CANVAS_PROXY_URL: "http://localhost:3000"
+      # Memory v2 sidecar (PR #2906) bundles the plugin into the
+      # tenant image and starts it before the main server. The plugin
+      # runs `CREATE EXTENSION vector` on first boot, which fails on
+      # the harness's plain postgres:15-alpine (no pgvector). The
+      # harness doesn't exercise memory features, so disable the
+      # sidecar via the entrypoint's documented escape hatch.
+      MEMORY_PLUGIN_DISABLE: "1"
     networks: [harness-net]
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O- http://localhost:8080/health || exit 1"]


### PR DESCRIPTION
## Summary

PR #2906 (memory-plugin sidecar bundle) broke the Harness Replays job. The plugin's first migration runs \`CREATE EXTENSION IF NOT EXISTS vector\` which fails on the harness's plain \`postgres:15-alpine\` (no pgvector). The 30s health gate I built into the entrypoint then aborts boot:

\`\`\`
 Container harness-tenant-alpha-1  Error
 Container harness-tenant-beta-1   Error
dependency failed to start: container harness-tenant-alpha-1 exited (1)
\`\`\`

Currently blocking auto-promote PR #2914 (staging→main). Without this fix, Memory v2 sidecar code can't reach main, can't reach the prod tenant fleet, and your \`hongming\` canary doesn't pick up the new image.

## Fix

Use the documented escape hatch (\`MEMORY_PLUGIN_DISABLE=1\`) on both harness tenants in \`tests/harness/compose.yml\`. The harness doesn't exercise memory features, so the running sidecar adds zero value while paying the boot cost.

Two-line change in each tenant block (alpha + beta).

## Why not pgvector?

Switching the harness Postgres image to \`pgvector/pgvector:pg15\` would also work, but adds a CI dependency for code paths the harness doesn't actually verify. Deferred until the harness wants to test memory paths.

## Test plan

- [x] Locally: \`SECRETS_ENCRYPTION_KEY=test docker compose ... config\` validates
- [ ] CI Harness Replays passes
- [ ] Auto-promote PR #2914 unblocks once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)