### PR TITLE
fix(canvas/chat): handle platform-pending: scheme for poll-mode upload downloads (PR #2966 followup)

### DIFF
--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -1061,7 +1061,80 @@ function MyChatPanel({ workspaceId, data }: Props) {
                       : "dark:prose-invert dark:[--tw-prose-invert-body:theme(colors.zinc.100)] dark:[--tw-prose-invert-headings:theme(colors.white)] dark:[--tw-prose-invert-bold:theme(colors.white)] dark:[--tw-prose-invert-code:theme(colors.zinc.100)]"
                   }`}
                 >
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{msg.content}</ReactMarkdown>
+                  <ReactMarkdown
+                    remarkPlugins={[remarkGfm]}
+                    components={{
+                      // Default ReactMarkdown renders `<a href="...">`
+                      // with no target and no scheme handling, so:
+                      //
+                      //   1. http/https links navigate the canvas tab
+                      //      itself away — user loses canvas state.
+                      //   2. workspace://, file://, and bare /workspace/
+                      //      paths from agent-authored markdown produce
+                      //      an unhandled-protocol click → browser ends
+                      //      up at about:blank with no download (the
+                      //      reported bug from 2026-05-05).
+                      //
+                      // Override: external URLs open in a new tab with
+                      // rel="noopener noreferrer"; in-container paths
+                      // route through downloadChatFile so the browser
+                      // gets a real Blob with proper auth headers.
+                      a: ({ href, children, ...rest }) => {
+                        const url = String(href ?? "");
+                        const containerPath = url.startsWith("workspace:") ||
+                          url.startsWith("file:///workspace") ||
+                          url.startsWith("file:///configs") ||
+                          url.startsWith("file:///home") ||
+                          url.startsWith("file:///plugins") ||
+                          url.startsWith("/workspace") ||
+                          url.startsWith("/configs") ||
+                          url.startsWith("/home") ||
+                          url.startsWith("/plugins");
+                        if (containerPath) {
+                          return (
+                            <a
+                              href={url}
+                              {...rest}
+                              onClick={(e) => {
+                                e.preventDefault();
+                                // Construct a synthetic ChatAttachment
+                                // and route through the same
+                                // authenticated download path the
+                                // download chips use. Filename is the
+                                // last path segment so Save-As prefills
+                                // sensibly.
+                                const name = url.split(/[\\/]/).pop() || "download";
+                                downloadChatFile(workspaceId, {
+                                  uri: url,
+                                  name,
+                                }).catch((err) => {
+                                  setError(
+                                    err instanceof Error
+                                      ? `Download failed: ${err.message}`
+                                      : "Download failed",
+                                  );
+                                });
+                              }}
+                            >
+                              {children}
+                            </a>
+                          );
+                        }
+                        // External (http(s) / mailto / unknown scheme):
+                        // open in new tab so canvas state survives.
+                        return (
+                          <a
+                            href={url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            {...rest}
+                          >
+                            {children}
+                          </a>
+                        );
+                      },
+                    }}
+                  >{msg.content}</ReactMarkdown>
                 </div>
               )}
               {msg.attachments && msg.attachments.length > 0 && (
@@ -1167,7 +1240,22 @@ function MyChatPanel({ workspaceId, data }: Props) {
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey) {
+              // IME-safe send: while a CJK / Japanese / Korean IME is
+              // composing, Enter accepts the candidate selection — not a
+              // newline, not a send. `e.nativeEvent.isComposing` is the
+              // standard signal (modern WebKit/Blink/Gecko); the keyCode
+              // 229 fallback covers older Safari / WebKit-based mobile
+              // browsers that delay setting isComposing on the
+              // composition-end Enter. Reported 2026-05-05: typing
+              // Chinese with the system IME, pressing Enter to commit
+              // a candidate would inadvertently send the half-typed
+              // message.
+              if (
+                e.key === "Enter" &&
+                !e.shiftKey &&
+                !e.nativeEvent.isComposing &&
+                e.keyCode !== 229
+              ) {
                 e.preventDefault();
                 sendMessage();
               }

--- a/canvas/src/components/tabs/ChatTab.tsx
+++ b/canvas/src/components/tabs/ChatTab.tsx
@@ -7,7 +7,7 @@ import { api } from "@/lib/api";
 import { useCanvasStore, type WorkspaceNodeData } from "@/store/canvas";
 import { useSocketEvent } from "@/hooks/useSocketEvent";
 import { type ChatMessage, type ChatAttachment, createMessage, appendMessageDeduped } from "./chat/types";
-import { uploadChatFiles, downloadChatFile } from "./chat/uploads";
+import { uploadChatFiles, downloadChatFile, isPlatformAttachment } from "./chat/uploads";
 import { AttachmentChip, PendingAttachmentPill } from "./chat/AttachmentViews";
 import { extractFilesFromTask } from "./chat/message-parser";
 import { AgentCommsPanel } from "./chat/AgentCommsPanel";
@@ -1081,16 +1081,13 @@ function MyChatPanel({ workspaceId, data }: Props) {
                       // gets a real Blob with proper auth headers.
                       a: ({ href, children, ...rest }) => {
                         const url = String(href ?? "");
-                        const containerPath = url.startsWith("workspace:") ||
-                          url.startsWith("file:///workspace") ||
-                          url.startsWith("file:///configs") ||
-                          url.startsWith("file:///home") ||
-                          url.startsWith("file:///plugins") ||
-                          url.startsWith("/workspace") ||
-                          url.startsWith("/configs") ||
-                          url.startsWith("/home") ||
-                          url.startsWith("/plugins");
-                        if (containerPath) {
+                        // Use the SSOT helper isPlatformAttachment so
+                        // the markdown link override and the chip
+                        // download path agree on which schemes need
+                        // auth-routed download. Pre-fix this list was
+                        // duplicated and missed `platform-pending:`,
+                        // producing about:blank for poll-mode uploads.
+                        if (isPlatformAttachment(url)) {
                           return (
                             <a
                               href={url}

--- a/canvas/src/components/tabs/__tests__/ChatTab.imeAndLinks.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ChatTab.imeAndLinks.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+//
+// Pins two regressions reported on production 2026-05-05:
+//
+// 1. IME composition + Enter key: typing Chinese (or any CJK / IME-
+//    composed text) and pressing Enter to commit the candidate
+//    selection used to send the half-typed message. The fix checks
+//    `event.nativeEvent.isComposing` (and a `keyCode === 229`
+//    fallback for older WebKit) before treating Enter as send.
+//
+// 2. Markdown link clicks: the agent's ReactMarkdown-rendered links
+//    used to:
+//       - http/https → navigate canvas tab away (user lost canvas state)
+//       - workspace://path / file:///workspace/... / /workspace/... →
+//         browser hit about:blank (unhandled protocol).
+//    Fix: external links get target="_blank" + noopener; in-container
+//    paths route through downloadChatFile (same auth path as chips).
+
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import { render, screen, cleanup, fireEvent, waitFor } from "@testing-library/react";
+import React from "react";
+
+afterEach(cleanup);
+
+// Mock the api module so render doesn't try to talk to a real CP.
+const apiGet = vi.fn(() => Promise.resolve([]));
+const apiPost = vi.fn(() => Promise.resolve({}));
+vi.mock("@/lib/api", () => ({
+  api: {
+    get: (path: string) => apiGet(path),
+    post: (path: string, body: unknown) => apiPost(path, body),
+    del: vi.fn(),
+    patch: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock("@/store/canvas", () => ({
+  useCanvasStore: vi.fn((selector?: (s: unknown) => unknown) =>
+    selector ? selector({ agentMessages: {}, consumeAgentMessages: () => [] }) : {},
+  ),
+}));
+
+// Capture the downloadChatFile call so the markdown-link test can
+// assert in-container paths route through the authenticated download
+// path rather than the browser's bare anchor click.
+const downloadChatFileMock = vi.fn(() => Promise.resolve());
+vi.mock("../chat/uploads", async () => {
+  const actual = await vi.importActual<typeof import("../chat/uploads")>("../chat/uploads");
+  return {
+    ...actual,
+    downloadChatFile: (...args: unknown[]) => downloadChatFileMock(...args),
+  };
+});
+
+beforeEach(() => {
+  apiGet.mockClear();
+  apiPost.mockClear();
+  downloadChatFileMock.mockClear();
+  // jsdom doesn't implement scrollIntoView; ChatTab calls it after
+  // every render with a new message.
+  Element.prototype.scrollIntoView = vi.fn();
+  // Stub IntersectionObserver — the lazy-history sentinel uses it.
+  class FakeIO {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+  (window as unknown as { IntersectionObserver: unknown }).IntersectionObserver = FakeIO;
+  (globalThis as unknown as { IntersectionObserver: unknown }).IntersectionObserver = FakeIO;
+});
+
+import { ChatTab } from "../ChatTab";
+
+const minimalData = {
+  status: "online" as const,
+  runtime: "claude-code",
+  currentTask: null,
+} as unknown as Parameters<typeof ChatTab>[0]["data"];
+
+describe("ChatTab — IME-safe Enter key", () => {
+  it("does NOT send the message when Enter fires during IME composition (isComposing)", async () => {
+    render(<ChatTab workspaceId="ws-ime" data={minimalData} />);
+
+    // Find the textarea by its aria-label.
+    const textarea = await screen.findByLabelText(/Message to agent/i);
+    fireEvent.change(textarea, { target: { value: "你好" } });
+
+    // Simulate the Enter that commits an IME selection: isComposing=true.
+    fireEvent.keyDown(textarea, { key: "Enter", isComposing: true });
+
+    // sendMessage POSTs via api.post; assert it was NOT called.
+    await waitFor(() => {
+      expect(apiPost).not.toHaveBeenCalled();
+    });
+    // And the input is preserved — ChatTab clears it only on actual send.
+    expect((textarea as HTMLTextAreaElement).value).toBe("你好");
+  });
+
+  it("does NOT send when keyCode is 229 (older Safari IME fallback)", async () => {
+    render(<ChatTab workspaceId="ws-ime2" data={minimalData} />);
+    const textarea = await screen.findByLabelText(/Message to agent/i);
+    fireEvent.change(textarea, { target: { value: "한국어" } });
+
+    // keyCode 229 is the older-Safari signal that an IME is composing.
+    // Some mobile WebKit-based browsers delay setting isComposing on
+    // the composition-end Enter; the keyCode fallback covers that.
+    fireEvent.keyDown(textarea, { key: "Enter", keyCode: 229 });
+
+    await waitFor(() => {
+      expect(apiPost).not.toHaveBeenCalled();
+    });
+  });
+
+  it("DOES send on a non-composing Enter (the happy path stays intact)", async () => {
+    render(<ChatTab workspaceId="ws-ok" data={minimalData} />);
+    const textarea = await screen.findByLabelText(/Message to agent/i);
+    fireEvent.change(textarea, { target: { value: "hello world" } });
+
+    fireEvent.keyDown(textarea, { key: "Enter" /* no isComposing, no 229 */ });
+
+    // The api.post for /a2a fires inside sendMessage. waitFor since
+    // the call goes through several effects.
+    await waitFor(() => {
+      expect(apiPost).toHaveBeenCalled();
+    });
+  });
+
+  it("Shift+Enter inserts newline regardless (no send)", async () => {
+    render(<ChatTab workspaceId="ws-shift" data={minimalData} />);
+    const textarea = await screen.findByLabelText(/Message to agent/i);
+    fireEvent.change(textarea, { target: { value: "line 1" } });
+
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    await waitFor(() => {
+      expect(apiPost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/canvas/src/components/tabs/__tests__/ChatTab.imeAndLinks.test.tsx
+++ b/canvas/src/components/tabs/__tests__/ChatTab.imeAndLinks.test.tsx
@@ -23,8 +23,8 @@ import React from "react";
 afterEach(cleanup);
 
 // Mock the api module so render doesn't try to talk to a real CP.
-const apiGet = vi.fn(() => Promise.resolve([]));
-const apiPost = vi.fn(() => Promise.resolve({}));
+const apiGet = vi.fn((_path: string): Promise<unknown> => Promise.resolve([]));
+const apiPost = vi.fn((_path: string, _body: unknown): Promise<unknown> => Promise.resolve({}));
 vi.mock("@/lib/api", () => ({
   api: {
     get: (path: string) => apiGet(path),
@@ -44,12 +44,13 @@ vi.mock("@/store/canvas", () => ({
 // Capture the downloadChatFile call so the markdown-link test can
 // assert in-container paths route through the authenticated download
 // path rather than the browser's bare anchor click.
-const downloadChatFileMock = vi.fn(() => Promise.resolve());
+const downloadChatFileMock = vi.fn((_workspaceId: string, _att: { uri: string; name: string }) => Promise.resolve());
 vi.mock("../chat/uploads", async () => {
   const actual = await vi.importActual<typeof import("../chat/uploads")>("../chat/uploads");
   return {
     ...actual,
-    downloadChatFile: (...args: unknown[]) => downloadChatFileMock(...args),
+    downloadChatFile: (workspaceId: string, att: { uri: string; name: string }) =>
+      downloadChatFileMock(workspaceId, att),
   };
 });
 

--- a/canvas/src/components/tabs/chat/uploads.ts
+++ b/canvas/src/components/tabs/chat/uploads.ts
@@ -44,6 +44,8 @@ export async function uploadChatFiles(
  *    - `workspace:<abs-path>` (our canonical form)
  *    - `file:///workspace/...` (some agents emit this)
  *    - `/workspace/...` (bare absolute path inside the container)
+ *    - `platform-pending:<wsid>/<file_id>` (poll-mode upload, staged
+ *      on platform side; resolves to /pending-uploads/<file_id>/content)
  *  Everything that looks like an allowed-root container path is
  *  rewritten to the authenticated /chat/download endpoint. HTTP(S)
  *  URIs pass through unchanged so we can also render links to
@@ -53,11 +55,48 @@ export function resolveAttachmentHref(
   workspaceId: string,
   uri: string,
 ): string {
+  // platform-pending: agents-emitted URI that lives in the platform-side
+  // staging layer (poll-mode chat uploads, see workspace-server's
+  // chat_files.go ~line 690 + pendinguploads.Storage). The wire shape
+  // is `platform-pending:<workspace_id>/<file_id>`. Resolving it
+  // requires hitting GET /workspaces/<wsid>/pending-uploads/<file_id>/content
+  // which streams the bytes with full workspace auth. Without this
+  // case the browser sees an unhandled-protocol click → about:blank,
+  // which was the user-visible bug from 2026-05-05 (reno-stars).
+  if (uri.startsWith("platform-pending:")) {
+    const rest = uri.slice("platform-pending:".length);
+    const slash = rest.indexOf("/");
+    // Defensive: if the URI doesn't have the expected wsid/fileid
+    // shape, fall through to raw-URI handling so the consumer can
+    // still try to render it (rather than producing a broken /pending-
+    // uploads/// path).
+    if (slash > 0) {
+      const wsid = rest.slice(0, slash);
+      const fileID = rest.slice(slash + 1);
+      if (wsid && fileID) {
+        // Use the URI's own workspace_id (the bytes live in THAT
+        // workspace's pending-uploads store), not the chat's
+        // workspace_id — these CAN differ when a user drags a file
+        // into one workspace's chat that gets forwarded to another
+        // (cross-workspace delegation, agent forwarding).
+        return `${PLATFORM_URL}/workspaces/${wsid}/pending-uploads/${fileID}/content`;
+      }
+    }
+    return uri;
+  }
   const containerPath = normalizeWorkspaceUri(uri);
   if (containerPath) {
     return `${PLATFORM_URL}/workspaces/${workspaceId}/chat/download?path=${encodeURIComponent(containerPath)}`;
   }
   return uri;
+}
+
+/** Returns true when the URI points at a platform-side resource that
+ *  requires our auth headers — caller should route through
+ *  downloadChatFile rather than letting the browser navigate. */
+export function isPlatformAttachment(uri: string): boolean {
+  if (uri.startsWith("platform-pending:")) return true;
+  return normalizeWorkspaceUri(uri) !== null;
 }
 
 /** Extracts the absolute container path from a workspace-scoped URI,
@@ -96,8 +135,7 @@ export async function downloadChatFile(
   attachment: ChatAttachment,
 ): Promise<void> {
   const href = resolveAttachmentHref(workspaceId, attachment.uri);
-  const isContainerPath = normalizeWorkspaceUri(attachment.uri) !== null;
-  if (!isContainerPath) {
+  if (!isPlatformAttachment(attachment.uri)) {
     // External URL — let the browser navigate. Opens in new tab so
     // the canvas context survives a navigation. `href` here is the
     // raw URI (http(s), or anything else the agent sent back).


### PR DESCRIPTION
## Summary

Console error from production reno-stars after applying PR #2966:

\`\`\`
Failed to launch 'platform-pending:d76977b1-…/bb0dcaf3-…'
because the scheme does not have a registered handler.
\`\`\`

The agent's "download link" was a \`platform-pending:<wsid>/<file_id>\` URI — the canonical reference for poll-mode chat uploads (see \`workspace-server/internal/handlers/chat_files.go:690\` + \`workspace/inbox_uploads.py\`). PR #2966 only handled \`workspace:\`, \`file:///\`, and absolute container paths; \`platform-pending:\` fell through to the raw URI which the browser couldn't navigate to → about:blank.

## Fix

**\`resolveAttachmentHref\`**: added \`platform-pending:\` branch resolving to \`${PLATFORM_URL}/workspaces/<wsid>/pending-uploads/<file_id>/content\`. Uses the wsid from the URI, **not** the chat's workspace_id — these can differ when a file is forwarded across workspaces.

**\`isPlatformAttachment(uri)\`** — new SSOT helper for "this URI requires our auth headers, route through downloadChatFile". Used by both \`downloadChatFile\` (chip click) and ChatTab's markdown-link override. Pre-fix the scheme list was duplicated and missed \`platform-pending:\`.

## Test plan

- [x] tsc clean
- [x] 4 IME tests still pass (no regressions)
- [ ] CI green
- [ ] **Manual** post-deploy: send a chat upload from external workspace, click the link in markdown, verify download (not about:blank)

Refs PR #2966.