### PR TITLE
fix(canvas): include peer-initiated rows in chat history (reno-stars data loss)

### DIFF
--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -153,9 +153,26 @@ async function loadMessagesFromDB(
   beforeTs?: string,
 ): Promise<{ messages: ChatMessage[]; error: string | null; reachedEnd: boolean }> {
   try {
+    // Reported on reno-stars (production, 2026-05-05): "received [a
+    // message] while the chat was open but it's not persisted." Live
+    // delivery via WebSocket worked; refresh + reopen-tab dropped it.
+    //
+    // Root cause: this fetch was filtering `source=canvas` (source_id
+    // IS NULL), which only returns rows where the canvas-user is the
+    // initiator. Peer-initiated rows — another agent A2A-sending into
+    // this workspace — have source_id set to the peer's UUID and were
+    // excluded from history even though they ARE persisted in
+    // activity_log. Result: a real message visible live, gone on reload.
+    //
+    // Fix: drop the source filter and return BOTH user-initiated and
+    // peer-initiated a2a_receive rows. activityRowToMessages handles
+    // the role assignment per row (user vs agent vs system) — a peer-
+    // initiated row's request_body is rendered as a "user" bubble that
+    // labels itself with the peer's source. A future polish PR will
+    // distinguish the bubble visually (e.g. "via <peer name>") but the
+    // critical fix is stopping the data loss.
     const params = new URLSearchParams({
       type: "a2a_receive",
-      source: "canvas",
       limit: String(limit),
     });
     if (beforeTs) params.set("before_ts", beforeTs);

--- a/canvas/src/components/tabs/__tests__/ChatTab.lazyHistory.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ChatTab.lazyHistory.test.tsx
@@ -34,17 +34,25 @@ afterEach(cleanup);
 
 // Both ChatTab sub-panels (MyChat + AgentComms) mount simultaneously so
 // keyboard tab order and aria-controls land on a real DOM. Both fire
-// /activity GETs on mount: MyChat's hits `type=a2a_receive&source=canvas`,
+// /activity GETs on mount: MyChat's hits `type=a2a_receive` (no source
+// filter so peer-initiated rows are also included — see fix for the
+// reno-stars chat-history persistence bug, ChatTab.tsx loadHistory),
 // AgentComms's hits a different filter. Route the mock by URL so each
 // gets a sensible default and only MyChat's call is what the assertions
 // scrutinise.
+//
+// IMPORTANT: AgentComms's activity URL also contains
+// `type=a2a_receive`, so we must distinguish via a feature unique to
+// MyChat. AgentComms appends source=agent (peer-only); MyChat now has
+// no source param at all. The discriminator below picks MyChat by
+// "no source param" in the URL.
 const myChatActivityCalls: string[] = [];
 let myChatNextResponse: { ok: true; rows: unknown[] } | { ok: false; err: Error } = {
   ok: true,
   rows: [],
 };
 const apiGet = vi.fn((path: string): Promise<unknown> => {
-  if (path.includes("type=a2a_receive") && path.includes("source=canvas")) {
+  if (path.includes("type=a2a_receive") && !path.includes("source=")) {
     myChatActivityCalls.push(path);
     if (myChatNextResponse.ok) return Promise.resolve(myChatNextResponse.rows);
     return Promise.reject(myChatNextResponse.err);


### PR DESCRIPTION
## Summary

Reported on production tenant **reno-stars** (CEO Ryan PC external workspace): \"received [a message] while the chat was open but it's not persisted.\" Live WebSocket delivery worked; close+reopen tab and full page refresh both lost the message.

## Root cause

\`ChatTab.loadHistory\` filters \`/workspaces/:id/activity\` with \`source=canvas\` (backend: \`source_id IS NULL\`), which returns ONLY canvas-user-initiated rows. **Peer-initiated** \`a2a_receive\` rows — another agent A2A-sending into this workspace, with \`source_id\` set to the peer's UUID — were excluded from history even though they ARE persisted in \`activity_log\`.

Net effect: a real message visible live (via WebSocket), gone on reload.

## Fix

Drop the \`source\` query param from the loadHistory call so both canvas-initiated AND peer-initiated rows return. \`activityRowToMessages\` already handles role assignment per-row from \`request_body\` / \`response_body\`.

## Test plan

- [x] \`npx vitest run src/components/tabs/__tests__/ChatTab\` — 8/8 pass after updating the discriminator (was matching \`source=canvas\`, now matches \"no source filter\" for MyChat)
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Approver: \`hongmingwang-moleculeai\`
- [ ] **Manual** post-deploy: send a peer message into a tenant workspace, refresh the chat tab, verify message persists

## Followup (separate PR)

Distinguish peer-initiated bubbles visually (e.g. \"via <peer name>:\") so users can tell their own messages from peer messages. Today both render as \"user\" bubbles — functionally correct (message belongs to this workspace's chat) but visually ambiguous.