### PR TITLE
docs: callout Python>=3.11 on Universal MCP snippet + runtime doc

### DIFF
--- a/docs/workspace-runtime-package.md
+++ b/docs/workspace-runtime-package.md
@@ -1,5 +1,14 @@
 # Workspace Runtime PyPI Package
 
+## Requires Python >= 3.11
+
+The wheel pins `requires_python>=3.11`. On Python 3.10 or older, `pip install
+molecule-ai-workspace-runtime` fails with `Could not find a version that
+satisfies the requirement (from versions: none)` — the pin filters the only
+available artifact before pip even attempts install. Upgrade the interpreter
+(`brew install python@3.12` / `apt install python3.12` / etc.) or use a
+3.11+ venv.
+
 ## Overview
 
 The shared workspace runtime infrastructure has **one editable source** and

--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -198,6 +198,13 @@ const externalUniversalMcpTemplate = `# Universal MCP — standalone register + 
 # Pair with the Claude Code or Python SDK tab if your runtime needs
 # inbound A2A delivery (canvas messages → agent conversation turns).
 
+# Requires Python >= 3.11. On 3.10 or older pip says
+# "Could not find a version that satisfies the requirement
+# (from versions: none)" — the wheel's requires_python pin filters
+# the only available artifact before pip even attempts install.
+# Upgrade the interpreter (brew install python@3.12 / apt install
+# python3.12 / etc.) or use a 3.11+ venv.
+
 # 1. Install the workspace runtime wheel:
 pip install molecule-ai-workspace-runtime
 


### PR DESCRIPTION
## User-visible problem
Operator runs the canvas-rendered `pip install molecule-ai-workspace-runtime` snippet on a Python 3.10 interpreter and gets `Could not find a version that satisfies the requirement (from versions: none)`. pip's `requires_python` filter silently drops the only available wheel before attempting install, so the error doesn't mention Python at all. Operators see "package missing", file a bug, chase a phantom CDN/visibility issue.

This was the second time today this came up — surfacing the requirement at the operator-touch surface preempts the next report.

## Two changes
1. **`workspace-server/internal/handlers/external_connection.go`** — `externalUniversalMcpTemplate` (rendered into the canvas Connect-External-Agent modal) now leads with a brief `Requires Python >= 3.11` block + the exact pip error string + upgrade paths.
2. **`docs/workspace-runtime-package.md`** — same callout at the top of the doc, before the Overview, so search hits land on the answer immediately.

## Verification
- `go build ./...` clean
- `go test ./internal/handlers/... -count=1` green
- 16 LOC, additive only

## Test plan
- [x] Build + tests clean
- [ ] CI green
- [ ] Manual: open canvas Connect-External-Agent modal, verify the new callout renders before the install command

🤖 Generated with [Claude Code](https://claude.com/claude-code)
