### PR TITLE
fix(external-connect): use molecule-mcp wrapper in Codex/OpenClaw templates (#2957)

### DIFF
--- a/workspace-server/internal/handlers/external_connection.go
+++ b/workspace-server/internal/handlers/external_connection.go
@@ -423,14 +423,23 @@ mkdir -p ~/.codex
 # (then open ~/.codex/config.toml in your editor and paste:)
 #
 # [mcp_servers.molecule]
-# command = "python3"
-# args = ["-m", "molecule_runtime.a2a_mcp_server"]
+# command = "molecule-mcp"
+# args = []
 # startup_timeout_sec = 30
 #
 # [mcp_servers.molecule.env]
 # WORKSPACE_ID = "{{WORKSPACE_ID}}"
 # PLATFORM_URL = "{{PLATFORM_URL}}"
 # MOLECULE_WORKSPACE_TOKEN = "<paste from create response>"
+#
+# Use the "molecule-mcp" console-script wrapper (NOT
+# "python3 -m molecule_runtime.a2a_mcp_server"). The wrapper is what
+# keeps the workspace ALIVE on the canvas: it POSTs /registry/register
+# at startup and runs a 20s heartbeat thread alongside the MCP stdio
+# loop. The bare a2a_mcp_server module exposes tools but does NOT
+# heartbeat — pointing codex at it leaves the canvas showing this
+# workspace as awaiting_agent (OFFLINE) within 60-90s even while
+# tools work.
 
 # 3. Run the bridge daemon as a durable background process — this
 #    is the INBOUND path. Long-polls the platform inbox and runs
@@ -507,11 +516,20 @@ pip install molecule-ai-workspace-runtime
 
 # 3. Wire the molecule MCP server. {{WORKSPACE_ID}} + {{PLATFORM_URL}}
 # are stamped server-side; paste the auth token before running.
+#
+# Use the "molecule-mcp" console-script wrapper (NOT
+# "python3 -m molecule_runtime.a2a_mcp_server"). The wrapper is what
+# keeps the workspace ALIVE on the canvas: it POSTs /registry/register
+# at startup and runs a 20s heartbeat thread alongside the MCP stdio
+# loop. The bare a2a_mcp_server module exposes tools but does NOT
+# heartbeat — pointing openclaw at it leaves the canvas showing this
+# workspace as awaiting_agent (OFFLINE) within 60-90s even while
+# tools work.
 WORKSPACE_TOKEN="<paste from create response>"
 openclaw mcp set molecule "$(cat <<EOF
 {
-  "command": "python3",
-  "args": ["-m", "molecule_runtime.a2a_mcp_server"],
+  "command": "molecule-mcp",
+  "args": [],
   "env": {
     "WORKSPACE_ID": "{{WORKSPACE_ID}}",
     "PLATFORM_URL": "{{PLATFORM_URL}}",

--- a/workspace-server/internal/handlers/external_connection_test.go
+++ b/workspace-server/internal/handlers/external_connection_test.go
@@ -38,3 +38,40 @@ func TestExternalTemplates_NoMoleculeOrgIDPlaceholder(t *testing.T) {
 		}
 	}
 }
+
+// TestExternalMcpTemplates_UseMoleculeMcpWrapper pins the invariant
+// that operator-facing snippets configuring an MCP server entry point
+// use the ``molecule-mcp`` console-script wrapper (mcp_cli.main),
+// NOT the bare ``a2a_mcp_server`` module.
+//
+// Why: a2a_mcp_server exposes the MCP tools but does NOT call
+// /registry/register or run the 20s heartbeat thread. mcp_cli wraps
+// it with both, which is what flips the canvas presence indicator
+// from awaiting_agent (OFFLINE) to online and keeps it that way.
+// Originally tracked by molecule-core#2957 — operator hit the
+// silent-OFFLINE failure mode when the Codex tab pointed at the bare
+// module.
+//
+// The hermes-channel template intentionally uses the bare module: it
+// owns the platform plugin path and runs its own
+// register_platform/heartbeat code in-process, so wrapping with
+// mcp_cli would double-heartbeat. universalMcp / codex / openclaw
+// must all use the wrapper.
+func TestExternalMcpTemplates_UseMoleculeMcpWrapper(t *testing.T) {
+	mustUseWrapper := map[string]string{
+		"externalUniversalMcpTemplate": externalUniversalMcpTemplate,
+		"externalCodexTemplate":        externalCodexTemplate,
+		"externalOpenClawTemplate":     externalOpenClawTemplate,
+	}
+	for name, body := range mustUseWrapper {
+		if !strings.Contains(body, "molecule-mcp") {
+			t.Errorf("%s does not reference 'molecule-mcp' — operator-facing MCP snippets must point at the heartbeat-wrapping console script, not the bare a2a_mcp_server module (#2957)", name)
+		}
+		if strings.Contains(body, `"-m", "molecule_runtime.a2a_mcp_server"`) {
+			t.Errorf("%s spawns 'python3 -m molecule_runtime.a2a_mcp_server' — that bypasses the standalone register/heartbeat wrapper, leaving the canvas showing the workspace OFFLINE (#2957). Use 'molecule-mcp' instead.", name)
+		}
+		if strings.Contains(body, `["-m", "molecule_runtime.a2a_mcp_server"]`) {
+			t.Errorf("%s spawns 'python3 -m molecule_runtime.a2a_mcp_server' — that bypasses the standalone register/heartbeat wrapper, leaving the canvas showing the workspace OFFLINE (#2957). Use 'molecule-mcp' instead.", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

[#2957](https://github.com/Molecule-AI/molecule-core/issues/2957) item 1 — the External Connect modal's Codex and OpenClaw tabs render an MCP config that spawns the bare \`a2a_mcp_server\` module instead of the \`molecule-mcp\` console-script wrapper:

\`\`\`toml
# Before (broken)
[mcp_servers.molecule]
command = \"python3\"
args = [\"-m\", \"molecule_runtime.a2a_mcp_server\"]

# After
[mcp_servers.molecule]
command = \"molecule-mcp\"
args = []
\`\`\`

The wrapper is what calls \`POST /registry/register\` at startup and runs the 20s heartbeat thread alongside the MCP stdio loop. Without it the canvas flips the workspace back to \`awaiting_agent\` (OFFLINE) within 60-90s — even while tools work — because nothing is heartbeating. The universal-MCP template already handles this correctly; Codex + OpenClaw templates were the laggards.

Operator-side this looks like: registered, tools work, but canvas shows \"offline\" / \"Restart\" CTA, peer agents see \`awaiting_agent\` in \`list_peers\`, and inbound A2A delivery silently fails the readiness check.

## Test plan

- [x] **Regression gate added.** \`TestExternalMcpTemplates_UseMoleculeMcpWrapper\` asserts every operator-facing MCP template that should use the wrapper does so, and explicitly bans the \`-m molecule_runtime.a2a_mcp_server\` form.
- [x] **Verified the new test FAILS on pre-fix source** by stashing only \`external_connection.go\` and re-running — both Codex and OpenClaw fail the gate as expected.
- [x] **Verified the new test PASSES on the fix.**
- [x] **Existing test still passes** — \`TestExternalTemplates_NoMoleculeOrgIDPlaceholder\`.
- [x] **Full handler suite passes** — \`go test ./internal/handlers/\` clean.

## Hermes-channel exemption

The hermes-channel template is **intentionally** excluded from the wrapper-required gate. The hermes plugin owns the platform-plugin path and runs its own \`register_platform\`/heartbeat code in-process; wrapping with \`mcp_cli\` would double-heartbeat. Universal/Codex/OpenClaw all need the wrapper; hermes does not. Test enumerates the three that must.

## Out of scope

Items 2–5 from #2957 (Codex version logging, opaque canvas errors hiding stderr, stale-session model-pin recovery, empty \`canvas:\` chat key) live in [codex-channel-molecule](https://github.com/Molecule-AI/codex-channel-molecule) — file-issues-where-implementation-lives. Will land separately there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)